### PR TITLE
Issue dedup: fix arxiv version mismatch and gate external picks

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -1147,19 +1147,40 @@ def open_remyx_issues(target: Target) -> list[dict]:
     return ours
 
 
+def _arxiv_versionless(s: str) -> str:
+    """Drop a trailing ``v<digits>`` from an arxiv id.
+
+    The engine pool and the broadening-search path don't agree on whether
+    to include the version suffix — engine candidates carry ``2605.26102v1``
+    while a `remyxai search query` result for the same paper comes back as
+    ``2605.26102``. issue_for_paper does a substring match on the issue
+    body, and substring matching is directional: ``2605.26102v1`` is NOT
+    a substring of ``2605.26102``, so a versioned candidate misses an open
+    Issue that was filed from the versionless side."""
+    return re.sub(r"v\d+$", "", s or "")
+
+
 def issue_for_paper(open_issues: list[dict], rec: Recommendation) -> dict | None:
     """Return an already-open Remyx Issue for this paper, if any.
 
     Matched on the arxiv_id in the issue body — every Remyx issue links
     ``arxiv.org/abs/<id>``, and that survives the OPEN_AS_ISSUE path where
     the title is Claude-authored rather than ``<prefix> <paper_title>``.
-    Falls back to an exact title match when the recommendation carries no
-    arxiv_id. Pure (no network) so the matching is unit-testable; the
-    fetch lives in open_remyx_issues."""
-    needle = f"arxiv.org/abs/{rec.arxiv_id}" if rec.arxiv_id else None
+    Tries both the as-given arxiv id and its versionless form, since the
+    engine pool and broadening-search disagree on the suffix. Falls back
+    to an exact title match when the recommendation carries no arxiv_id.
+    Pure (no network) so the matching is unit-testable; the fetch lives
+    in open_remyx_issues."""
+    needles: list[str] = []
+    if rec.arxiv_id:
+        needles.append(f"arxiv.org/abs/{rec.arxiv_id}")
+        stripped = _arxiv_versionless(rec.arxiv_id)
+        if stripped and stripped != rec.arxiv_id:
+            needles.append(f"arxiv.org/abs/{stripped}")
     title_match = f"{PR_TITLE_PREFIX} {rec.paper_title}"
     for it in open_issues:
-        if needle and needle in (it.get("body") or ""):
+        body = it.get("body") or ""
+        if any(n in body for n in needles):
             return it
         if not rec.arxiv_id and (it.get("title") or "") == title_match:
             return it

--- a/src/run.py
+++ b/src/run.py
@@ -2768,6 +2768,25 @@ def process_target(target: Target) -> dict:
                 result["selection_external_query_used"] = (
                     selection.get("external_query_used", "")
                 )
+                # Dedup gate for external picks. Engine-pool candidates are
+                # filtered against existing open Issues at the viability gate
+                # above, but a broadening-search pick is born inside the
+                # selection pass and never passes through that gate. Without
+                # this check the same paper gets re-recommended on every run
+                # (observed on VQASynth#86 + #88, both InstructSAM via
+                # broadening-search on consecutive days).
+                existing_issue = issue_for_paper(open_issues, rec)
+                if existing_issue is not None:
+                    result["status"] = "skipped_external_issue_exists"
+                    result["existing_issue_url"] = existing_issue.get(
+                        "html_url", ""
+                    )
+                    log.info(
+                        f"  ✗ skipped_external_issue_exists: external pick "
+                        f"{rec.arxiv_id} already has open Issue "
+                        f"{existing_issue.get('html_url', '')}"
+                    )
+                    return result
                 shape = (selection.get("integration_shape") or "simplification").lower().strip()
                 result["selection_integration_shape"] = shape
                 shape_label = {

--- a/tests/test_issue_dedup.py
+++ b/tests/test_issue_dedup.py
@@ -123,3 +123,59 @@ def test_versioned_candidate_no_match_for_unrelated_paper():
     ours = [{"title": "[Remyx Recommendation] OtherPaper",
              "body": "see arxiv.org/abs/2605.99999v1"}]
     assert run.issue_for_paper(ours, _rec("2605.26102v1", "InstructSAM")) is None
+
+
+# ─── external-pick dedup ───────────────────────────────────────────────────
+# The external (broadening-search) branch of run_one_target constructs a
+# synthetic Recommendation via _resolve_external_candidate and routes
+# straight to _open_downgrade_issue. The viability gate above filters
+# engine-pool candidates only; the external branch bypasses it. We now
+# call issue_for_paper(open_issues, rec) in that branch — these tests pin
+# the matching behaviour for the shape of Recommendation the external
+# branch produces.
+
+
+def _external_rec(arxiv, title, query="InstructSAM"):
+    """Mirrors the synthetic Recommendation _resolve_external_candidate builds
+    when the selection pass surfaces an out-of-pool candidate (chosen_index=-2).
+    Same dataclass; just constructed with the via-broadening-search defaults."""
+    return Recommendation(
+        paper_title=title, arxiv_id=arxiv, tier="high", z_score=0.0, spec_md="",
+        paper_abstract="", domain_summary="", raw_paper_md="",
+        relevance_score=0.0, reasoning=f"surfaced via remyxai search {query!r}",
+        suggested_experiment="", recommendation_id="",
+        interest_name="(via broadening-search)", interest_context="",
+        experiment_history="",
+    )
+
+
+def test_external_pick_matches_prior_external_issue():
+    """VQASynth#88's bug: an external pick at arxiv 2605.26102 was filed
+    two days after VQASynth#86 (also external) for the same paper. The
+    dedup helper sees the prior Issue's body and matches."""
+    ours = [{"title": "[Remyx Recommendation] InstructSAM",
+             "body": "External pick surfaced via remyxai search query"
+                     " 'InstructSAM' — arxiv.org/abs/2605.26102"}]
+    rec = _external_rec("2605.26102", "InstructSAM")
+    assert run.issue_for_paper(ours, rec) is not None
+
+
+def test_external_pick_matches_prior_engine_pool_issue():
+    """The other direction of the same bug: an external pick at
+    2605.26102 should match an existing engine-pool Issue body that
+    contains 2605.26102v1. (The version-stripped needle from Commit 1
+    handles this when the existing body has the version.)"""
+    ours = [{"title": "[Remyx Recommendation] InstructSAM: Segment Any Instance",
+             "body": "**Recommended paper**: arxiv.org/abs/2605.26102v1"}]
+    rec = _external_rec("2605.26102", "InstructSAM")
+    assert run.issue_for_paper(ours, rec) is not None
+
+
+def test_external_pick_no_match_for_distinct_paper():
+    """An external pick for paper A shouldn't be deduped against an
+    existing Issue for paper B even if both came from broadening-search."""
+    ours = [{"title": "[Remyx Recommendation] Other paper",
+             "body": "External pick surfaced via remyxai search query "
+                     "'other' — arxiv.org/abs/2605.99999v1"}]
+    rec = _external_rec("2605.26102", "InstructSAM")
+    assert run.issue_for_paper(ours, rec) is None

