### PR TITLE
Add Validate-waitlist CTA to PR body

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -594,6 +594,8 @@ _PR_BODY_TEMPLATE = """\
 
 ---
 
+> **Want eval-on-every-PR?** Outrider Validate (coming soon, paid tier) runs your benchmark suite against this diff and posts the results as a PR comment. Design partner pilot is open — [join the waitlist](https://github.com/remyxai/outrider/discussions/19).
+
 _Opened by the [Remyx Recommendation]({attribution_url}) orchestrator._
 """
 


### PR DESCRIPTION
## Summary

Outrider-generated PRs now carry a one-line CTA pointing to the Validate beta waitlist (GitHub Discussion #19 on this repo). Every PR Outrider opens becomes a touchpoint for the design-partner funnel.

Sized small — one sentence + one link, visually separated as a blockquote so it reads as the upsell, not as core content.

## Where it goes

Between the test/self-review section and the attribution footer in `_PR_BODY_TEMPLATE`.

## What it looks like

> **Want eval-on-every-PR?** Outrider Validate (coming soon, paid tier) runs your benchmark suite against this diff and posts the results as a PR comment. Design partner pilot is open — [join the waitlist](https://github.com/remyxai/outrider/discussions/19).

## Tag

Will tag as v1.1.5 after merge so existing consumers (VQASynth + FFMPerative) start carrying the CTA on next dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)