### PR TITLE
Workflow: mint remyx[bot] token so artifacts are authored by the Remyx App

### DIFF
--- a/.github/workflows/outrider.yml
+++ b/.github/workflows/outrider.yml
@@ -21,6 +21,20 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
+      # Mint a remyx[bot] token from Remyx so the PR / Issue is authored by
+      # the Remyx GitHub App (not github-actions[bot]). The App private key
+      # stays on Remyx's side; this uses the REMYX_API_KEY already in secrets.
+      # If it can't be minted (e.g. App not installed), the token is empty and
+      # the action falls back to the workflow's built-in GITHUB_TOKEN.
+      - name: Mint Remyx bot token
+        id: remyx-bot
+        shell: bash
+        run: |
+          token="$(curl -sf -X POST             -H "Authorization: Bearer ${{ secrets.REMYX_API_KEY }}"             -H "Content-Type: application/json"             -d "{\"repo\": \"${{ github.repository }}\"}"             "https://engine.remyx.ai/api/v1.0/github/installation-token"             | python3 -c "import sys, json; print(json.load(sys.stdin).get('token', ''))")" || token=""
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
       - uses: ./
         with:
           interest-id: '054bb25c-ff68-4d10-bd65-762df0aca8e8'
+          # remyx[bot] token (empty → action falls back to GITHUB_TOKEN).
+          github-token: ${{ steps.remyx-bot.outputs.token }}


### PR DESCRIPTION
## What

Adds the canonical **Mint Remyx bot token** step to the self-dogfooding workflow and passes the result as the action's `github-token` input. 

## Why

The workflow was set up manually without the mint step, so every PR/Issue Outrider opened here was authored by `github-actions[bot]` instead of `remyx-ai[bot]`.

Server-side prerequisites are already in place (verified today):
- Remyx GitHub App is installed on `remyxai/outrider`
- `POST /api/v1.0/github/installation-token` returns 200 for this repo (provisioned-action record now exists)

## Behavior

- Token mints → action runs as `remyx-ai[bot]`
- Mint fails for any reason → token is empty → action falls back to the workflow's built-in `GITHUB_TOKEN`, exactly as today

## Verify after merge

Trigger *Actions → Outrider → Run workflow* and confirm the resulting PR/Issue author is `remyx-ai[bot]`. (Requires the repo's `REMYX_API_KEY` secret to be a key with `github:write` owned by the user who owns interest `054bb25c…` — ping if the next artifact still shows `github-actions[bot]` and we'll rotate the secret.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)