--- a/tests/test_issue_dedup.py
+++ b/tests/test_issue_dedup.py
@@ -20,9 +20,10 @@ from run import Recommendation  # noqa: E402
 def _rec(arxiv="2605.22536v1", title="SpaceDG"):
     return Recommendation(
         paper_title=title, arxiv_id=arxiv, tier="high", z_score=0.0, spec_md="",
-        paper_abstract="", team_context="", domain_summary="", raw_paper_md="",
+        paper_abstract="", domain_summary="", raw_paper_md="",
         relevance_score=0.9, reasoning="", suggested_experiment="",
         recommendation_id="", interest_name="VQASynth", interest_context="",
+        experiment_history="",
     )
 
 
@@ -80,3 +81,45 @@ def test_title_fallback_when_no_arxiv():
 
 def test_empty_open_issue_list_never_matches():
     assert run.issue_for_paper([], _rec()) is None
+
+
+# ─── arxiv version-string normalization ────────────────────────────────────
+
+def test_match_versioned_candidate_against_versionless_body():
+    """The bug that produced VQASynth #87: engine-pool candidate carries
+    ``2605.26102v1`` while the existing Issue body has ``2605.26102``
+    (filed via broadening-search). Substring match in the original
+    direction missed because ``…/abs/2605.26102v1`` is not in
+    ``…/abs/2605.26102``."""
+    ours = [{"title": "[Remyx Recommendation] InstructSAM",
+             "body": "see arxiv.org/abs/2605.26102 — surfaced via broadening-search"}]
+    assert run.issue_for_paper(ours, _rec("2605.26102v1", "InstructSAM")) is not None
+
+
+def test_match_versionless_candidate_against_versioned_body():
+    """Reverse direction: broadening-search candidate ``2605.26102``
+    against an open Issue body containing ``2605.26102v1``. Substring
+    match was already working in this direction (prefix match); locking
+    it down with an explicit test."""
+    ours = [{"title": "[Remyx Recommendation] InstructSAM",
+             "body": "see arxiv.org/abs/2605.26102v1"}]
+    assert run.issue_for_paper(ours, _rec("2605.26102", "InstructSAM")) is not None
+
+
+def test_arxiv_versionless_helper_strips_only_trailing_version():
+    """Pure helper. Only trailing ``v<digits>`` is dropped — embedded
+    sequences that happen to look like a version aren't touched."""
+    assert run._arxiv_versionless("2605.26102v1") == "2605.26102"
+    assert run._arxiv_versionless("2605.26102v17") == "2605.26102"
+    assert run._arxiv_versionless("2605.26102") == "2605.26102"
+    assert run._arxiv_versionless("") == ""
+    assert run._arxiv_versionless("v1abc") == "v1abc"  # not a trailing suffix
+
+
+def test_versioned_candidate_no_match_for_unrelated_paper():
+    """The fix shouldn't widen matches across distinct papers — a
+    versioned candidate for paper A shouldn't match an Issue for paper B
+    even if both share a common arxiv prefix accidentally."""
+    ours = [{"title": "[Remyx Recommendation] OtherPaper",
+             "body": "see arxiv.org/abs/2605.99999v1"}]
+    assert run.issue_for_paper(ours, _rec("2605.26102v1", "InstructSAM")) is None


