### PR TITLE
docs: add demo GIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Scouts the arXiv frontier for your repo. On a schedule you choose, Outrider picks the next paper most implementable against your codebase and either opens a draft PR wiring it into an existing call site, or starts a discussion Issue when a PR would be premature.
 
+<p align="center">
+  <img src="https://github.com/remyxai/outrider/releases/download/readme-assets/outrider-v1.gif" alt="Outrider demo" width="800">
+</p>
+
 ```yaml
 - uses: remyxai/outrider@v1
   with:


### PR DESCRIPTION
Adds a demo GIF as a hero under the tagline.

The GIF (3.8MB) is hosted as a release asset on the `readme-assets` release (marked not-latest, media only) rather than committed, so it stays out of git history.

**Please check the rendered README preview below confirms the GIF animates inline** before merging.