### PR TITLE
Fix rate-limit ordering: gate PR-track only, not Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Visit your repo's **Actions** tab → **Outrider** → **Run workflow**. The fir
 | `github-token` | *(empty — falls back to `${{ github.token }}`)* | Token used for git push + PR/Issue creation. Leave unset for the standard same-repo install; the action will use the workflow's built-in `GITHUB_TOKEN`. Override with a PAT (`${{ secrets.MY_PAT }}`) only for cross-repo controller patterns. |
 | `min-confidence` | `moderate` | Tier gate: `high` / `moderate` / `low`. Recommendations below this are skipped. |
 | `draft-mode` | `always` | PR-draft policy: `always` (default), `on_test_failure`, or `never`. |
-| `rate-limit-days` | `7` | Skip if a previous Remyx PR was opened within this window. Set `0` to rely only on per-paper dedup. |
+| `rate-limit-days` | `7` | PR-cadence guard: skip the implementation pass if a Remyx PR was opened within this window. Issue-track candidates are NOT gated — pre-flight Issues continue to flow daily even during PR throttle. Set `0` to disable. |
 | `guardrails-allowlist` | `''` | Comma-separated extra path globs Claude Code may modify (most repos don't need this). |
 | `lookback` | `week` | Recommendation lookback window: `today` / `week` / `month`. The candidate pool is pulled over this window before the selection pass. |
 | `candidate-pool` | `25` | How many recommendations to pull into the selection pool. The selection pass picks the most implementable one; the rest are recorded as rejected with a reason. |

--- a/action.yml
+++ b/action.yml
@@ -38,9 +38,12 @@ inputs:
     default: 'always'
   rate-limit-days:
     description: |
-      Skip the run if a previous Remyx Recommendation PR was opened
-      within this many days. Default 7 (weekly cadence). Set to 0 to
-      disable the rate limit and rely only on per-paper dedup.
+      PR-cadence guard: skip the implementation pass if a Remyx
+      Recommendation PR was opened within this many days. Applies only
+      to PR-track candidates — pre-flight Issues continue to flow daily
+      even during PR throttle, since Issues are cheap discussion
+      surfaces that don't add to the review queue. Default 7 (weekly
+      PR cadence). Set to 0 to disable.
     required: false
     default: '7'
   guardrails-allowlist:

--- a/src/run.py
+++ b/src/run.py
@@ -2243,6 +2243,9 @@ def process_target(target: Target) -> dict:
 
         skipped_low_confidence            — tier below min_confidence
         skipped_rate_limit                — recent PR within rate-limit-days
+                                            AND pre-flight routed this
+                                            candidate to PR (Issues are
+                                            never rate-limited)
         skipped_pr_exists                 — every candidate already has an
                                             open PR (or a mix of open PRs/Issues)
         skipped_issue_exists              — every candidate already has an
@@ -2267,11 +2270,15 @@ def process_target(target: Target) -> dict:
     """
     result: dict = {"repo": target.repo, "status": "unknown"}
 
-    # 1. Rate-limit (per-repo) — cheapest gate, before any candidate work
-    #    or checkout.
-    if recent_pr_within_rate_limit(target):
-        result["status"] = "skipped_rate_limit"
-        return result
+    # 1. (was: rate-limit pre-check) — moved to §5.7. The old §1 ran
+    #    recent_pr_within_rate_limit() before any candidate work, which
+    #    blocked Issue-track activity too. It now fires AFTER pre-flight
+    #    decides PR-vs-Issue, so it only gates PR-track candidates.
+    #    Issues are cheap discussion surfaces that don't add to the
+    #    team's review queue — gating them was overcautious. The
+    #    trade-off: ~$0.10-0.20 spent on pre-flight + selection per
+    #    rate-limited day, in exchange for daily Issue-track scouting
+    #    and a more accurate cadence guard.
 
     # 2. Query the candidate pool over the lookback window (default: the
     #    past week). The old flow took only papers[0], wasting the
@@ -2416,6 +2423,20 @@ def process_target(target: Target) -> dict:
             result["status"] = "issue_opened_preflight"
             result["issue_url"] = issue_url
             log.info(f"  ✓ issue_opened_preflight: {issue_url}")
+            return result
+
+        # 5.7. Rate-limit (PR-cadence guard). Now that pre-flight has
+        # decided this candidate is PR-track, check whether a recent
+        # Remyx PR was opened within rate-limit-days. If so, skip
+        # implementation. Issue-track candidates already returned above
+        # — Issues are cheap discussion surfaces that don't add to the
+        # team's review queue, so they aren't gated.
+        if recent_pr_within_rate_limit(target):
+            result["status"] = "skipped_rate_limit"
+            log.info(
+                f"  ✗ rate-limit hit before PR-track implementation; "
+                f"would have implemented {rec.arxiv_id}"
+            )
             return result
 
         # 6. Claude Code


### PR DESCRIPTION
## Summary

Fixes a design flaw in `process_target`: the rate-limit gate fires *before* candidate work, so it blocks Issue-track activity along with PR-track. Issues are cheap discussion surfaces and shouldn't be throttled by a guard whose stated intent is "PR-cadence."

## The bug, succinctly

```
BEFORE:
  rate-limit (blocks ALL activity)
  → query candidates
  → per-paper dedup
  → selection
  → pre-flight: PR or Issue?
  → implementation

AFTER:
  query candidates
  → per-paper dedup
  → selection
  → pre-flight: PR or Issue?
  → IF Issue: open Issue (no gate)
  → IF PR: rate-limit check → if hit, skip
  → implementation
```

Per `recent_pr_within_rate_limit` (src/run.py:1010), the check only counts PRs by branch prefix — never Issues. So semantically it was always about PR cadence. The bug was the ordering.

## Cost trade-off (worth flagging)

On rate-limited days the action now spends ~$0.10–0.20 (selection pass + pre-flight pass) before discovering the rate-limit hit. For weekly-cadence consumers with daily crons: ~$0.70/week extra.

The benefit: daily Issue-track scouting (papers that don't fit cleanly surface as discussions even during PR throttle) and a cadence guard that matches the README's stated semantics.

## Backwards-compatibility note

Customers with default `rate-limit-days: 7` will see Issues opening daily where previously they saw nothing on 6/7 days. Strictly more product activity, visible in their Issues tab. Should be called out in release notes for v1.1.1.

## Test plan

- [ ] Merge → tag v1.1.1 → move `v1` floating tag
- [ ] Re-trigger Outrider on VQASynth (where `rate-limit-days: '0'` so behavior is unchanged for that repo)
- [ ] Eventually validate against a repo with `rate-limit-days: 7` to confirm Issue-track flows through during PR throttle

## Linear

Filing follow-up ticket separately for documentation in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)