### PR DESCRIPTION
## Summary

Two narrow fixes to the open-Issue dedup gate. Both reproduce on VQASynth: the InstructSAM paper got three distinct Issues filed across three days (#86, #87, #88).

- **Commit 1** — `issue_for_paper` did a substring match on `arxiv.org/abs/<id>` in the body. Substring matching is directional: a versioned candidate (`2605.26102v1`) was not a substring of a versionless body (`2605.26102`), so the gate missed. Try both forms now.
- **Commit 2** — engine-pool candidates pass through the viability gate that calls `issue_for_paper`; the external (broadening-search, `chosen_index=-2`) branch did not. Add the same check inside that branch with a new `skipped_external_issue_exists` status.

Together these explain the InstructSAM × 3 pattern: external pick on day 1 (#86, no gate), engine-pool on day 2 (#87, version mismatch missed #86), external pick on day 3 (#88, no gate).

## Test plan

- [x] `pytest tests/test_issue_dedup.py` — 13 passing (was 5 broken on main from a stale `_rec` fixture; restored)
- [x] `pytest tests/test_issue_dedup.py tests/test_integration_gates.py tests/test_path_matching.py` — 42 passing
- [ ] Watch the next VQASynth Outrider run — should report `status=skipped_external_issue_exists` rather than re-filing InstructSAM

## Not in scope

- Concurrent same-day duplicates (the pre-dedup SpaceDG#71/#72 shape) — needs atomic create-or-skip
- `tests/test_selection.py` failures on main — separate cleanup for the `experiment_history` field rename