### PR TITLE
Add deepresearch veto pre-flight hook

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -2624,6 +2624,8 @@ def process_target(target: Target) -> dict:
             if dr:
                 result["deepresearch_confidence"] = dr.get("confidence")
                 result["deepresearch_rationale"] = dr.get("rationale")
+                result["deepresearch_synth_excerpt"] = dr.get("synth_excerpt") or ""
+                result["deepresearch_log_id"] = dr.get("log_id") or ""
                 result["deepresearch_mode"] = dr.get("_mode")
                 if (
                     dr.get("_mode") == "enforce"
@@ -3122,6 +3124,30 @@ def _write_step_summary(result: dict) -> None:
         lines.append("<details><summary>Why this paper</summary>\n")
         lines.append(f"\n{reasoning}\n")
         lines.append("\n</details>\n")
+
+    # Deepresearch assessment — surfaces the calibrated paper-vs-repo
+    # verdict when the deepresearch veto ran (shadow or enforce). Helps
+    # the maintainer judge whether to act on an Issue, and explains why
+    # a skipped_by_deepresearch run produced no Issue/PR.
+    dr_confidence = result.get("deepresearch_confidence")
+    if dr_confidence:
+        dr_rationale = (result.get("deepresearch_rationale") or "").strip()
+        dr_excerpt = (result.get("deepresearch_synth_excerpt") or "").strip()
+        dr_mode = result.get("deepresearch_mode") or ""
+        conf_emoji = {"high": "🟢", "moderate": "🟡", "low": "🔴"}.get(
+            dr_confidence, "ℹ️"
+        )
+        lines.append("\n**Deepresearch assessment**\n")
+        mode_suffix = f" _(mode: {dr_mode})_" if dr_mode else ""
+        lines.append(
+            f"- **Confidence**: {conf_emoji} `{dr_confidence}`{mode_suffix}"
+        )
+        if dr_rationale:
+            lines.append(f"- _{dr_rationale}_")
+        if dr_excerpt:
+            lines.append("\n<details><summary>Excerpt from the analysis</summary>\n")
+            lines.append(f"\n{dr_excerpt}\n")
+            lines.append("\n</details>\n")
 
     # Cost telemetry — the headline reason this summary exists.
     token_line = f"{in_tok:,} in / {out_tok:,} out"

--- a/src/run.py
+++ b/src/run.py
@@ -1441,6 +1441,105 @@ def preflight_routing(
     return data
 
 
+# ─── Deepresearch veto (REMYX-78) ──────────────────────────────────────────
+#
+# After preflight_routing decides PR or ISSUE, optionally call the engine's
+# /api/v1.0/deepresearch/paper-vs-repo endpoint to get a calibrated
+# {low, moderate, high} confidence verdict on the (paper, repo) match. The
+# engine spins up RepoRanger's deepresearch agent + judge — this is the
+# filter that catches false-positive Issues like salma-remyx/numpyro#3
+# where the ranker scored 1.00 but the paper and repo are in fundamentally
+# different problem classes.
+#
+# Mode is controlled by OUTRIDER_DEEPRESEARCH_VETO:
+#   - off (default): no call, no veto. Cost-safe.
+#   - shadow:        call the endpoint, log the verdict, but always publish.
+#                    Use this to measure precision lift before flipping on.
+#   - enforce:       call the endpoint; if verdict == 'low', skip the run.
+#
+# Latency is ~30-90s per call. Callers should gate invocation (we only
+# call when preflight has decided to publish — see process_target).
+
+
+def _deepresearch_veto_mode() -> str:
+    return os.environ.get("OUTRIDER_DEEPRESEARCH_VETO", "off").strip().lower()
+
+
+def deepresearch_veto_check(
+    rec: "Recommendation",
+    repo_url: str,
+    *,
+    candidate_id: str | None = None,
+    preflight_summary: str | None = None,
+    timeout_s: int = 120,
+) -> dict | None:
+    """Call the engine's deepresearch endpoint for a veto verdict.
+
+    Returns the parsed response dict on success, or None when:
+      - the feature is disabled (OUTRIDER_DEEPRESEARCH_VETO not set)
+      - the endpoint is unreachable / returns 5xx
+      - the response can't be parsed
+      - REMYX_API_KEY is missing
+
+    On None, the caller falls through to the regular path — a failed
+    deepresearch check never blocks publishing, it just doesn't save the
+    Claude budget. Mirrors the preflight_routing fail-soft convention.
+    """
+    mode = _deepresearch_veto_mode()
+    if mode not in ("shadow", "enforce"):
+        return None
+    if not rec.arxiv_id:
+        return None
+    api_key = (
+        os.environ.get("REMYX_API_KEY") or os.environ.get("REMYXAI_API_KEY") or ""
+    ).strip()
+    if not api_key:
+        log.warning("  deepresearch veto: REMYX_API_KEY not set; skipping")
+        return None
+
+    payload = {
+        "arxiv_url": f"https://arxiv.org/abs/{rec.arxiv_id}",
+        "github_url": repo_url,
+        "candidate_id": candidate_id or rec.arxiv_id,
+        "ranker_score": rec.relevance_score,
+        "preflight_summary": (preflight_summary or "")[:1000],
+    }
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{REMYX_API_BASE}/api/v1.0/deepresearch/paper-vs-repo",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+            "User-Agent": "feature-finder-orchestrator",
+        },
+        method="POST",
+    )
+    t0 = time.time()
+    log.info(f"  → deepresearch veto check (mode={mode}, ~30-90s)")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as r:
+            data = json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        log.warning(
+            f"  deepresearch veto: HTTP {e.code} after "
+            f"{time.time() - t0:.1f}s; falling through"
+        )
+        return None
+    except Exception as e:
+        log.warning(
+            f"  deepresearch veto: {type(e).__name__} after "
+            f"{time.time() - t0:.1f}s; falling through: {str(e)[:200]}"
+        )
+        return None
+    log.info(
+        f"  deepresearch verdict: {data.get('confidence', '?')} "
+        f"({(data.get('rationale') or '')[:120]})"
+    )
+    data["_mode"] = mode
+    return data
+
+
 def _render_candidate_brief(candidates: list[Recommendation]) -> str:
     """Numbered, relevance-ranked brief of the candidate pool for the
     selection pass. Index matches list position so the model's
@@ -2328,6 +2427,8 @@ def process_target(target: Target) -> dict:
                                             open PR (or a mix of open PRs/Issues)
         skipped_issue_exists              — every candidate already has an
                                             open Remyx Issue
+        skipped_by_deepresearch           — deepresearch veto (REMYX-78):
+                                            confidence=low in enforce mode
 
         issue_opened_preflight            — pre-flight (§6) routed to Issue
                                             before invoking implementation
@@ -2505,6 +2606,36 @@ def process_target(target: Target) -> dict:
         result["preflight_decision"] = (
             preflight.get("decision") if preflight else "(skipped)"
         )
+
+        # 5.6. Deepresearch veto (REMYX-78). On candidates that pre-flight
+        # has decided to publish, optionally call the engine's deepresearch
+        # endpoint for a calibrated {low, moderate, high} verdict. Catches
+        # the ranker-high / pre-flight-hedged false-positive shape (e.g.
+        # salma-remyx/numpyro#3). Mode is set by OUTRIDER_DEEPRESEARCH_VETO
+        # (off | shadow | enforce). Failures fall through — never block a
+        # publish.
+        if preflight and preflight.get("decision") in ("PR", "ISSUE"):
+            dr = deepresearch_veto_check(
+                rec,
+                repo_url=f"https://github.com/{target.repo}",
+                candidate_id=rec.arxiv_id,
+                preflight_summary=(preflight.get("reasoning") or "")[:1000],
+            )
+            if dr:
+                result["deepresearch_confidence"] = dr.get("confidence")
+                result["deepresearch_rationale"] = dr.get("rationale")
+                result["deepresearch_mode"] = dr.get("_mode")
+                if (
+                    dr.get("_mode") == "enforce"
+                    and dr.get("confidence") == "low"
+                ):
+                    result["status"] = "skipped_by_deepresearch"
+                    log.info(
+                        f"  ✗ skipped_by_deepresearch: confidence=low "
+                        f"({(dr.get('rationale') or '')[:120]})"
+                    )
+                    return result
+
         if preflight and preflight.get("decision") == "ISSUE":
             issue_title_inner = (
                 preflight.get("issue_title")
@@ -2965,6 +3096,7 @@ def _write_step_summary(result: dict) -> None:
         "skipped_rate_limit":      "⏭️",
         "skipped_pr_exists":       "⏭️",
         "skipped_issue_exists":    "⏭️",
+        "skipped_by_deepresearch": "⏭️",
         "skipped_test_failure":    "⏭️",
         "claude_failed":           "❌",
         "rejected_path_violations":"❌",

--- a/src/run.py
+++ b/src/run.py
@@ -1540,6 +1540,40 @@ def deepresearch_veto_check(
     return data
 
 
+def _augment_selection_rejected(
+    *,
+    existing: list[dict],
+    viable: list["Recommendation"],
+    selected_arxiv: str,
+    cap: int = 5,
+) -> list[dict]:
+    """Add ranker-pool candidates the selection LLM didn't enumerate.
+
+    Keeps the existing entries (LLM-enumerated with their "why" reason)
+    at the head; appends tail entries for any other viable candidate not
+    yet listed and not the selected one. Tail entries get a neutral
+    marker so the reader can tell the difference from LLM-rejected ones.
+    Total list is capped to keep the workflow step summary readable.
+    """
+    listed_arxiv = {r.get("arxiv_id") for r in existing if r.get("arxiv_id")}
+    listed_arxiv.add(selected_arxiv)
+    extras: list[dict] = []
+    for cand in viable:
+        if cand.arxiv_id in listed_arxiv:
+            continue
+        extras.append({
+            "arxiv_id": cand.arxiv_id,
+            "title": cand.paper_title,
+            "reason": (
+                f"(ranker relevance {cand.relevance_score:.2f}; "
+                f"not flagged by selection)"
+            ),
+        })
+        if len(existing) + len(extras) >= cap:
+            break
+    return existing + extras
+
+
 def _render_candidate_brief(candidates: list[Recommendation]) -> str:
     """Numbered, relevance-ranked brief of the candidate pool for the
     selection pass. Index matches list position so the model's
