### PR TITLE
Rate-limit counts Issues too — true global cadence guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Visit your repo's **Actions** tab → **Outrider** → **Run workflow**. The fir
 | `github-token` | *(empty — falls back to `${{ github.token }}`)* | Token used for git push + PR/Issue creation. Leave unset for the standard same-repo install; the action will use the workflow's built-in `GITHUB_TOKEN`. Override with a PAT (`${{ secrets.MY_PAT }}`) only for cross-repo controller patterns. |
 | `min-confidence` | `moderate` | Tier gate: `high` / `moderate` / `low`. Recommendations below this are skipped. |
 | `draft-mode` | `always` | PR-draft policy: `always` (default), `on_test_failure`, or `never`. |
-| `rate-limit-days` | `7` | PR-cadence guard: skip the implementation pass if a Remyx PR was opened within this window. Issue-track candidates are NOT gated — pre-flight Issues continue to flow daily even during PR throttle. Set `0` to disable. |
+| `rate-limit-days` | `7` | Cadence guard: skip the run if any Remyx artifact (PR **or** Issue) was opened within this window. Customers see at most one Remyx artifact per `rate-limit-days` regardless of route. Set `0` to disable and rely only on per-paper dedup. |
 | `guardrails-allowlist` | `''` | Comma-separated extra path globs Claude Code may modify (most repos don't need this). |
 | `lookback` | `week` | Recommendation lookback window: `today` / `week` / `month`. The candidate pool is pulled over this window before the selection pass. |
 | `candidate-pool` | `25` | How many recommendations to pull into the selection pool. The selection pass picks the most implementable one; the rest are recorded as rejected with a reason. |

--- a/action.yml
+++ b/action.yml
@@ -38,12 +38,12 @@ inputs:
     default: 'always'
   rate-limit-days:
     description: |
-      PR-cadence guard: skip the implementation pass if a Remyx
-      Recommendation PR was opened within this many days. Applies only
-      to PR-track candidates — pre-flight Issues continue to flow daily
-      even during PR throttle, since Issues are cheap discussion
-      surfaces that don't add to the review queue. Default 7 (weekly
-      PR cadence). Set to 0 to disable.
+      Cadence guard: skip the run if any Remyx Recommendation artifact
+      (PR or Issue) was opened on the target repo within this many
+      days. Counts both routes so customers see at most one Remyx
+      artifact per `rate-limit-days` regardless of whether it lands as
+      a PR or as a discussion Issue. Default 7 (weekly cadence). Set
+      to 0 to disable and rely only on per-paper dedup.
     required: false
     default: '7'
   guardrails-allowlist:

--- a/src/run.py
+++ b/src/run.py
@@ -973,7 +973,7 @@ def open_remyx_issues(target: Target) -> list[dict]:
     separately by existing_pr_for. We keep only items that look like one
     of ours: the title carries the PR_TITLE_PREFIX or the body has the
     orchestrator's attribution footer. Bounded to the first 100 open
-    issues (same pragmatic cap as recent_pr_within_rate_limit)."""
+    issues (same pragmatic cap as recent_remyx_activity_within_rate_limit)."""
     issues = gh_api(
         "GET", f"/repos/{target.repo}/issues?state=open&per_page=100"
     ) or []
@@ -1007,12 +1007,22 @@ def issue_for_paper(open_issues: list[dict], rec: Recommendation) -> dict | None
     return None
 
 
-def recent_pr_within_rate_limit(target: Target) -> bool:
-    """Return True if a Remyx Recommendation PR was opened on the target
-    repo within `rate_limit_days`."""
+def recent_remyx_activity_within_rate_limit(target: Target) -> bool:
+    """Return True if any Remyx Recommendation PR OR Issue was opened on
+    the target repo within `rate_limit_days`.
+
+    Counts both states (open and closed) — a recently-closed artifact
+    still represents a recent customer interruption that the rate-limit
+    is designed to throttle. Counts both PRs (identified by branch
+    prefix) and Issues (identified by title prefix or body marker), so
+    a cadence guard set to e.g. 7 days produces at most one Remyx
+    artifact per week, regardless of whether it lands as a PR or an
+    Issue."""
     if target.rate_limit_days <= 0:
         return False
     cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=target.rate_limit_days)
+
+    # PRs — identified by branch prefix.
     prs = gh_api(
         "GET", f"/repos/{target.repo}/pulls?state=all&per_page=20"
     )
@@ -1023,10 +1033,32 @@ def recent_pr_within_rate_limit(target: Target) -> bool:
         created = dt.datetime.fromisoformat(pr["created_at"].replace("Z", "+00:00"))
         if created > cutoff:
             log.info(
-                f"  rate-limit hit: {pr['html_url']} opened "
+                f"  rate-limit hit (PR): {pr['html_url']} opened "
                 f"{(dt.datetime.now(dt.timezone.utc) - created).days}d ago"
             )
             return True
+
+    # Issues — identified by title prefix or body attribution marker.
+    # GitHub's /issues endpoint also returns PRs (they carry a
+    # 'pull_request' key); filter those out so we don't double-count.
+    issues = gh_api(
+        "GET", f"/repos/{target.repo}/issues?state=all&per_page=50"
+    ) or []
+    for it in issues:
+        if it.get("pull_request"):
+            continue
+        title = it.get("title") or ""
+        body = it.get("body") or ""
+        if not (title.startswith(PR_TITLE_PREFIX) or "Remyx Recommendation" in body):
+            continue
+        created = dt.datetime.fromisoformat(it["created_at"].replace("Z", "+00:00"))
+        if created > cutoff:
+            log.info(
+                f"  rate-limit hit (Issue): {it['html_url']} opened "
+                f"{(dt.datetime.now(dt.timezone.utc) - created).days}d ago"
+            )
+            return True
+
     return False
 
 
