### PR TITLE
v1.5.1: extension floor 0.85 + missing-link recovery + self-dogfooding workflow

### DIFF
--- a/.github/workflows/outrider.yml
+++ b/.github/workflows/outrider.yml
@@ -1,0 +1,26 @@
+name: Outrider
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: outrider
+  cancel-in-progress: false
+
+jobs:
+  recommend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    env:
+      REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          interest-id: '054bb25c-ff68-4d10-bd65-762df0aca8e8'

--- a/src/run.py
+++ b/src/run.py
@@ -666,6 +666,46 @@ Tools available:
     bypasses keyword-search retrieval gaps
   - `remyxai search query` — keyword broaden beyond the pool if needed
 
+Recovery strategies for missing/broken links (apply BEFORE concluding
+"paper has no code" or "candidate is unreadable"):
+  - **Arxiv URL variants.** If `arxiv.org/html/<id>` 404s or returns a
+    near-empty page, try `arxiv.org/abs/<id>` first (most reliable),
+    then `ar5iv.labs.arxiv.org/<id>` (HTML5 mirror — better for very
+    recent papers), then `arxiv.org/pdf/<id>` as last resort.
+  - **Dead live URLs (project pages, github repos).** Academic project
+    pages routinely die within months. If `WebFetch <url>` 404s or
+    times out, try `web.archive.org/web/<url>` for the latest archived
+    snapshot. Especially relevant for `*.github.io/*` project pages
+    and university-hosted demo sites.
+  - **Engine reports `github_url: (none)` but code likely exists.**
+    Don't take the engine's null at face value. In order:
+      1. `gh search code "<distinctive method name from paper>"` — the
+         method name (not the paper title) usually surfaces the official
+         repo if one exists.
+      2. WebFetch the arxiv abstract page and grep for `github.com/`
+         links — abstracts often mention code that the engine's
+         regex missed.
+      3. If `huggingface_url` is populated, WebFetch the model card —
+         it routinely cross-references the official codebase.
+      4. If a project page is mentioned in the abstract, follow it
+         one hop — code links cluster on project pages even when
+         absent from the abstract.
+    Treat "no code found" as a verdict you reach AFTER exhausting these,
+    not a default. Many engine `github_url: (none)` cases have code
+    reachable via one of these paths (REMYX-100 will fix this at ingest;
+    until then, agent-side recovery is the defense).
+  - **Login-wall detection.** Pages from Colab, Drive, JSTOR, OpenReview
+    can return HTTP 200 with sign-in content that LOOKS like real
+    content. If a fetched page is < 500 chars of non-nav body AND
+    contains "Sign in" / "Log in" / "Please log in", treat as
+    unfetched (the content you got is not the content you wanted).
+    Note in `reasoning` if a login-wall blocked verification.
+  - **Failure budget.** Spend at most ~3 turns on recovery per
+    candidate before moving on. If a candidate has multiple broken
+    links and no reachable code/context, that itself is a signal —
+    document the failed lookups in `reasoning` and reject the
+    candidate rather than burning the turn budget guessing.
+
 Stop iterating once you have enough evidence to pick (verified one
 candidate fits one of the three shapes) OR to reject all (every
 candidate has a structural mismatch). Don't burn turns on diminishing

--- a/src/run.py
+++ b/src/run.py
@@ -570,8 +570,11 @@ a structural mismatch and should be rejected.
          contribution. If a partial implementation exists, this is
          addition or replacement, not extension.
       4. **Higher relevance + interest-alignment bar than addition** —
-         tier MUST be `high` AND relevance MUST be ≥ 0.90 AND the
+         tier MUST be `high` AND relevance MUST be ≥ 0.85 AND the
          `reasoning` field MUST verbalize the interest-alignment.
