### PR TITLE
Dedup candidates against open Remyx Issues, not just open PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Visit your repo's **Actions** tab → **Remyx Recommendation** → **Run workflo
 | `issue_opened_self_review` | Second Claude pass judged the new code an **orphan** — unreachable from any production path (at most its own tests call it). This is a reachability check, not a triviality one (stub density covers triviality) |
 | `skipped_low_confidence` | Recommendation below `min-confidence` |
 | `skipped_rate_limit` | A previous Remyx PR was opened within `rate-limit-days` |
-| `skipped_pr_exists` | An open PR for this exact paper already exists |
+| `skipped_pr_exists` | Every candidate in the pool already has an open PR (or a mix of open PRs and Issues) |
+| `skipped_issue_exists` | Every candidate in the pool already has an open Remyx Issue — nothing new to surface. Close an Issue to make that paper eligible again |
 | `skipped_test_failure` | Tests failed AND `draft-mode: never` |
 | `claude_failed` | Claude CLI exited non-zero |
 | `rejected_path_violations` | Claude touched files outside the guardrails allowlist; no PR opened |

--- a/action.yml
+++ b/action.yml
@@ -74,8 +74,8 @@ outputs:
     description: |
       Run outcome: "pr_opened" | "pr_opened_draft" | "issue_opened" |
       "skipped_low_confidence" | "skipped_rate_limit" | "skipped_pr_exists" |
-      "skipped_test_failure" | "claude_failed" | "rejected_path_violations" |
-      "error".
+      "skipped_issue_exists" | "skipped_test_failure" | "claude_failed" |
+      "rejected_path_violations" | "error".
     value: ${{ steps.recommend.outputs.status }}
   pr_url:
     description: 'URL of the opened PR (set when status starts with "pr_opened").'

--- a/src/run.py
+++ b/src/run.py
@@ -853,6 +853,48 @@ def existing_pr_for(target: Target, branch: str) -> dict | None:
     return prs[0] if prs else None
 
 
+def open_remyx_issues(target: Target) -> list[dict]:
+    """Open Remyx Recommendation Issues on the target repo.
+
+    GitHub's /issues endpoint also returns PRs (they carry a
+    'pull_request' key) — those are filtered out; PRs are deduped
+    separately by existing_pr_for. We keep only items that look like one
+    of ours: the title carries the PR_TITLE_PREFIX or the body has the
+    orchestrator's attribution footer. Bounded to the first 100 open
+    issues (same pragmatic cap as recent_pr_within_rate_limit)."""
+    issues = gh_api(
+        "GET", f"/repos/{target.repo}/issues?state=open&per_page=100"
+    ) or []
+    ours = []
+    for it in issues:
+        if it.get("pull_request"):
+            continue
+        title = it.get("title") or ""
+        body = it.get("body") or ""
+        if title.startswith(PR_TITLE_PREFIX) or "Remyx Recommendation" in body:
+            ours.append(it)
+    return ours
+
+
+def issue_for_paper(open_issues: list[dict], rec: Recommendation) -> dict | None:
+    """Return an already-open Remyx Issue for this paper, if any.
+
+    Matched on the arxiv_id in the issue body — every Remyx issue links
+    ``arxiv.org/abs/<id>``, and that survives the OPEN_AS_ISSUE path where
+    the title is Claude-authored rather than ``<prefix> <paper_title>``.
+    Falls back to an exact title match when the recommendation carries no
+    arxiv_id. Pure (no network) so the matching is unit-testable; the
+    fetch lives in open_remyx_issues."""
+    needle = f"arxiv.org/abs/{rec.arxiv_id}" if rec.arxiv_id else None
+    title_match = f"{PR_TITLE_PREFIX} {rec.paper_title}"
+    for it in open_issues:
+        if needle and needle in (it.get("body") or ""):
+            return it
+        if not rec.arxiv_id and (it.get("title") or "") == title_match:
+            return it
+    return None
+
+
 def recent_pr_within_rate_limit(target: Target) -> bool:
     """Return True if a Remyx Recommendation PR was opened on the target
     repo within `rate_limit_days`."""
@@ -1908,7 +1950,10 @@ def process_target(target: Target) -> dict:
 
         skipped_low_confidence            — tier below min_confidence
         skipped_rate_limit                — recent PR within rate-limit-days
-        skipped_pr_exists                 — open PR already exists for paper
+        skipped_pr_exists                 — every candidate already has an
+                                            open PR (or a mix of open PRs/Issues)
+        skipped_issue_exists              — every candidate already has an
+                                            open Remyx Issue
 
         issue_opened_preflight            — pre-flight (§6) routed to Issue
                                             before invoking implementation
