### PR TITLE
Align README + Claude prompts to 'PR would be premature' framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Outrider — GitHub Action
 
-Scouts the arXiv frontier for your repo. On a schedule you choose, Outrider picks the next paper most implementable against your codebase and either opens a draft PR wiring it into an existing call site, or opens a discussion Issue when the paper doesn't fit cleanly.
+Scouts the arXiv frontier for your repo. On a schedule you choose, Outrider picks the next paper most implementable against your codebase and either opens a draft PR wiring it into an existing call site, or starts a discussion Issue when a PR would be premature.
 
 ```yaml
 - uses: remyxai/outrider@v1
@@ -11,7 +11,7 @@ Scouts the arXiv frontier for your repo. On a schedule you choose, Outrider pick
 ## What you get
 
 - **Draft PRs** that wire a paper's contribution into an existing module, with a self-review section in the body honestly noting what was implemented vs. left out
-- **Issues** when the paper doesn't fit — pre-flight, validators, or self-review route it to discussion instead of scaffold-shaped PRs
+- **Issues** when a PR would be premature — pre-flight, validators, or self-review route the paper to discussion instead of scaffold-shaped PRs
 - **One artifact per `rate-limit-days`** by default — no Issue spam
 
 The orchestrator defaults to opening Issues. A PR ships only when new code is actually wired into an existing call site, passes a stub-density check, has a test that imports from a pre-existing module, and survives a Claude self-review pass.

--- a/src/run.py
+++ b/src/run.py
@@ -314,7 +314,7 @@ implementable.)
 ```
 
 The orchestrator detects this file and opens an Issue instead of a PR.
-This is the HONEST outcome when the paper doesn't fit, not a failure.
+This is the HONEST outcome when a PR would be premature, not a failure.
 
 # Step 2 — only if you're proceeding with PR: implement an INTEGRATION
 
@@ -364,7 +364,7 @@ Required outputs:
   instead — the orchestrator will reject the run anyway.
 - If your new module would import cleanly but never be called by
   anything else in the repo, STOP and write the Issue file instead.
-- The Issue-mode path is the correct route when the paper doesn't fit.
+- The Issue-mode path is the correct route when a PR would be premature.
   It is NOT a failure mode.
 
 Run pytest before declaring done. If tests fail, fix them or scope down


### PR DESCRIPTION
## Summary

Replaces \"when the paper doesn't fit\" with \"when a PR would be premature\" in the README intro, the What-you-get bullet, and the two Claude-prompt strings in src/run.py.

\"Doesn't fit\" reads as a failure framing — like the paper got rejected. The Issue route is actually a deliberate quality gate. \"Premature\" captures the temporal nuance (\"not yet, here's what would unblock it\") instead of the binary \"doesn't work.\"

Matches the repo's About description set 2026-05-31.

## Bonus: nudge for Claude

The two updated strings live in the spec-bundle prompts Claude reads when deciding PR vs Issue. The \"premature\" framing should cue Claude's Issue bodies toward \"what would need to be true to proceed\" content rather than just \"this doesn't work\" — a small quality improvement with no behavior change anywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)