+         Gates 1-3 carry the structural-fit load — gate 4 is a
+         "ranker put this candidate in the top band" sanity check,
+         not a second pass on relevance.
     Verification: cite the specific team-direction signal that satisfies
     gate 2 in the `team_direction_signal` schema field below. Cite the
     adjacent pipeline stage (upstream or downstream of the proposed new
@@ -3172,18 +3175,24 @@ def select_recommendation(
             )
             data["chosen_index"] = -1
             return data
-        # Extension floor: tier=high AND relevance >= 0.90 (gate 4 of the
-        # four-gate verification). Only validate when chosen_index >= 0;
-        # external extension picks (-2) don't have a pool candidate to
-        # check against.
+        # Extension floor: tier=high AND relevance >= 0.85 (gate 4 of the
+        # four-gate verification). The 0.85 threshold (down from the
+        # original 0.90) admits high-tier candidates that fall just under
+        # the old hard 0.90 cut — the 0.85-0.90 boundary band where
+        # several legitimate extension picks were being rejected on
+        # relevance alone. Gates 1-3 carry the structural-fit load; this
+        # gate is a "ranker put this candidate in the top band" sanity
+        # check, not a second pass on relevance. Only validate when
+        # chosen_index >= 0; external extension picks (-2) don't have a
+        # pool candidate to check against.
         if idx >= 0 and 0 <= idx < len(candidates):
             cand = candidates[idx]
-            if cand.tier.lower() != "high" or cand.relevance_score < 0.90:
+            if cand.tier.lower() != "high" or cand.relevance_score < 0.85:
                 log.warning(
                     f"  selection: extension pick [{idx}] "
                     f"{cand.paper_title[:50]}… fails extension floor "
                     f"(tier={cand.tier!r}, relevance={cand.relevance_score:.2f}); "
-                    f"extension requires tier=high AND relevance>=0.90; "
+                    f"extension requires tier=high AND relevance>=0.85; "
                     f"falling back to skip-by-verification"
                 )
                 data["chosen_index"] = -1

--- a/tests/test_extension_shape.py
+++ b/tests/test_extension_shape.py
@@ -9,8 +9,10 @@
     extension (extension is last-resort)
   - `select_recommendation` rejects extension picks missing the
     required fields (treats as malformed → falls back to skip)
-  - Extension floor: tier=high AND relevance >= 0.90 required for
+  - Extension floor: tier=high AND relevance >= 0.85 required for
     in-pool extension picks; below-floor picks are rejected
+    (recalibrated from 0.90 in v1.5.1 to admit candidates in the
+    0.85-0.90 boundary band that the old hard cut was over-rejecting)
   - Extension picks thread through `selection_team_direction_signal`
     and `selection_proposed_call_site` in the result dict (for
     downgrade Issue body + step summary consumption)
@@ -151,13 +153,13 @@ def test_extension_pick_missing_proposed_call_site_rejected(
 
 
 def test_extension_pick_below_relevance_floor_rejected(monkeypatch, tmp_path):
-    """Gate 4: tier=high AND relevance >= 0.90. A pick at relevance 0.85
+    """Gate 4: tier=high AND relevance >= 0.85. A pick at relevance 0.60
     fails gate 4 and must be rejected even if the other fields are
     present."""
     result = _run_selection(
         monkeypatch, tmp_path,
         candidates=[
-            _rec("2605.26004", "Paper Alpha", relevance=0.85),
+            _rec("2605.26004", "Paper Alpha", relevance=0.60),
             _rec("9999.99999", "Filler"),
         ],
         claude_response={
@@ -166,6 +168,65 @@ def test_extension_pick_below_relevance_floor_rejected(monkeypatch, tmp_path):
             "team_direction_signal": "Issue #95 names this paper",
             "proposed_call_site": "after stage_a, before publish",
             "reasoning": "below-floor relevance — must reject",
+        },
+    )
+    assert result["chosen_index"] == -1
+
+
+def test_extension_pick_at_0p85_floor_passes(monkeypatch, tmp_path):
+    """Recalibrated v1.5.1 boundary: relevance exactly at 0.85 passes
+    gate 4 (the comparison is `< 0.85`, not `<=`). A pick at 0.87 — the
+    target boundary-band score regime the recalibration was designed to
+    admit — must also pass."""
+    result = _run_selection(
+        monkeypatch, tmp_path,
+        candidates=[
+            _rec("2605.26004", "Paper Alpha", tier="high", relevance=0.85),
+            _rec("9999.99999", "Filler"),
+        ],
+        claude_response={
+            "chosen_index": 0,
+            "integration_shape": "extension",
+            "team_direction_signal": "Issue #95 names this paper",
+            "proposed_call_site": "after stage_a, before publish",
+            "reasoning": "at-floor boundary-band pick — must pass",
+        },
+    )
+    assert result["chosen_index"] == 0
+
+    result = _run_selection(
+        monkeypatch, tmp_path,
+        candidates=[
+            _rec("2605.26004", "Paper Beta", tier="high", relevance=0.87),
+            _rec("9999.99999", "Filler"),
+        ],
+        claude_response={
+            "chosen_index": 0,
+            "integration_shape": "extension",
+            "team_direction_signal": "Issue #95 names this paper",
+            "proposed_call_site": "after stage_a, before publish",
+            "reasoning": "common boundary-band score — must pass",
+        },
+    )
+    assert result["chosen_index"] == 0
+
+
+def test_extension_pick_below_0p85_floor_rejected(monkeypatch, tmp_path):
+    """Recalibrated v1.5.1 boundary: 0.84 must fail (one tick below the
+    new floor). Pinning this boundary protects against accidental
+    recalibration drift."""
+    result = _run_selection(
+        monkeypatch, tmp_path,
+        candidates=[
+            _rec("2605.26004", "Paper Alpha", relevance=0.84),
+            _rec("9999.99999", "Filler"),
+        ],
+        claude_response={
+            "chosen_index": 0,
+            "integration_shape": "extension",
+            "team_direction_signal": "Issue #95 names this paper",
+            "proposed_call_site": "after stage_a, before publish",
+            "reasoning": "just-below-floor — must reject",
         },
     )
     assert result["chosen_index"] == -1

--- a/tests/test_link_robustness.py
+++ b/tests/test_link_robustness.py
@@ -1,0 +1,147 @@
+"""Tests for v1.5.1 missing-link recovery strategies in the selection
+prompt (REMYX-104).
+
+These tests lock in the *presence* of the recovery-strategy guidance —
+the selection-pass agent (Claude Code) reads the prompt and applies the
+strategies with its own tool kit (WebFetch + Bash + gh). The strategies
+themselves are documented in the prompt; this test file ensures the
+guidance doesn't get accidentally deleted or watered down in future
+edits.
+
+A follow-up release will add CLI helpers (`arxiv-fetch`,
+`web-fetch-resilient`) and instrument `failed_lookups` in the result
+dict per the full REMYX-104 ticket; tests for those land then.
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+def _unwrap(s: str) -> str:
+    return " ".join(s.split())
+
+
+# ─── Recovery-strategy block is present and labeled ───────────────────────
+
+
+def test_prompt_has_recovery_strategies_section():
+    """A dedicated section labels the recovery strategies — without
+    the section header the LLM may not connect "failed lookup" to
+    "try alternative URLs". The header is the load-bearing pointer."""
+    prompt = _unwrap(run._SELECTION_PROMPT_TEMPLATE)
+    assert "Recovery strategies for missing/broken links" in prompt
+
+
+# ─── Arxiv URL variant fallbacks ──────────────────────────────────────────
+
+
+def test_prompt_documents_arxiv_variant_chain():
+    """The four arxiv URL variants the agent should try when one 404s.
+    All four must be named so the agent knows the full fallback chain.
+    Order matters — abs is most reliable, ar5iv is the recent-paper
+    fallback, pdf is last-resort."""
+    prompt = _unwrap(run._SELECTION_PROMPT_TEMPLATE)
+    assert "Arxiv URL variants" in prompt
+    assert "arxiv.org/abs/" in prompt
+    assert "arxiv.org/html/" in prompt
+    assert "ar5iv.labs.arxiv.org/" in prompt
+    assert "arxiv.org/pdf/" in prompt
+
+
+# ─── Dead live URL → archive.org fallback ─────────────────────────────────
+
+
+def test_prompt_documents_archive_org_fallback():
+    """For non-arxiv URLs (project pages, github repos), agent should
+    fall back to web.archive.org when the live URL 404s. This is the
+    single most-impactful recovery pattern — project pages routinely
+    rot within months of paper publication."""
+    prompt = _unwrap(run._SELECTION_PROMPT_TEMPLATE)
+    assert "web.archive.org/web/" in prompt
+    # Calling out the regime where this matters (academic project pages)
+    assert "project page" in prompt
+
+
+# ─── Engine reports github_url: (none) recovery chain ─────────────────────
+
+
+def test_prompt_documents_missing_github_url_recovery_chain():
+    """The most common engine-side gap: paper has code but the engine's
+    regex didn't catch it. The prompt must direct the agent NOT to take
+    null at face value, and document the four-step recovery chain.
+
+    This is the load-bearing protection against rejecting viable
+    candidates that the engine mis-labeled as code-less — the failure
+    mode that surfaced REMYX-104 in the first place."""
+    prompt = _unwrap(run._SELECTION_PROMPT_TEMPLATE)
+    assert "Engine reports `github_url: (none)`" in prompt
+    # Tells the agent explicitly not to trust the null
+    assert "Don't take the engine's null at face value" in prompt
+    # Four-step chain — at least the four anchors must be present
+    assert 'gh search code' in prompt
+    assert "abstract page and grep for `github.com/`" in prompt
+    assert "model card" in prompt  # huggingface_url → model card check
+    assert "project page" in prompt  # one-hop project-page follow
+
+
+def test_prompt_documents_no_code_as_post_recovery_verdict():
+    """`github_url: (none)` should be a verdict the agent reaches AFTER
+    exhausting recovery, not a default. The prompt must make that
+    sequencing explicit so the agent doesn't shortcut to "no code
+    available → reject" without trying recovery first."""
+    prompt = _unwrap(run._SELECTION_PROMPT_TEMPLATE)
+    assert 'Treat "no code found" as a verdict you reach AFTER exhausting' in prompt
+
+
+# ─── Login-wall detection ─────────────────────────────────────────────────
+
+
+def test_prompt_documents_login_wall_detection():
+    """Colab/Drive/OpenReview return HTTP 200 with sign-in pages that
+    LOOK like content. Without explicit detection guidance, the agent
+    may treat the sign-in page as the actual paper/repo content and
+    draw wrong conclusions."""
+    prompt = _unwrap(run._SELECTION_PROMPT_TEMPLATE)
+    assert "Login-wall detection" in prompt
+    # The detection heuristic — short body + sign-in phrases
+    assert "< 500 chars of non-nav body" in prompt
+    assert "Sign in" in prompt  # at least one of the trigger phrases
+
+
+# ─── Failure budget — don't burn turns on dead-end candidates ─────────────
+
+
+def test_prompt_documents_recovery_failure_budget():
+    """The recovery patterns are unbounded in principle — the agent
+    could spend all 25 turns chasing broken links. The prompt must cap
+    recovery effort per candidate and tell the agent that "many broken
+    links + no reachable context" is itself a rejection signal."""
+    prompt = _unwrap(run._SELECTION_PROMPT_TEMPLATE)
+    assert "Failure budget" in prompt
+    assert "at most ~3 turns on recovery per candidate" in prompt
+    # The "broken links are themselves a signal" framing — protects
+    # against the agent treating recovery as endless
+    assert "that itself is a signal" in prompt
+
+
+# ─── Recovery section placement — before "Stop iterating" guidance ────────
+
+
+def test_recovery_strategies_placed_before_stop_iterating_clause():
+    """Ordering matters: the agent reads top-to-bottom; recovery
+    strategies must appear BEFORE the "stop iterating" guidance, or
+    the agent may stop iterating prematurely on a broken-link candidate
+    before applying recovery."""
+    prompt = run._SELECTION_PROMPT_TEMPLATE
+    recovery_idx = prompt.find("Recovery strategies for missing/broken links")
+    stop_idx = prompt.find("Stop iterating once you have enough evidence")
+    assert recovery_idx > 0 and stop_idx > 0
+    assert recovery_idx < stop_idx, (
+        "Recovery-strategies section must precede the stop-iterating "
+        "clause so the agent applies recovery before deciding to stop."
+    )


### PR DESCRIPTION
## Summary

- **Extension floor 0.90 → 0.85.** Admits high-tier candidates in the 0.85-0.90 boundary band that the old hard cut was over-rejecting on relevance alone. Gates 1-3 carry the structural-fit load; gate 4 is a top-band sanity check.
- **Recovery strategies for missing/broken links in the selection prompt.** Adds explicit guidance: arxiv URL variant chain, web.archive.org fallback, four-step recovery when engine reports `github_url: (none)`, login-wall detection, and a ~3-turn-per-candidate failure budget. "No code found" becomes a verdict reached after recovery, not a default.
- **Self-dogfooding workflow.** Outrider runs against itself weekly via `uses: ./` so HEAD changes get dogfooded immediately.

## Test plan

- [x] `pytest tests/ -q` — 259 tests pass (was 249; +8 link-robustness, +2 floor-boundary)
- [ ] After merge: confirm REMYX_API_KEY + ANTHROPIC_API_KEY repo secrets are set
- [ ] After merge: tag v1.5.1 on main
- [ ] First scheduled run (next Monday 14:00 UTC) — verify run lands a PR or Issue against this repo's pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)