@@ -1943,14 +1988,21 @@ def process_target(target: Target) -> dict:
     result["candidates_returned"] = len(candidates)
 
     # 3. Per-candidate gates. Drop anything below the confidence tier or
-    #    already in flight (an open PR for its branch) so the selection
-    #    pass only sees viable candidates. Running this BEFORE the clone
+    #    already in flight — an open PR for its branch, OR an open Remyx
+    #    Issue for the paper. The Issue check matters with a longer
+    #    lookback: a sticky top candidate that keeps routing to Issue would
+    #    otherwise be re-selected every run and reopen a duplicate Issue.
+    #    Treating an open Issue as "in flight" drops it from the pool so
+    #    selection advances to the next-best candidate; closing the Issue
+    #    makes the paper eligible again. Running this BEFORE the clone
     #    preserves the "don't check out the repo if nothing is actionable"
     #    optimization the single-pick flow had.
     min_required = TIER_RANK.get(target.min_confidence.lower(), 2)
+    open_issues = open_remyx_issues(target)
     viable: list[Recommendation] = []
     dropped_low_conf = 0
     dropped_pr_exists = 0
+    dropped_issue_exists = 0
     for c in candidates:
         if TIER_RANK.get(c.tier.lower(), 0) < min_required:
             dropped_low_conf += 1
@@ -1959,25 +2011,33 @@ def process_target(target: Target) -> dict:
         if existing_pr_for(target, c_branch):
             dropped_pr_exists += 1
             continue
+        if issue_for_paper(open_issues, c):
+            dropped_issue_exists += 1
+            continue
         viable.append(c)
 
     if not viable:
-        # Nothing actionable. Prefer the more specific skip reason: if the
-        # only thing stopping us is dedup, say so; otherwise it's the tier.
-        if dropped_pr_exists and not dropped_low_conf:
-            result["status"] = "skipped_pr_exists"
-            log.info(f"  ✗ all {dropped_pr_exists} candidate(s) already "
-                     f"have open PRs; skipping")
-        else:
+        # Nothing actionable. Prefer the most specific skip reason.
+        if dropped_low_conf and not dropped_pr_exists and not dropped_issue_exists:
             result["status"] = "skipped_low_confidence"
-            log.info(f"  ✗ no candidate at/above min {target.min_confidence} "
-                     f"({dropped_low_conf} below tier, "
-                     f"{dropped_pr_exists} already in flight); skipping")
+            log.info(f"  ✗ no candidate at/above min {target.min_confidence}; "
+                     f"skipping")
+        elif dropped_issue_exists and not dropped_pr_exists:
+            result["status"] = "skipped_issue_exists"
+            log.info(f"  ✗ all {dropped_issue_exists} candidate(s) already "
+                     f"have open Remyx Issues; skipping")
+        else:
+            # PR dedup, or a mix of open PRs and Issues.
+            result["status"] = "skipped_pr_exists"
+            log.info(f"  ✗ all candidates already in flight "
+                     f"({dropped_pr_exists} open PRs, "
+                     f"{dropped_issue_exists} open Issues); skipping")
         return result
 
     log.info(f"  ✓ {len(viable)} viable candidate(s) "
              f"(dropped {dropped_low_conf} low-confidence, "
-             f"{dropped_pr_exists} already in flight)")
+             f"{dropped_pr_exists} open PRs, "
+             f"{dropped_issue_exists} open Issues)")
 
     # 4. Workdir + selection. Clone first (the selection pass needs the
     #    repo's module layout), then let Claude pick the candidate most