@@ -2242,10 +2274,10 @@ def process_target(target: Target) -> dict:
     skip:
 
         skipped_low_confidence            — tier below min_confidence
-        skipped_rate_limit                — recent PR within rate-limit-days
-                                            AND pre-flight routed this
-                                            candidate to PR (Issues are
-                                            never rate-limited)
+        skipped_rate_limit                — any Remyx artifact (PR or
+                                            Issue) opened within
+                                            rate-limit-days; the gate is
+                                            a global cadence guard
         skipped_pr_exists                 — every candidate already has an
                                             open PR (or a mix of open PRs/Issues)
         skipped_issue_exists              — every candidate already has an
@@ -2270,15 +2302,17 @@ def process_target(target: Target) -> dict:
     """
     result: dict = {"repo": target.repo, "status": "unknown"}
 
-    # 1. (was: rate-limit pre-check) — moved to §5.7. The old §1 ran
-    #    recent_pr_within_rate_limit() before any candidate work, which
-    #    blocked Issue-track activity too. It now fires AFTER pre-flight
-    #    decides PR-vs-Issue, so it only gates PR-track candidates.
-    #    Issues are cheap discussion surfaces that don't add to the
-    #    team's review queue — gating them was overcautious. The
-    #    trade-off: ~$0.10-0.20 spent on pre-flight + selection per
-    #    rate-limited day, in exchange for daily Issue-track scouting
-    #    and a more accurate cadence guard.
+    # 1. Rate-limit (cadence guard) — cheapest gate, before any
+    #    candidate work or checkout. Counts BOTH Remyx PRs and Issues
+    #    opened within rate-limit-days; if any exists, skip the run.
+    #    This makes the rate-limit a true global cadence guard:
+    #    customers see at most one Remyx artifact per N days regardless
+    #    of which route (PR or Issue) it takes. The earlier version
+    #    counted only PRs, which let Issues open daily during PR
+    #    throttle — that was high-noise on daily crons.
+    if recent_remyx_activity_within_rate_limit(target):
+        result["status"] = "skipped_rate_limit"
+        return result
 
     # 2. Query the candidate pool over the lookback window (default: the
     #    past week). The old flow took only papers[0], wasting the
@@ -2423,20 +2457,6 @@ def process_target(target: Target) -> dict:
             result["status"] = "issue_opened_preflight"
             result["issue_url"] = issue_url
             log.info(f"  ✓ issue_opened_preflight: {issue_url}")
-            return result
-
-        # 5.7. Rate-limit (PR-cadence guard). Now that pre-flight has
-        # decided this candidate is PR-track, check whether a recent
-        # Remyx PR was opened within rate-limit-days. If so, skip
-        # implementation. Issue-track candidates already returned above
-        # — Issues are cheap discussion surfaces that don't add to the
-        # team's review queue, so they aren't gated.
-        if recent_pr_within_rate_limit(target):
-            result["status"] = "skipped_rate_limit"
-            log.info(
-                f"  ✗ rate-limit hit before PR-track implementation; "
-                f"would have implemented {rec.arxiv_id}"
-            )
             return result
 
         # 6. Claude Code


### PR DESCRIPTION
## Summary

Extends the rate-limit gate to count both Remyx PRs **and** Remyx Issues within the configured window. Customers now see at most one Remyx artifact per `rate-limit-days` regardless of route. This matches the natural mental model of "max one Remyx interruption per N days."

## Why the v1.1.1 fix was incomplete

v1.1.1 moved the rate-limit to after pre-flight routing so it only blocked PR-track candidates. The intent there was right (Issues don't add to PR review queue) but the consequence was **Issue spam**: a daily cron with `rate-limit-days: 7` could open up to 7 Issues per week if the candidate pool kept refreshing day-over-day, because nothing was throttling them.

## What changed

- `recent_pr_within_rate_limit` → `recent_remyx_activity_within_rate_limit`
- Function now counts both **Remyx PRs** (identified by branch prefix `remyx-recommendation/*`) AND **Remyx Issues** (identified by `[Remyx Recommendation]` title prefix or body attribution marker) opened within the window
- Counts all states (open + closed) — a recently-closed artifact still represents a recent customer interruption that the gate should respect
- Gate moves back to the early position (§1 in `process_target`) before any candidate work — costs `$0` on rate-limited days (vs. ~$0.10-0.20 in v1.1.1)
- Removes the §5.7 gate added in v1.1.1

## Net behavior change vs v1.1.1

| Scenario | v1.1.1 | This PR |
|---|---|---|
| Daily cron, `rate-limit-days: 7` | Up to 7 Issues/week (PR throttle only) | At most 1 Remyx artifact/week |
| Daily cron, `rate-limit-days: 0` (VQASynth) | Up to 7 PRs/week, relies on per-paper dedup | Unchanged — same behavior |
| Weekly cron, `rate-limit-days: 7` | 1 PR/week + some Issues | At most 1 artifact/week |

## Backwards compatibility

- VQASynth specifically (`rate-limit-days: '0'`) is unaffected
- Default-config customers see strictly less activity, which matches their (probable) original expectation
- Customers who want the v1.1.1 behavior — daily Issue scouting during PR throttle — can opt in via `rate-limit-days: '0'`, but lose PR throttling entirely. That trade-off is documented in the README.

## Test plan

- [ ] Merge → tag v1.1.2 → move `v1`
- [ ] VQASynth (`rate-limit-days: '0'`) — behavior unchanged, daily PRs continue
- [ ] Later: set up a second test repo with default `rate-limit-days: 7` to validate weekly-cadence behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)