### PR TITLE
Rename Action to Outrider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Remyx Recommendation — GitHub Action
+# Outrider — GitHub Action
 
-A composite GitHub Action that, on a schedule you choose, picks the next arXiv paper for your team to integrate (via the Remyx engine API) and either opens a draft pull request that wires the paper's contribution into an existing call site in your codebase, or opens a discussion Issue when the paper doesn't fit.
+A composite GitHub Action that scouts the arXiv frontier for your team — on a schedule you choose, it picks the next paper to integrate (via the Remyx engine API) and either opens a draft pull request that wires the paper's contribution into an existing call site in your codebase, or opens a discussion Issue when the paper doesn't fit.
 
 ```yaml
-- uses: remyxai/remyx-recommendation-action@v1
+- uses: remyxai/outrider@v1
   with:
     interest-id: ${{ vars.REMYX_INTEREST_ID }}
 ```
@@ -51,10 +51,10 @@ This is disabled by default at the org level for new repos. Without it, the acti
 
 ### 4. Add the workflow
 
-Create `.github/workflows/remyx-recommendation.yml`:
+Create `.github/workflows/outrider.yml`:
 
 ```yaml
-name: Remyx Recommendation
+name: Outrider
 
 on:
   schedule:
@@ -73,7 +73,7 @@ jobs:
       REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
-      - uses: remyxai/remyx-recommendation-action@v1
+      - uses: remyxai/outrider@v1
         with:
           interest-id: 'YOUR-INTEREST-UUID-HERE'
 ```
@@ -82,7 +82,7 @@ Replace `YOUR-INTEREST-UUID-HERE` with the UUID from engine.remyx.ai. (Tip: the 
 
 ### 5. First run
 
-Visit your repo's **Actions** tab → **Remyx Recommendation** → **Run workflow**. The first run takes 4-6 minutes; subsequent scheduled runs are identical. A draft PR appears in your **Pull Requests** tab when it completes.
+Visit your repo's **Actions** tab → **Outrider** → **Run workflow**. The first run takes 4-6 minutes; subsequent scheduled runs are identical. A draft PR appears in your **Pull Requests** tab when it completes.
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
-name: 'Remyx Recommendation'
-description: 'Open a draft PR with the next arXiv paper to integrate. Remyx ranks papers against your team''s research interest; Claude Code drafts the implementation scaffold.'
+name: 'Outrider'
+description: 'Sends a scout to the arXiv frontier — picks the next paper most implementable against your codebase and opens a draft PR. Remyx ranks; Claude Code drafts.'
 branding:
-  icon: 'book-open'
+  icon: 'compass'
   color: 'purple'
 
 inputs:

--- a/src/run.py
+++ b/src/run.py
@@ -1,6 +1,5 @@
 """
-run.py — Entry point for the remyxai/remyx-recommendation-action
-composite GitHub Action.
+run.py — Entry point for the remyxai/outrider composite GitHub Action.
 
 The action runs once per workflow invocation; it opens a draft PR (or
 an Issue when the recommended paper can't be cleanly scaffolded)


### PR DESCRIPTION
## Summary

Renames the GitHub Action surface from **Remyx Recommendation** to **Outrider**. Outrider matches the action's loop — a scout to the arXiv frontier that returns with one implementable PR.

This PR changes the *delivery brand* (what customers configure and see in the marketplace). The *content brand* — PR title prefix `[Remyx Recommendation]`, branch prefix `remyx-recommendation/`, bundle dir, committer identity — is unchanged so existing customer PRs/branches aren't orphaned.

The repo will be renamed `remyxai/remyx-recommendation-action` → `remyxai/outrider` immediately after merge. GitHub auto-creates a redirect for the old URL, so existing `uses: remyxai/remyx-recommendation-action@v1` references keep working.

## What changed

- `action.yml` — `name: Outrider`, new description, icon `book-open` → `compass`
- `README.md` — title, snippets (`uses: remyxai/outrider@v1`), workflow filename `outrider.yml`, Actions tab text
- `src/run.py` — module docstring header

## Test plan

- [ ] Merge → rename repo via Settings → Tag `v1.1.0` + move `v1`
- [ ] Update `remyxai/VQASynth` workflow to use `remyxai/outrider@v1`
- [ ] Trigger workflow_dispatch on VQASynth and confirm a PR opens cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)