--- a/tests/test_issue_dedup.py
+++ b/tests/test_issue_dedup.py
@@ -1,0 +1,82 @@
+"""Tests for Issue dedup in the candidate viability filter.
+
+The candidate filter drops a paper that already has an open Remyx Issue
+(treating it as "in flight", like an open PR), so a sticky top candidate
+that keeps routing to Issue isn't re-selected and reopened every run over a
+longer lookback window. issue_for_paper is the pure matcher; the fetch +
+"is this one of ours" filtering lives in open_remyx_issues.
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Recommendation  # noqa: E402
+
+
+def _rec(arxiv="2605.22536v1", title="SpaceDG"):
+    return Recommendation(
+        paper_title=title, arxiv_id=arxiv, tier="high", z_score=0.0, spec_md="",
+        paper_abstract="", team_context="", domain_summary="", raw_paper_md="",
+        relevance_score=0.9, reasoning="", suggested_experiment="",
+        recommendation_id="", interest_name="VQASynth", interest_context="",
+    )
+
+
+def _filter_ours(raw):
+    # Mirrors the keep-only-ours logic in open_remyx_issues (the network
+    # part), so we can test it without hitting GitHub.
+    return [
+        i for i in raw
+        if not i.get("pull_request")
+        and ((i.get("title") or "").startswith(run.PR_TITLE_PREFIX)
+             or "Remyx Recommendation" in (i.get("body") or ""))
+    ]
+
+
+def test_open_issue_filter_keeps_only_remyx_non_prs():
+    raw = [
+        {"title": "[Remyx Recommendation] SpaceDG",
+         "body": "arxiv.org/abs/2605.22536v1 ... Remyx Recommendation"},
+        {"title": "Some PR", "body": "x", "pull_request": {"url": "..."}},
+        {"title": "Unrelated bug", "body": "nothing here"},
+        {"title": "custom title",
+         "body": "opened by Remyx Recommendation; arxiv.org/abs/2605.10887v1"},
+    ]
+    ours = _filter_ours(raw)
+    assert len(ours) == 2
+    assert {i["title"] for i in ours} == {"[Remyx Recommendation] SpaceDG",
+                                          "custom title"}
+
+
+def test_match_by_arxiv_in_body_prefixed_title():
+    ours = [{"title": "[Remyx Recommendation] SpaceDG",
+             "body": "see arxiv.org/abs/2605.22536v1"}]
+    assert run.issue_for_paper(ours, _rec("2605.22536v1")) is not None
+
+
+def test_match_by_arxiv_in_body_custom_title():
+    # The OPEN_AS_ISSUE path gives a Claude-authored title; body still links arxiv.
+    ours = [{"title": "Add a degradation eval harness",
+             "body": "opened by Remyx Recommendation; arxiv.org/abs/2605.10887v1"}]
+    assert run.issue_for_paper(ours, _rec("2605.10887v1")) is not None
+
+
+def test_no_match_for_paper_without_open_issue():
+    ours = [{"title": "[Remyx Recommendation] SpaceDG",
+             "body": "arxiv.org/abs/2605.22536v1"}]
+    assert run.issue_for_paper(ours, _rec("9999.99999v1")) is None
+
+
+def test_title_fallback_when_no_arxiv():
+    ours = [{"title": "[Remyx Recommendation] CoolPaper",
+             "body": "opened by Remyx Recommendation (no arxiv link)"}]
+    assert run.issue_for_paper(ours, _rec(arxiv="", title="CoolPaper")) is not None
+    assert run.issue_for_paper(ours, _rec(arxiv="", title="OtherPaper")) is None
+
+
+def test_empty_open_issue_list_never_matches():
+    assert run.issue_for_paper([], _rec()) is None


### PR DESCRIPTION
## Why

Dedup was **PR-only**. `existing_pr_for` drops candidates with an open PR, and the rate-limit gate counts only PRs. A paper routed to an **Issue** leaves no PR, so neither gate saw it — and with the longer lookback pool, a sticky top candidate that keeps routing to Issue gets **re-selected every run and reopens a duplicate Issue**.

This is not hypothetical: during validation, SpaceDG produced Issues **#71** and **#72** on consecutive runs before a later run got it to a PR.

## What changed

The candidate viability filter now also drops a paper that already has an **open Remyx Issue**, treating it as "in flight" like an open PR — so selection **advances to the next-best candidate** instead of reopening. Closing the Issue makes the paper eligible again (the check is `state=open`), giving a natural "discussed it → closed it → retry" workflow.

- `open_remyx_issues(target)` — open issues that are ours (title prefix or attribution footer), excluding PRs (they carry a `pull_request` key). Fetched **once per run**, not per-candidate.
- `issue_for_paper(open_issues, rec)` — pure matcher (unit-testable, no network): matches on `arxiv.org/abs/<id>` in the body, which **survives the OPEN_AS_ISSUE path** where the title is Claude-authored; falls back to exact title match when the rec has no arxiv_id.
- New terminal status **`skipped_issue_exists`** when *every* candidate already has an open Issue. A mix of open PRs and Issues stays `skipped_pr_exists`.

## Behavior after this PR (the question that prompted it)

| Prior outcome for a repeatedly-top paper | Behavior now |
|---|---|
| Open PR, within `rate-limit-days` | whole run skips (`skipped_rate_limit`) |
| Open PR, after the window | dropped from pool → **next-best candidate** |
| **Open Issue** | dropped from pool → **next-best candidate** (was: duplicate Issue) |
| Issue closed by the team | eligible again → may be re-selected |

## Test plan
- [ ] `pytest tests/ -q` — `tests/test_issue_dedup.py` covers the "ours" filter, arxiv-body match (both title paths), title fallback, and non-matches (verified in-session; not run here per repo convention).

Note: `open_remyx_issues` scans the first 100 open issues (same pragmatic cap as `recent_pr_within_rate_limit`'s page of PRs). Fine for research repos; a repo with >100 open issues could miss an older Remyx Issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)