### PR TITLE
Marketplace-readiness cleanup: scrub internal references

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Scouts the arXiv frontier for your repo. On a schedule you choose, Outrider pick
 - **Issues** when a PR would be premature — pre-flight, validators, or self-review route the paper to discussion instead of scaffold-shaped PRs
 - **One artifact per `rate-limit-days`** by default — no Issue spam
 
-The orchestrator defaults to opening Issues. A PR ships only when new code is actually wired into an existing call site, passes a stub-density check, has a test that imports from a pre-existing module, and survives a Claude self-review pass.
-
 ## Setup (5 minutes)
 
 1. **Sign up at [engine.remyx.ai](https://engine.remyx.ai)** and connect your repo. Remyx ingests your commit history and creates a `ResearchInterest`. Edit its context body to sharpen the framing.

--- a/src/run.py
+++ b/src/run.py
@@ -1193,7 +1193,7 @@ def write_spec_bundle(
 
 # Per-run token/cost totals, accumulated across every `claude` call in a
 # run (pre-flight, selection, implementation, self-review) and surfaced in
-# the RUN SUMMARY + $GITHUB_OUTPUT. (REMYX-64)
+# the RUN SUMMARY + $GITHUB_OUTPUT.
 _RUN_COST = {
     "cost_usd": 0.0,
     "input_tokens": 0,
@@ -1228,7 +1228,7 @@ def _run_claude_json(
     cmd_prefix: list[str], prompt: str, cwd: Path, timeout_s: int
 ) -> tuple[bool, str]:
     """Run `claude … --output-format json -p <prompt>`, accumulate token/cost
-    usage into _RUN_COST (REMYX-64), and return (ok, model_text).
+    usage into _RUN_COST, and return (ok, model_text).
 
     With --output-format json the CLI prints a single envelope object
     ({result, total_cost_usd, usage, num_turns, is_error, …}); the model's
@@ -2920,7 +2920,7 @@ def main():
         result = {"repo": target.repo, "status": "error", "error": str(e)}
 
     # Token/cost totals across every Claude pass this run, captured even when
-    # process_target raised (REMYX-64).
+    # process_target raised.
     result["cost_usd"] = round(_RUN_COST["cost_usd"], 4)
     result["input_tokens"] = _RUN_COST["input_tokens"]
     result["output_tokens"] = _RUN_COST["output_tokens"]

--- a/tests/test_integration_gates.py
+++ b/tests/test_integration_gates.py
@@ -251,7 +251,7 @@ def test_classify_pytest():
     assert run._classify_pytest(1, "1 failed\nModuleNotFoundError: x") == "failed"
 
 
-# ── 6. REMYX-64: per-run token/cost accumulation ───────────────────────────
+# ── 6. Per-run token/cost accumulation ────────────────────────────────────
 
 def test_cost_accumulation():
     run._reset_run_cost()


### PR DESCRIPTION
## Summary

Marketplace-readiness pass on Outrider — removes 4 internal Linear ticket references (REMYX-64) from comments/docstrings and trims a redundant paragraph from the README.

## Changes

**Source scrubs** (4 occurrences of \`REMYX-64\` replaced with semantic descriptions):
- \`src/run.py:1196\` — Per-run token/cost totals comment
- \`src/run.py:1231\` — \`_run_claude_json\` docstring
- \`src/run.py:2923\` — Token/cost capture-on-exception comment
- \`tests/test_integration_gates.py:254\` — Section divider

**README trim** — removes the orchestrator-defaults paragraph in "What you get". Content is already covered by the collapsed \`Status codes\` section. 2 lines shorter.

## Marketplace audit (informational)

| Requirement | Status |
|---|---|
| Composite/Docker/JS action format | ✅ Composite |
| \`action.yml\` with name + description + branding | ✅ icon=\`compass\`, color=\`purple\` |
| LICENSE file | ✅ Apache 2.0 |
| README.md | ✅ |
| Repo topics + description | ✅ |
| GitHub Release | ⏳ pending (will tag v1.1.3 after PR #14 lands) |

## What's intentionally not changed

- \`BUNDLE_DIR_NAME = ".remyx-recommendation"\`, \`PR_TITLE_PREFIX = "[Remyx Recommendation]"\`, committer name — these are the content-brand layer (two-layer brand: Outrider = action surface, Remyx Recommendation = content). Changing them would orphan existing customer PRs/branches.
- Test fixture references to \`"VQASynth"\` — customers don't see tests; realistic data > cosmetic neutrality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)