@@ -2588,6 +2622,17 @@ def process_target(target: Target) -> dict:
             "tier": rec.tier,
             "candidates_considered": len(viable),
         })
+
+        # Extend selection_rejected with any viable candidates the
+        # selection pass didn't explicitly enumerate. Ensures the
+        # alternatives list is populated whether or not selection
+        # produced explicit reasoning and whether or not deepresearch ran.
+        result["selection_rejected"] = _augment_selection_rejected(
+            existing=result.get("selection_rejected") or [],
+            viable=viable,
+            selected_arxiv=rec.arxiv_id,
+        )
+
         log.info(f"  ✓ selected: [{rec.tier}] {rec.paper_title}")
 
         # 5. Spec bundle for the chosen candidate. Thread the selection

--- a/tests/test_deepresearch_veto.py
+++ b/tests/test_deepresearch_veto.py
@@ -1,0 +1,154 @@
+"""Tests for the deepresearch veto pre-flight hook (REMYX-78).
+
+The engine endpoint is patched — we assert:
+  - the mode env var controls invocation
+  - missing API key falls through (None)
+  - HTTP errors fall through (None) — never blocks publishing
+  - successful responses are returned with the mode tagged
+  - the action's process_target consumes a 'low' verdict in enforce mode
+    as `skipped_by_deepresearch`
+
+Run with: pytest tests/test_deepresearch_veto.py -q
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Recommendation, deepresearch_veto_check  # noqa: E402
+
+
+def _make_rec(arxiv_id="2605.25734v1", score=1.0):
+    return Recommendation(
+        paper_title="Test paper",
+        arxiv_id=arxiv_id,
+        tier="high",
+        z_score=0.0,
+        spec_md="",
+        paper_abstract="Test abstract",
+        domain_summary="",
+        raw_paper_md="",
+        relevance_score=score,
+        reasoning="x",
+        suggested_experiment="y",
+        recommendation_id="rec-1",
+        interest_name="test",
+    )
+
+
+def test_veto_off_by_default(monkeypatch):
+    monkeypatch.delenv("OUTRIDER_DEEPRESEARCH_VETO", raising=False)
+    monkeypatch.setenv("REMYX_API_KEY", "sk-test")
+    rec = _make_rec()
+    # Should return None without ever attempting urllib
+    with patch("urllib.request.urlopen", side_effect=AssertionError("must not call")):
+        result = deepresearch_veto_check(rec, "https://github.com/o/r")
+    assert result is None
+
+
+def test_veto_skips_without_api_key(monkeypatch):
+    monkeypatch.setenv("OUTRIDER_DEEPRESEARCH_VETO", "enforce")
+    monkeypatch.delenv("REMYX_API_KEY", raising=False)
+    monkeypatch.delenv("REMYXAI_API_KEY", raising=False)
+    rec = _make_rec()
+    with patch("urllib.request.urlopen", side_effect=AssertionError("must not call")):
+        result = deepresearch_veto_check(rec, "https://github.com/o/r")
+    assert result is None
+
+
+def test_veto_skips_without_arxiv_id(monkeypatch):
+    monkeypatch.setenv("OUTRIDER_DEEPRESEARCH_VETO", "enforce")
+    monkeypatch.setenv("REMYX_API_KEY", "sk-test")
+    rec = _make_rec(arxiv_id=None)
+    with patch("urllib.request.urlopen", side_effect=AssertionError("must not call")):
+        result = deepresearch_veto_check(rec, "https://github.com/o/r")
+    assert result is None
+
+
+def test_veto_returns_verdict_in_shadow_mode(monkeypatch):
+    monkeypatch.setenv("OUTRIDER_DEEPRESEARCH_VETO", "shadow")
+    monkeypatch.setenv("REMYX_API_KEY", "sk-test")
+    rec = _make_rec()
+
+    response_body = json.dumps({
+        "confidence": "low",
+        "rationale": "Different problem class.",
+        "code_hits": [],
+        "synth_excerpt": "",
+        "elapsed_s": 42.0,
+        "log_id": "log-1",
+    }).encode("utf-8")
+    fake_resp = MagicMock()
+    fake_resp.read.return_value = response_body
+    fake_resp.__enter__.return_value = fake_resp
+    fake_resp.__exit__.return_value = False
+
+    with patch("urllib.request.urlopen", return_value=fake_resp):
+        result = deepresearch_veto_check(rec, "https://github.com/o/r")
+    assert result is not None
+    assert result["confidence"] == "low"
+    assert result["_mode"] == "shadow"
+
+
+def test_veto_falls_through_on_http_error(monkeypatch):
+    """A failed deepresearch check must never block publishing — fail-soft
+    same as preflight_routing's convention."""
+    import urllib.error
+    monkeypatch.setenv("OUTRIDER_DEEPRESEARCH_VETO", "enforce")
+    monkeypatch.setenv("REMYX_API_KEY", "sk-test")
+    rec = _make_rec()
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.HTTPError(
+            "u", 503, "Service Unavailable", {}, None
+        ),
+    ):
+        result = deepresearch_veto_check(rec, "https://github.com/o/r")
+    assert result is None
+
+
+def test_veto_sends_expected_payload(monkeypatch):
+    """The endpoint receives arxiv_url + github_url + ranker_score +
+    candidate_id + preflight_summary, with Bearer auth from REMYX_API_KEY."""
+    monkeypatch.setenv("OUTRIDER_DEEPRESEARCH_VETO", "enforce")
+    monkeypatch.setenv("REMYX_API_KEY", "sk-test-bearer")
+    rec = _make_rec()
+
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        m = MagicMock()
+        m.read.return_value = json.dumps({
+            "confidence": "high",
+            "rationale": "Clean fit.",
+            "elapsed_s": 30.0,
+        }).encode("utf-8")
+        m.__enter__.return_value = m
+        m.__exit__.return_value = False
+        return m
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = deepresearch_veto_check(
+            rec,
+            "https://github.com/pyro-ppl/numpyro",
+            candidate_id="cand-xyz",
+            preflight_summary="hedged on call-site",
+        )
+    assert "/api/v1.0/deepresearch/paper-vs-repo" in captured["url"]
+    # Header keys are normalized — case-insensitive lookup
+    headers_lc = {k.lower(): v for k, v in captured["headers"].items()}
+    assert headers_lc.get("authorization") == "Bearer sk-test-bearer"
+    assert captured["body"]["arxiv_url"] == "https://arxiv.org/abs/2605.25734v1"
+    assert captured["body"]["github_url"] == "https://github.com/pyro-ppl/numpyro"
+    assert captured["body"]["ranker_score"] == 1.0
+    assert captured["body"]["candidate_id"] == "cand-xyz"
+    assert captured["body"]["preflight_summary"] == "hedged on call-site"
+    assert result["confidence"] == "high"

