### PR TITLE
Update README costs + shift example cron 8 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Scouts the arXiv frontier for your repo. On a schedule you choose, Outrider pick
    name: Outrider
    on:
      schedule:
-       - cron: '0 6 * * 1'   # Mondays 06:00 UTC; pick any cadence
+       - cron: '0 14 * * 1'  # Mondays 14:00 UTC; pick any cadence
      workflow_dispatch:
    jobs:
      recommend:
@@ -82,11 +82,11 @@ Scouts the arXiv frontier for your repo. On a schedule you choose, Outrider pick
 
 ## Costs
 
-- **Claude Code**: ~$0.40–0.70 per PR-track run, less for Issue-track (no implementation pass). You bring `ANTHROPIC_API_KEY`.
+- **Claude Code**: ~$2–3 per PR-track run (pre-flight + selection + implementation + self-review). Issue-track runs cost less since they skip the implementation pass. You bring `ANTHROPIC_API_KEY`.
 - **Remyx API**: included in your engine.remyx.ai subscription.
-- **GitHub Actions**: ~5 min on `ubuntu-latest` per run.
+- **GitHub Actions**: ~6–8 min on `ubuntu-latest` per run.
 
-At weekly cadence (default `rate-limit-days: 7`), expect ~$1–3/mo Claude.
+At weekly cadence (default `rate-limit-days: 7`), expect ~$2–4/mo Claude.
 
 <details>
 <summary><b>Status codes</b> (15 outcomes)</summary>


### PR DESCRIPTION
## Summary

Two small updates batched:

1. **Costs section reflects v1.1.3 measured cost.** End-to-end re-run on VQASynth (PR #78) measured $2.64 per PR-track run (was ~$0.40-0.70 in v1.1.2) and ~8 min wall time (was ~5 min). The added context (~6KB experiment-history bullets, read across pre-flight + selection + implementation + self-review passes) is the cost, but the outcome jumped from "self-review orphan downgrade → Issue" to "wired-in PR ready for review." Worth it.

   Weekly-cadence monthly estimate: ~\$1-3 → ~\$2-4.

2. **Example cron shift 06:00 UTC → 14:00 UTC.** 06:00 UTC = 11pm Pacific previous day (not useful arrival timing). 14:00 UTC = 7am Pacific / 10am Eastern / 3pm London / 9pm Tokyo — reasonable across US, EU, and APAC business hours. Customers set their own cadence; this only changes the README copy-paste suggestion.

## Test plan

- [ ] Squash-merge — pure docs, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)