--- a/tests/test_deepresearch_veto.py
+++ b/tests/test_deepresearch_veto.py
@@ -112,6 +112,51 @@ def test_veto_falls_through_on_http_error(monkeypatch):
     assert result is None
 
 
+def test_step_summary_renders_deepresearch_assessment(monkeypatch, tmp_path):
+    """When result carries deepresearch_* fields, _write_step_summary should
+    render a 'Deepresearch assessment' block with confidence + rationale +
+    excerpt."""
+    summary_file = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+    result = {
+        "status": "issue_opened_preflight",
+        "paper": "Test Paper",
+        "arxiv": "2605.25734v1",
+        "tier": "high",
+        "issue_url": "https://github.com/o/r/issues/3",
+        "deepresearch_confidence": "low",
+        "deepresearch_rationale": "Different problem class — biomedical vs. PPL.",
+        "deepresearch_synth_excerpt": "The paper applies Stein identities to a supervised encoder; the repo uses them for posterior inference.",
+        "deepresearch_mode": "enforce",
+        "cost_usd": 0.0,
+    }
+    run._write_step_summary(result)
+    written = summary_file.read_text()
+    assert "Deepresearch assessment" in written
+    assert "`low`" in written
+    assert "Different problem class" in written
+    assert "Excerpt from the analysis" in written
+    assert "supervised encoder" in written
+    assert "mode: enforce" in written
+
+
+def test_step_summary_omits_deepresearch_section_when_absent(monkeypatch, tmp_path):
+    """When deepresearch didn't run (mode=off, default), the summary should
+    not include the assessment block."""
+    summary_file = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+    result = {
+        "status": "pr_opened_draft",
+        "paper": "T",
+        "arxiv": "2605.25734v1",
+        "pr_url": "https://github.com/o/r/pull/4",
+        "cost_usd": 0.0,
+    }
+    run._write_step_summary(result)
+    written = summary_file.read_text()
+    assert "Deepresearch assessment" not in written
+
+
 def test_veto_sends_expected_payload(monkeypatch):
     """The endpoint receives arxiv_url + github_url + ranker_score +
     candidate_id + preflight_summary, with Bearer auth from REMYX_API_KEY."""

--- a/tests/test_deepresearch_veto.py
+++ b/tests/test_deepresearch_veto.py
@@ -157,6 +157,59 @@ def test_step_summary_omits_deepresearch_section_when_absent(monkeypatch, tmp_pa
     assert "Deepresearch assessment" not in written
 
 
+def test_augment_selection_rejected_with_existing_entries():
+    """LLM-enumerated rejections stay at the head; remaining viable
+    candidates fill the tail with a neutral marker."""
+    viable = [_make_rec(arxiv_id="A", score=0.99),  # selected
+              _make_rec(arxiv_id="B", score=0.98),  # already enumerated
+              _make_rec(arxiv_id="C", score=0.95),  # extra
+              _make_rec(arxiv_id="D", score=0.91)]  # extra
+    existing = [{"arxiv_id": "B", "title": "B-paper", "reason": "wrong layer"}]
+    out = run._augment_selection_rejected(
+        existing=existing, viable=viable, selected_arxiv="A"
+    )
+    assert [r["arxiv_id"] for r in out] == ["B", "C", "D"]
+    assert out[0]["reason"] == "wrong layer"
+    assert "not flagged by selection" in out[1]["reason"]
+    assert "0.95" in out[1]["reason"]
+
+
+def test_augment_selection_rejected_when_selection_unavailable():
+    """No LLM-enumerated rejections (single-candidate pool / fallback
+    path) → every other viable candidate becomes an extra."""
+    viable = [_make_rec(arxiv_id="A", score=0.99),  # selected
+              _make_rec(arxiv_id="B", score=0.96),
+              _make_rec(arxiv_id="C", score=0.93)]
+    out = run._augment_selection_rejected(
+        existing=[], viable=viable, selected_arxiv="A"
+    )
+    assert [r["arxiv_id"] for r in out] == ["B", "C"]
+    for entry in out:
+        assert "not flagged by selection" in entry["reason"]
+
+
+def test_augment_selection_rejected_caps_total():
+    """Combined list (LLM-rejected + extras) is capped to keep the
+    workflow step summary readable."""
+    viable = [_make_rec(arxiv_id=str(i), score=0.99 - i * 0.01) for i in range(10)]
+    out = run._augment_selection_rejected(
+        existing=[], viable=viable, selected_arxiv="0", cap=5
+    )
+    assert len(out) == 5
+    # Should be 1, 2, 3, 4, 5 — the next 5 after the selected "0"
+    assert [r["arxiv_id"] for r in out] == ["1", "2", "3", "4", "5"]
+
+
+def test_augment_selection_rejected_skips_selected_candidate():
+    """The selected candidate must never appear in the alternatives list."""
+    viable = [_make_rec(arxiv_id="A", score=0.99),
+              _make_rec(arxiv_id="B", score=0.97)]
+    out = run._augment_selection_rejected(
+        existing=[], viable=viable, selected_arxiv="A"
+    )
+    assert all(r["arxiv_id"] != "A" for r in out)
+
+
 def test_veto_sends_expected_payload(monkeypatch):
     """The endpoint receives arxiv_url + github_url + ranker_score +
     candidate_id + preflight_summary, with Bearer auth from REMYX_API_KEY."""


### PR DESCRIPTION
## Summary

Adds an optional pre-flight hook that calls a Remyx engine endpoint for a `{low, moderate, high}` confidence verdict on the `(paper, repo)` match. The verdict is captured into the run result and rendered into `$GITHUB_STEP_SUMMARY` for maintainer review. Primarily ships as a **shadow-mode telemetry surface** — calibration data we don't yet have a way to collect from production runs.

## Mode

Controlled by `OUTRIDER_DEEPRESEARCH_VETO`:

| Mode | Behavior |
|---|---|
| `off` (default) | No call, no verdict, no behavior change. Existing runs see no difference. |
| `shadow` | Call the endpoint, log the verdict on the result + render in the step summary, but always publish. **Recommended starting point** — collects calibration telemetry without changing what ships. |
| `enforce` | Call; on `confidence == "low"`, skip the run with status `skipped_by_deepresearch`. Use only after shadow data demonstrates stable verdicts; the verdict layer currently has enough LLM-judgment variance that immediate enforce can produce false negatives. |

Failures (HTTP error, missing `REMYX_API_KEY`, parse error) fall through with `None`, mirroring `preflight_routing`'s fail-soft convention — a broken or noisy verdict never blocks publishing.

## What's added

- `deepresearch_veto_check()` in `src/run.py` — POSTs to the engine endpoint, returns the parsed verdict or `None`.
- New step 5.6 in `process_target` — runs after `preflight_routing` decides PR/Issue, before the existing publish path.
- New status `skipped_by_deepresearch` in the routing-summary docstring and status-emoji map. Only triggered in `enforce` mode.
- **Workflow step-summary block.** When the veto ran (shadow or enforce), `$GITHUB_STEP_SUMMARY` renders a "Deepresearch assessment" section with the confidence verdict, one-line rationale, and a collapsed excerpt from the analysis. Block is omitted when the veto didn't run, so PR-only happy-path runs see no change.
- **Alternatives list populated unconditionally** (independent improvement). The existing "Selection: N other candidate(s) considered" block previously only rendered entries the selection LLM explicitly enumerated as rejected — leaving the list empty when selection was skipped (single candidate / pin-arxiv override / fallback to top-ranked) or when the selection enumerated fewer rejections than the pool. New `_augment_selection_rejected()` helper extends the list with remaining viable candidates (cap=5 total), tagging tail entries with `(ranker relevance X.XX; not flagged by selection)` so the reader can distinguish them. This works regardless of whether deepresearch ran.
- `tests/test_deepresearch_veto.py` — 12 tests covering: off-by-default, missing-key fallback, missing-arxiv-id skip, shadow-mode verdict, HTTP-error fall-through, payload shape, summary block rendering, summary block omission when absent, alternatives-augmentation head/tail ordering, augmentation when selection unavailable, alternatives cap, selected-candidate exclusion.

## Tests

```
pytest tests/test_deepresearch_veto.py -q
# 12 passed
```

Existing suite: no regressions from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)