### PR TITLE
Step-summary telemetry + opt-in weekly Discussion digest mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,9 +250,12 @@ no PR or Issue.
 
 Setup:
 
-1. **Create (or pick) a Discussion** on your repo to host the digests, and
+1. **Enable Discussions** on your repo if it isn't already on:
+   *Settings → General → Features → ☑ Discussions*. (Repos — forks
+   especially — have Discussions off by default.)
+2. **Create (or pick) a Discussion** on your repo to host the digests, and
    note its number from the URL.
-2. **Add a second scheduled job** (weekly cron) that calls the action in
+3. **Add a second scheduled job** (weekly cron) that calls the action in
    `weekly-summary` mode. Note the extra `discussions: write` permission:
 
    ```yaml
@@ -279,6 +282,11 @@ Setup:
              mode: weekly-summary
              weekly-discussion-id: '123'  # your Discussion number
    ```
+
+The digest posts as `remyx-ai[bot]` when the Remyx GitHub App is installed
+on the repo with Discussions access (if a permission prompt is pending,
+accept it under *Settings → GitHub Apps → remyx-ai*); otherwise it falls
+back to the workflow's `GITHUB_TOKEN` and posts as `github-actions[bot]`.
 
 Cost: one Claude call per week (~$0.10–0.20) to draft the interpretive
 sections; the rest is GitHub API reads. If that call fails, the digest still

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Sett
 | `candidate-pool` | `25` | How many candidates the selection pass picks from |
 | `claude-timeout` | `900` | Wall-clock seconds for the Claude Code implementation step. Bump for very large repos; lower to cap cost. |
 | `pin-arxiv` | `''` | Optional `arxiv_id`. When set and present in the candidate pool, the action implements that exact paper and skips the selection pass — use it for reproducible eval re-runs. Empty = normal selection. |
+| `mode` | `recommend` | `recommend` (classic per-run flow) / `weekly-summary` (post a weekly digest to a Discussion — see [Weekly Discussion summary](#weekly-discussion-summary-opt-in)) |
+| `weekly-discussion-id` | `''` | Discussion number (from its URL) or GraphQL node ID. Only read in `weekly-summary` mode. |
 
 ## Outputs
 
@@ -103,6 +105,7 @@ Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Sett
 | `tier` | when a paper was picked | `high` / `moderate` / `low` / `noise` |
 | `cost_usd` | always | Claude spend for this run |
 | `input_tokens` / `output_tokens` | always | Token usage |
+| `discussion_comment_url` | `weekly_summary_posted` | URL of the posted weekly digest comment |
 
 ## Costs
 
@@ -136,6 +139,9 @@ At weekly cadence (default `rate-limit-days: 7`), expect ~$2–4/mo Claude.
 | `claude_failed` | Claude CLI exited non-zero |
 | `rejected_path_violations` | Claude touched files outside the guardrails allowlist |
 | `error` | Unhandled exception |
+| `weekly_summary_posted` | Weekly digest comment posted to the configured Discussion |
+| `weekly_summary_skipped_no_discussion_id` | `mode: weekly-summary` ran without a `weekly-discussion-id` |
+| `weekly_summary_failed` | Weekly mode hit an unhandled error (nothing was posted) |
 
 </details>
 
@@ -231,6 +237,54 @@ Pre-flight Claude pass: PR or Issue?
 The Remyx engine (commit-history extraction, candidate pool, embedding pre-filter, ranking) runs server-side. This action is a pure consumer.
 
 </details>
+
+## Weekly Discussion summary (opt-in)
+
+A rolling weekly digest of Outrider's work on your repo, posted as a comment
+on a Discussion you designate: run outcomes, the selection pass's verdicts
+(with its rejection reasoning quoted verbatim), refine-query themes, the
+license gate's class distribution, open Outrider Issues with a next-action
+column, and a short "patterns worth attention" section. Makes the action's
+work auditable at a glance — including the runs that deliberately produced
+no PR or Issue.
+
+Setup:
+
+1. **Create (or pick) a Discussion** on your repo to host the digests, and
+   note its number from the URL.
+2. **Add a second scheduled job** (weekly cron) that calls the action in
+   `weekly-summary` mode. Note the extra `discussions: write` permission:
+
+   ```yaml
+   name: Outrider weekly summary
+   on:
+     schedule:
+       - cron: '0 15 * * 1'  # Mondays 15:00 UTC
+     workflow_dispatch:
+   jobs:
+     weekly-summary:
+       runs-on: ubuntu-latest
+       permissions:
+         contents: read
+         actions: read        # read the week's run logs
+         issues: read         # list open Outrider Issues
+         discussions: write   # post the digest comment
+       env:
+         REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
+         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+       steps:
+         - uses: remyxai/outrider@v1
+           with:
+             interest-id: 'YOUR-INTEREST-UUID-HERE'
+             mode: weekly-summary
+             weekly-discussion-id: '123'  # your Discussion number
+   ```
+
+Cost: one Claude call per week (~$0.10–0.20) to draft the interpretive
+sections; the rest is GitHub API reads. If that call fails, the digest still
+posts with the data tables only. Runs whose logs have aged out of GitHub's
+retention window are listed as "details unavailable" rather than silently
+dropped.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -34,11 +34,13 @@ inputs:
     description: >-
       GitHub token used for git push, PR / Issue creation, and the
       existing-PR dedup check. Leave empty for the standard same-repo
-      install — the action falls back to the workflow's built-in
-      github.token, which has write access to the repo the workflow
-      runs in. Override with a PAT only for cross-repo controller
-      patterns (action runs in repo A but writes PRs to repo B);
-      the PAT needs `repo` scope on the target.
+      install — the action self-mints a remyx[bot] token from
+      engine.remyx.ai (using REMYX_API_KEY) so artifacts are authored
+      by the Remyx App by default, and falls back to the workflow's
+      built-in github.token when minting isn't available. Override
+      with a PAT only for cross-repo controller patterns (action runs
+      in repo A but writes PRs to repo B); the PAT needs `repo` scope
+      on the target.
     required: false
     default: ''
   min-confidence:

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,26 @@ inputs:
       Remyx ResearchInterest UUID. Get it from engine.remyx.ai → your
       interest's detail page → "Workflow snippet" tab.
     required: true
+  mode:
+    description: |
+      Run mode:
+        - "recommend" (default): scout a paper, draft a PR or open an
+          Issue — the classic per-run flow.
+        - "weekly-summary": aggregate the past 7 days of Outrider runs
+          on this repo and post a digest comment to the Discussion named
+          by `weekly-discussion-id`. Opt-in; customers add a second
+          scheduled job (weekly cron) that calls the action in this
+          mode. Requires `discussions: write` in the workflow's
+          permissions block.
+    required: false
+    default: 'recommend'
+  weekly-discussion-id:
+    description: |
+      Target Discussion for weekly-summary mode. Accepts the Discussion
+      number (from its URL) or the GraphQL node ID. Only read when
+      `mode: weekly-summary`; the mode skips cleanly when empty.
+    required: false
+    default: ''
   github-token:
     description: >-
       GitHub token used for git push, PR / Issue creation, and the
@@ -114,8 +134,15 @@ outputs:
       Run outcome: "pr_opened" | "pr_opened_draft" | "issue_opened" |
       "skipped_low_confidence" | "skipped_rate_limit" | "skipped_pr_exists" |
       "skipped_issue_exists" | "skipped_test_failure" | "claude_failed" |
-      "rejected_path_violations" | "error".
+      "rejected_path_violations" | "error". In weekly-summary mode:
+      "weekly_summary_posted" | "weekly_summary_skipped_no_discussion_id" |
+      "weekly_summary_failed".
     value: ${{ steps.recommend.outputs.status }}
+  discussion_comment_url:
+    description: |
+      URL of the posted weekly-summary Discussion comment (set when
+      status == "weekly_summary_posted").
+    value: ${{ steps.recommend.outputs.discussion_comment_url }}
   pr_url:
     description: 'URL of the opened PR (set when status starts with "pr_opened").'
     value: ${{ steps.recommend.outputs.pr_url }}
@@ -189,6 +216,9 @@ runs:
         INPUT_TEST_INTEGRATION_POLICY: ${{ inputs.test-integration-policy }}
         INPUT_CLAUDE_TIMEOUT: ${{ inputs.claude-timeout }}
         INPUT_PIN_ARXIV: ${{ inputs.pin-arxiv }}
+        # Weekly Discussion summary (opt-in second scheduled job).
+        REMYX_MODE: ${{ inputs.mode }}
+        REMYX_WEEKLY_DISCUSSION_ID: ${{ inputs.weekly-discussion-id }}
         # Lookback window + pool size for the candidate selection pass.
         # run.py reads these directly (not via INPUT_*) — they default to
         # week / 10 in run.py too, so omitting them is safe.

--- a/src/run.py
+++ b/src/run.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import ast
 import base64
 import datetime as dt
+import io
 import json
 import logging
 import os
@@ -58,6 +59,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -836,8 +838,9 @@ TEST_INTEGRATION_POLICIES = ("strict", "soft", "off")
 # Terminal statuses that should make the workflow step exit non-zero (red
 # in CI). Everything else — Issues, skips, PRs — is a legitimate green
 # outcome. `claude_failed` used to exit 0, so a run that produced no PR/Issue
-# looked green; it now fails visibly.
-FAILURE_EXIT_STATUSES = {"error", "claude_failed"}
+# looked green; it now fails visibly. `weekly_summary_failed` is the
+# weekly-summary mode's analog: a run that posted nothing should be red.
+FAILURE_EXIT_STATUSES = {"error", "claude_failed", "weekly_summary_failed"}
 
 
 @dataclass
@@ -961,6 +964,13 @@ class Recommendation:
                                       # releases), the representative carries
                                       # a human-readable summary of the
                                       # siblings. Empty for solo candidates.
+    refine_query: str = ""            # Non-empty when this candidate reached
+                                      # the pool via a deep-search refine
+                                      # query (audit pass) rather than the
+                                      # broad /papers/recommended ranking.
+                                      # Carries the query text for provenance;
+                                      # "" = broad pool. Drives the pool-
+                                      # composition telemetry.
 
 
 # ─── Helpers ───────────────────────────────────────────────────────────────
@@ -1013,6 +1023,49 @@ def gh_api(method: str, path: str, body: dict | None = None) -> Any:
     except urllib.error.HTTPError as e:
         body_text = e.read().decode("utf-8", errors="replace")[:500]
         raise RuntimeError(f"GitHub {method} {path} → HTTP {e.code}: {body_text}") from e
+
+
+def gh_graphql(query: str, variables: dict | None = None) -> dict:
+    """Minimal GitHub GraphQL wrapper — sibling of ``gh_api``.
+
+    The Discussions API is GraphQL-only (no REST endpoint exists for
+    posting Discussion comments), so the weekly-summary mode needs this
+    alongside the REST helper. Same token resolution and error shape as
+    ``gh_api``: raises RuntimeError on transport errors AND on
+    GraphQL-level errors (GraphQL returns HTTP 200 with an ``errors``
+    array; surfacing those as exceptions keeps the two helpers
+    behaviorally identical for callers). Returns the ``data`` object.
+    """
+    token = _github_token()
+    if not token:
+        raise RuntimeError(
+            "Neither INPUT_GITHUB_TOKEN nor GITHUB_TOKEN is set. The "
+            "action.yml should pass ${{ github.token }} as GITHUB_TOKEN "
+            "by default; if you're invoking the script outside an Action, "
+            "export GITHUB_TOKEN manually."
+        )
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        "https://api.github.com/graphql", data=payload, method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "feature-finder-orchestrator",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            raw = r.read()
+            resp = json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode("utf-8", errors="replace")[:500]
+        raise RuntimeError(f"GitHub GraphQL → HTTP {e.code}: {body_text}") from e
+    if resp.get("errors"):
+        raise RuntimeError(
+            f"GitHub GraphQL errors: {json.dumps(resp['errors'])[:500]}"
+        )
+    return resp.get("data") or {}
 
 
 def slugify(s: str, max_len: int = 60) -> str:
@@ -1725,6 +1778,7 @@ def _asset_to_recommendation(
         experiment_history=experiment_history,
         paper_github_url=paper_github_url,
         paper_huggingface_url=paper_huggingface_url,
+        refine_query=refine_query,
     )
 
 
@@ -1961,6 +2015,7 @@ def audit_and_refine_pool(
              f"{(data.get('reasoning') or '')[:160]}")
     if not queries:
         return broad_candidates
+    _RUN_REFINE_QUERIES.extend(queries)
     # Pre-collect existing arxiv ids (with version-stripped variants) so
     # refine results that duplicate the broad pool are skipped silently.
     seen: set[str] = set()
@@ -2107,6 +2162,49 @@ def query_remyx_candidates(target: Target) -> list[Recommendation]:
                  f"({c.license_class}, compat={c.license_compat:.2f})"
                  f"{source_hint}{url_hint}")
     return candidates
+
+
+# Canonical rendering order for license-class distributions. Any class
+# outside this list (future additions) is appended after, so the line
+# never silently drops a bucket.
+_LICENSE_CLASS_ORDER = (
+    "permissive", "copyleft", "nc", "no-code-link", "unknown", "missing",
+)
+
+
+def _pool_composition(candidates: list[Recommendation]) -> tuple[int, int]:
+    """(broad, refine) candidate counts, post family-dedup.
+
+    Counted from the per-candidate ``refine_query`` provenance marker so
+    the numbers reflect the pool the selection pass actually saw —
+    ``_coalesce_candidate_families`` may have collapsed siblings from
+    either source.
+    """
+    refine = sum(1 for c in candidates if c.refine_query)
+    return len(candidates) - refine, refine
+
+
+def _license_class_counts(candidates: list[Recommendation]) -> dict[str, int]:
+    """Per-class license distribution across the candidate pool."""
+    counts: dict[str, int] = {}
+    for c in candidates:
+        cls = c.license_class or "unknown"
+        counts[cls] = counts.get(cls, 0) + 1
+    return counts
+
+
+def _format_license_class_counts(counts: dict) -> str:
+    """Single-line distribution: ``permissive: 4 · nc: 1 · missing: 30``.
+
+    Canonical class order first, unexpected classes appended;
+    zero-count classes omitted (the dict only carries observed ones).
+    """
+    parts = [f"{k}: {counts[k]}" for k in _LICENSE_CLASS_ORDER if counts.get(k)]
+    parts += [
+        f"{k}: {v}" for k, v in counts.items()
+        if k not in _LICENSE_CLASS_ORDER and v
+    ]
+    return " · ".join(parts) if parts else "(no candidates)"
 
 
 def _coalesce_candidate_families(
@@ -2660,12 +2758,19 @@ _RUN_COST = {
     "claude_calls": 0,
 }
 
+# Refine queries the audit pass actually executed this run, including ones
+# that returned zero new candidates (those are signal too — "explored, no
+# hits"). Run-scoped like _RUN_COST; surfaced on the result dict so the
+# weekly summary can aggregate themes across runs.
+_RUN_REFINE_QUERIES: list[str] = []
+
 
 def _reset_run_cost() -> None:
     _RUN_COST.update(
         cost_usd=0.0, input_tokens=0, output_tokens=0,
         cache_read_input_tokens=0, num_turns=0, claude_calls=0,
     )
+    _RUN_REFINE_QUERIES.clear()
 
 
 def _record_claude_usage(env: dict) -> None:
@@ -3273,6 +3378,35 @@ def self_review_diff(
     return data
 
 
+# Class-coded emoji shared by the Issue/PR body license section and the
+# step summary's license-verdict line, so the two surfaces never disagree
+# on severity color.
+_LICENSE_CLASS_EMOJI = {
+    "permissive": "🟢",
+    "copyleft": "🟡",
+    "nc": "🔴",
+    "missing": "🔴",
+    "no-code-link": "🟡",
+    "unknown": "⚪",
+}
+
+
+def _license_enrichment_ran(rec: Recommendation) -> bool:
+    """True when the license gate populated any signal on ``rec``.
+
+    Every field at its dataclass default means enrichment never ran
+    (env opt-out, or a caller that bypasses query_remyx_candidates) —
+    renderers should omit the license verdict rather than report a
+    misleading "unknown".
+    """
+    return bool(
+        rec.paper_github_url or rec.paper_huggingface_url
+        or rec.paper_license
+        or rec.license_class not in ("unknown", "")
+        or rec.license_compat != 0.0
+    )
+
+
 def _render_license_section(rec: Recommendation) -> str:
     """Render the License & code availability block for the PR/Issue body.
 
@@ -3281,20 +3415,16 @@ def _render_license_section(rec: Recommendation) -> str:
     query_remyx_candidates). Otherwise renders a short status block
     with a class-coded emoji and a one-line note so the maintainer
     reads it at a glance.
+
+    Deliberately a sibling of ``_render_engineering_section``: the
+    license verdict and the engineering verdict are two independent
+    calls a maintainer must be able to read separately — an A++
+    engineering analysis fused with a wrong license flag means the
+    reader can miss either one.
     """
-    if (not rec.paper_github_url and not rec.paper_huggingface_url
-            and not rec.paper_license
-            and rec.license_class in ("unknown", "")
-            and rec.license_compat == 0.0):
+    if not _license_enrichment_ran(rec):
         return "\n"
-    emoji = {
-        "permissive": "🟢",
-        "copyleft": "🟡",
-        "nc": "🔴",
-        "missing": "🔴",
-        "no-code-link": "🟡",
-        "unknown": "⚪",
-    }.get(rec.license_class, "⚪")
+    emoji = _LICENSE_CLASS_EMOJI.get(rec.license_class, "⚪")
     note = {
         "permissive": "Permissive license — safe to adopt.",
         "copyleft":
@@ -3342,6 +3472,57 @@ def _render_license_section(rec: Recommendation) -> str:
         f"{family_line}"
         "\n"
     )
+
+
+def _render_engineering_section(
+    *,
+    integration_shape: str = "",
+    contract_match: str = "",
+    migration_cost: str = "",
+    team_direction_signal: str = "",
+    proposed_call_site: str = "",
+) -> str:
+    """Render the Engineering verdict block for Issue bodies.
+
+    Sibling of ``_render_license_section`` — the engineering call
+    (call site, contract match, migration cost) and the license call
+    must read as two adjacent, independent verdicts rather than
+    interleaved prose, so a maintainer can take one without the other
+    (e.g. a great swap proposal under a blocking license stays findable
+    if upstream relicenses). Returns ``""`` when no field carries
+    signal so callers skip the section silently.
+    """
+    rows = []
+    if integration_shape.strip():
+        rows.append(f"- **Integration shape**: {integration_shape.strip()}")
+    if contract_match.strip():
+        rows.append(f"- **Contract match**: {contract_match.strip()}")
+    if migration_cost.strip():
+        rows.append(f"- **Migration cost**: {migration_cost.strip()}")
+    if team_direction_signal.strip():
+        rows.append(
+            f"- **Team-direction signal**: {team_direction_signal.strip()}"
+        )
+    if proposed_call_site.strip():
+        rows.append(f"- **Proposed call site**: {proposed_call_site.strip()}")
+    if not rows:
+        return ""
+    return "## Engineering verdict\n\n" + "\n".join(rows) + "\n"
+
+
+def _record_verdict_fields(result: dict, rec: Recommendation) -> None:
+    """Thread the chosen candidate's license axis onto the result dict.
+
+    The step summary renders a license-verdict line adjacent to the
+    engineering verdict from these fields. Skipped entirely when the
+    license gate never ran, so the summary degrades silently instead
+    of reporting a misleading "unknown".
+    """
+    if not _license_enrichment_ran(rec):
+        return
+    result["license_class"] = rec.license_class
+    result["license_compat"] = rec.license_compat
+    result["paper_license"] = rec.paper_license
 
 
 def _render_self_review_section(review: dict) -> str:
@@ -4219,6 +4400,7 @@ def _open_downgrade_issue(
     implementation_diff: str = "",
     *,
     tldr: str = "",
+    engineering_section: str = "",
     selection_note: str = "",
     selection_rejected: list[dict] | None = None,
     skip_paper_reasoning_section: bool = False,
@@ -4239,6 +4421,10 @@ def _open_downgrade_issue(
     Optional kwargs (added in v1.4.5 to tighten reviewer triage):
 
       tldr: at-a-glance one-paragraph summary; opens the body when set
+      engineering_section: pre-rendered "## Engineering verdict" block
+        (_render_engineering_section). Rendered immediately above the
+        license section so the two verdicts read as adjacent,
+        independent calls.
       selection_note: "Why this candidate from the pool" rationale —
         parity with PR-body selection section. Skips parenthetical
         fallback strings.
@@ -4271,6 +4457,11 @@ def _open_downgrade_issue(
 
     if tldr.strip():
         sections.append(f"\n## TL;DR\n\n{tldr.strip()}\n")
+
+    # Engineering verdict then license verdict, adjacent — two
+    # independent calls, not interleaved prose.
+    if engineering_section.strip():
+        sections.append(engineering_section.rstrip() + "\n")
 
     license_section = _render_license_section(rec)
     if license_section.strip():
@@ -4459,6 +4650,18 @@ def process_target(target: Target) -> dict:
     #    the most implementable candidate.
     candidates = query_remyx_candidates(target)
     result["candidates_returned"] = len(candidates)
+    # Pool-composition + license-distribution telemetry.
+    # Post-dedup counts (query_remyx_candidates coalesces families before
+    # returning). Carried on the result dict so the step summary can
+    # surface them and the weekly summary can aggregate across runs;
+    # these are also the fields engine-side run telemetry will persist.
+    broad_n, refine_n = _pool_composition(candidates)
+    result["broad_pool_size"] = broad_n
+    result["refine_pool_size"] = refine_n
+    if _RUN_REFINE_QUERIES:
+        result["refine_queries"] = list(_RUN_REFINE_QUERIES)
+    if os.environ.get("REMYX_LICENSE_GATE", "1") != "0":
+        result["license_class_counts"] = _license_class_counts(candidates)
 
     # 3. Per-candidate gates. Drop anything below the confidence tier or
     #    already in flight — an open PR for its branch, OR an open Remyx
@@ -4639,37 +4842,45 @@ def process_target(target: Target) -> dict:
                     )
                 contract_match = selection.get("contract_match", "")
                 migration_cost = selection.get("migration_cost", "")
+                result["selection_contract_match"] = contract_match
+                result["selection_migration_cost"] = migration_cost
+                # Engineering axis rendered as its own section (adjacent
+                # to the license section in the body) instead of fused
+                # into the routing prose. Extension
+                # picks use different schema fields: team_direction_signal
+                # and proposed_call_site instead of contract_match /
+                # migration_cost (which don't apply when there's no
+                # existing call site).
                 if shape == "extension":
-                    # Extension picks use different schema fields. Render
-                    # the team_direction_signal and proposed_call_site
-                    # instead of contract_match / migration_cost (which
-                    # don't apply when there's no existing call site).
                     tds = selection.get("team_direction_signal", "")
                     pcs = selection.get("proposed_call_site", "")
+                    engineering_section = _render_engineering_section(
+                        integration_shape=shape_label,
+                        team_direction_signal=tds or "(none reported)",
+                        proposed_call_site=pcs or "(none reported)",
+                    )
                     detail = (
-                        f"**Integration shape**: {shape_label}\n\n"
-                        f"**Team-direction signal**: "
-                        f"{tds or '(none reported)'}\n\n"
-                        f"**Proposed adjacent call site**: "
-                        f"{pcs or '(none reported)'}\n\n"
                         f"_Selection reasoning_: "
                         f"{selection.get('reasoning', '')}\n\n"
                         f"This candidate proposes a NEW capability the "
                         f"repository does not currently have. The selection "
                         f"pass verified that the team has signaled openness "
                         f"to this capability via the direction signal "
-                        f"above (an RFC, a README roadmap item, or a "
-                        f"CONTEXT.md investment pattern). Opening as an "
+                        f"in the Engineering verdict above (an RFC, a "
+                        f"README roadmap item, or a CONTEXT.md investment "
+                        f"pattern). Opening as an "
                         f"Issue rather than a PR because there is no "
                         f"existing call site to integrate against — this "
                         f"is a proposal for the maintainer to weigh, not a "
                         f"drop-in implementation."
                     )
                 else:
+                    engineering_section = _render_engineering_section(
+                        integration_shape=shape_label,
+                        contract_match=contract_match or "(none reported)",
+                        migration_cost=migration_cost or "(none reported)",
+                    )
                     detail = (
-                        f"**Integration shape**: {shape_label}\n\n"
-                        f"**Contract match**: {contract_match or '(none reported)'}\n\n"
-                        f"**Migration cost**: {migration_cost or '(none reported)'}\n\n"
                         f"_Selection reasoning_: {selection.get('reasoning', '')}\n\n"
                         f"This candidate was surfaced via `remyxai search query "
                         f"{selection.get('external_query_used', '')!r}` — it is NOT "
@@ -4681,10 +4892,12 @@ def process_target(target: Target) -> dict:
                         f"because external picks need dependency changes that "
                         f"fall outside the PR guardrails."
                     )
+                _record_verdict_fields(result, rec)
                 issue_url = _open_downgrade_issue(
                     target, rec,
                     reason=f"Selection identified an {shape_label} candidate",
                     detail=detail,
+                    engineering_section=engineering_section,
                     selection_note=selection.get("reasoning", ""),
                     selection_rejected=result.get("selection_rejected"),
                     footer_override=(
@@ -4722,6 +4935,12 @@ def process_target(target: Target) -> dict:
                 # half-built PR.
                 shape = (selection.get("integration_shape") or "addition").lower().strip()
                 result["selection_integration_shape"] = shape
+                result["selection_contract_match"] = (
+                    selection.get("contract_match", "")
+                )
+                result["selection_migration_cost"] = (
+                    selection.get("migration_cost", "")
+                )
                 if shape in ("replacement", "simplification"):
                     contract_match = selection.get("contract_match", "")
                     migration_cost = selection.get("migration_cost", "")
@@ -4730,20 +4949,26 @@ def process_target(target: Target) -> dict:
                         if shape == "replacement"
                         else "pipeline simplification"
                     )
+                    # Engineering axis as its own section, adjacent to the
+                    # license section.
+                    engineering_section = _render_engineering_section(
+                        integration_shape=shape_label,
+                        contract_match=contract_match or "(none reported)",
+                        migration_cost=migration_cost or "(none reported)",
+                    )
                     detail = (
-                        f"**Integration shape**: {shape_label}\n\n"
-                        f"**Contract match**: {contract_match or '(none reported)'}\n\n"
-                        f"**Migration cost**: {migration_cost or '(none reported)'}\n\n"
                         f"_Selection reasoning_: {selection.get('reasoning', '')}\n\n"
                         f"This swap touches dependency files and existing module "
                         f"boundaries — changes that fall outside Outrider's "
                         f"auto-PR guardrails. Opening as an Issue so the team "
                         f"can decide whether to merge the upgrade."
                     )
+                    _record_verdict_fields(result, rec)
                     issue_url = _open_downgrade_issue(
                         target, rec,
                         reason=f"Selection identified a {shape_label} candidate",
                         detail=detail,
+                        engineering_section=engineering_section,
                         selection_note=selection.get("reasoning", ""),
                         selection_rejected=result.get("selection_rejected"),
                         footer_override=(
@@ -4784,6 +5009,7 @@ def process_target(target: Target) -> dict:
             "tier": rec.tier,
             "candidates_considered": len(viable),
         })
+        _record_verdict_fields(result, rec)
         log.info(f"  ✓ selected: [{rec.tier}] {rec.paper_title}")
 
         # 5. Spec bundle for the chosen candidate. Thread the selection
@@ -5292,6 +5518,454 @@ def build_target_from_env() -> Target:
     )
 
 
+# ─── Weekly Discussion summary ─────────────────────────────────────────────
+#
+# A rolling weekly digest of Outrider's work on the target repo, posted as
+# a comment on a designated GitHub Discussion. Opt-in: fires only when the
+# action is invoked with `mode: weekly-summary` AND REMYX_WEEKLY_DISCUSSION_ID
+# is set. Data source: the GitHub Actions API + per-run logs (the engine
+# engine-side `recommendation_runs` table is the preferred long-term
+# carrier; `_fetch_week_runs` is the seam to swap when it ships). Runs whose
+# logs have aged out of retention are listed without details rather than
+# silently dropped. One Claude call drafts the interpretive sections; on
+# failure the post degrades to data-only.
+
+WEEKLY_WINDOW_DAYS = 7
+
+
+def _resolve_discussion_id(target: Target, raw: str) -> str:
+    """Resolve REMYX_WEEKLY_DISCUSSION_ID to a GraphQL node ID.
+
+    Accepts either the node ID itself (``D_kwDO…``) or a plain Discussion
+    number — numbers are friendlier to copy from the Discussion URL, so
+    resolve them via one GraphQL query. Raises RuntimeError when a number
+    doesn't match any Discussion on the target repo.
+    """
+    raw = raw.strip()
+    if not raw.isdigit():
+        return raw
+    owner, _, name = target.repo.partition("/")
+    data = gh_graphql(
+        "query($owner: String!, $name: String!, $number: Int!) {"
+        " repository(owner: $owner, name: $name) {"
+        " discussion(number: $number) { id } } }",
+        {"owner": owner, "name": name, "number": int(raw)},
+    )
+    node = (data.get("repository") or {}).get("discussion") or {}
+    disc_id = node.get("id") or ""
+    if not disc_id:
+        raise RuntimeError(
+            f"Discussion #{raw} not found on {target.repo} — check "
+            f"REMYX_WEEKLY_DISCUSSION_ID / the weekly-discussion-id input."
+        )
+    return disc_id
+
+
+def _post_discussion_comment(discussion_id: str, body: str) -> str:
+    """Post ``body`` as a comment on the Discussion; return the comment URL."""
+    data = gh_graphql(
+        "mutation($id: ID!, $body: String!) {"
+        " addDiscussionComment(input: {discussionId: $id, body: $body}) {"
+        " comment { url } } }",
+        {"id": discussion_id, "body": body},
+    )
+    comment = (data.get("addDiscussionComment") or {}).get("comment") or {}
+    return comment.get("url") or ""
+
+
+_LOG_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z ?")
+
+
+def _extract_run_summary(log_text: str) -> dict | None:
+    """Parse the RUN SUMMARY JSON object out of a raw Actions job log.
+
+    GitHub prefixes every log line with an ISO timestamp; strip it, find
+    the last ``=== RUN SUMMARY ===`` marker, then collect from the first
+    ``{`` to the matching column-0 ``}`` (json.dumps(indent=2) shape).
+    Returns None when no marker / unparseable — callers treat that as
+    "not an Outrider run" or "log truncated".
+    """
+    if "=== RUN SUMMARY ===" not in log_text:
+        return None
+    lines = [_LOG_TIMESTAMP_RE.sub("", l) for l in log_text.splitlines()]
+    marker_idx = max(
+        i for i, l in enumerate(lines) if "=== RUN SUMMARY ===" in l
+    )
+    buf: list[str] = []
+    for line in lines[marker_idx + 1:]:
+        if not buf:
+            if line.startswith("{"):
+                buf.append(line)
+            continue
+        buf.append(line)
+        if line.startswith("}"):
+            break
+    if not buf:
+        return None
+    try:
+        parsed = json.loads("\n".join(buf))
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _fetch_run_log_text(repo: str, run_id: int) -> str | None:
+    """Download one workflow run's log archive and return the text of the
+    member containing the RUN SUMMARY marker (or the largest member when
+    none matches — callers re-check). Returns None when the archive is
+    gone (aged out of retention → HTTP 410/404) or unreadable."""
+    token = _github_token()
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/logs",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "feature-finder-orchestrator",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            blob = r.read()
+        archive = zipfile.ZipFile(io.BytesIO(blob))
+        for info in archive.infolist():
+            if not info.filename.endswith(".txt"):
+                continue
+            text = archive.read(info).decode("utf-8", errors="replace")
+            if "=== RUN SUMMARY ===" in text:
+                return text
+        return ""
+    except Exception as e:
+        log.debug(f"  weekly: log fetch for run {run_id} failed: {e}")
+        return None
+
+
+def _fetch_week_runs(target: Target, since: "dt.datetime") -> list[dict]:
+    """Completed Outrider runs on the target repo since ``since``.
+
+    Returns entries ``{"run": <Actions run envelope>, "summary": dict|None}``,
+    newest first. A run counts as an Outrider run when its log contains the
+    RUN SUMMARY marker; when the log has aged out, the workflow name/path
+    containing "outrider" is the fallback signal and the entry carries
+    ``summary=None`` (rendered as "details unavailable" — an honest gap,
+    never a silent drop). Weekly-summary runs themselves are excluded.
+    """
+    created = urllib.parse.quote(f">={since.strftime('%Y-%m-%d')}")
+    resp = gh_api(
+        "GET",
+        f"/repos/{target.repo}/actions/runs?created={created}&per_page=100",
+    )
+    runs = resp.get("workflow_runs") or []
+    total = resp.get("total_count") or len(runs)
+    if total > len(runs):
+        log.info(f"  weekly: repo had {total} runs this window; "
+                 f"only the first {len(runs)} were fetched")
+    entries: list[dict] = []
+    for run in runs:
+        if run.get("status") != "completed":
+            continue
+        log_text = _fetch_run_log_text(target.repo, run.get("id"))
+        if log_text is None:
+            name_path = (
+                (run.get("name") or "") + (run.get("path") or "")
+            ).lower()
+            if "outrider" in name_path:
+                entries.append({"run": run, "summary": None})
+            continue
+        summary = _extract_run_summary(log_text)
+        if summary is None:
+            continue  # not an Outrider run
+        if summary.get("mode") == "weekly-summary":
+            continue  # don't aggregate the digest runs themselves
+        entries.append({"run": run, "summary": summary})
+    entries.sort(key=lambda e: e["run"].get("created_at") or "", reverse=True)
+    return entries
+
+
+def _aggregate_week(entries: list[dict]) -> dict:
+    """Mechanical aggregation across the week's run entries.
+
+    Everything here is data, not interpretation — the one Claude call in
+    ``_draft_weekly_narrative`` works from this dict. Costs are summed
+    only over runs whose logs parsed; ``unverified_runs`` counts the
+    retention gaps so the digest never reports an estimate as exact.
+    """
+    agg: dict = {
+        "rows": [],
+        "n_runs": len(entries),
+        "n_success": 0,
+        "n_failed": 0,
+        "status_counts": {},
+        "verified_cost": 0.0,
+        "unverified_runs": 0,
+        "license_class_counts": {},
+        "refine_queries": [],
+        "selection_quotes": [],
+    }
+    for e in entries:
+        run, summary = e["run"], e["summary"]
+        date = (run.get("created_at") or "")[:10]
+        if run.get("conclusion") == "success":
+            agg["n_success"] += 1
+        else:
+            agg["n_failed"] += 1
+        if summary is None:
+            agg["unverified_runs"] += 1
+            agg["rows"].append({
+                "date": date,
+                "status": "(outside log retention — details unavailable)",
+                "output": "—",
+            })
+            continue
+        status = summary.get("status", "unknown")
+        agg["status_counts"][status] = agg["status_counts"].get(status, 0) + 1
+        artifact = summary.get("pr_url") or summary.get("issue_url") or ""
+        if artifact:
+            number = artifact.rstrip("/").split("/")[-1]
+            output = f"[#{number}]({artifact})"
+        else:
+            output = "No artifact"
+        agg["rows"].append({"date": date, "status": status, "output": output})
+        agg["verified_cost"] += float(summary.get("cost_usd") or 0.0)
+        for cls, n in (summary.get("license_class_counts") or {}).items():
+            agg["license_class_counts"][cls] = (
+                agg["license_class_counts"].get(cls, 0) + int(n)
+            )
+        agg["refine_queries"].extend(summary.get("refine_queries") or [])
+        reasoning = (summary.get("selection_reasoning") or "").strip()
+        if status == "skipped_by_selection_verification" and reasoning:
+            agg["selection_quotes"].append(reasoning)
+    return agg
+
+
+_WEEKLY_NARRATIVE_PROMPT_TEMPLATE = """\
+You are drafting the interpretive sections of Outrider's weekly summary
+for the repository __REPO__. Everything below is the week's aggregated
+run data plus the open Outrider Issues awaiting maintainer review. Your
+output supplements the data tables — do NOT restate them.
+
+Aggregated run data (JSON)
+--------------------------
+__AGG_JSON__
+
+Open Outrider Issues (number, title, body excerpt)
+--------------------------------------------------
+__OPEN_ISSUES__
+
+Produce strictly this JSON object (no prose wrapper):
+{
+  "verdict_bullets": ["...", ...],
+  "refine_themes": [{"theme": "...", "queries": N, "hit_rate": "..."}, ...],
+  "patterns": ["...", ...],
+  "next_actions": {"<issue number>": "<one-line next action>", ...}
+}
+
+Rules:
+- verdict_bullets: 2-4 bullets summarizing what the selection pass did
+  this week (what it anchored on, what it rejected and why). Do not
+  paraphrase any verbatim reasoning quote — that is rendered separately.
+- refine_themes: cluster the refine queries into themes with a per-theme
+  query count and a one-phrase hit-rate assessment. Empty list if there
+  were no refine queries.
+- patterns: 3-5 entries. Each MUST lead with a noun, and each MUST end
+  with a concrete maintainer action. This is the only opinionated
+  section of the summary — interpretation, not data.
+- next_actions: for each open Issue where the body makes the next step
+  obvious (a flag to flip, a license to re-check, a question to answer),
+  a one-line action. Omit Issues where no clear next action exists.
+"""
+
+
+def _draft_weekly_narrative(
+    agg: dict, open_issues: list[dict],
+) -> dict | None:
+    """One Claude call drafting the interpretive sections. None on any
+    failure — the digest degrades to data-only, never blocks the post."""
+    issues_block = "\n".join(
+        f"#{it.get('number')} {it.get('title', '')}\n"
+        f"  {' '.join((it.get('body') or '').split())[:1200]}"
+        for it in open_issues
+    ) or "(none open)"
+    prompt = (
+        _WEEKLY_NARRATIVE_PROMPT_TEMPLATE
+        .replace("__REPO__", agg.get("repo", ""))
+        .replace("__AGG_JSON__", json.dumps(agg, indent=2)[:20000])
+        .replace("__OPEN_ISSUES__", issues_block)
+    )
+    timeout_s = int(os.environ.get("REMYX_WEEKLY_TIMEOUT_S", "180"))
+    max_turns = int(os.environ.get("REMYX_WEEKLY_MAX_TURNS", "3"))
+    with tempfile.TemporaryDirectory(prefix="outrider-weekly-") as tmp:
+        ok, output = _run_claude_oneshot(
+            Path(tmp), prompt, timeout_s, max_turns=max_turns,
+        )
+    if not ok:
+        log.warning(f"  weekly: narrative call failed: {output[:200]}")
+        return None
+    data = _extract_json_object(output)
+    if not isinstance(data, dict):
+        log.warning(f"  weekly: narrative JSON unparseable: {output[:200]!r}")
+        return None
+    return data
+
+
+def _compose_weekly_markdown(
+    window_start: "dt.datetime",
+    window_end: "dt.datetime",
+    agg: dict,
+    open_issues: list[dict],
+    drafted: dict | None,
+) -> str:
+    """Assemble the Discussion-comment body. Data sections are mechanical;
+    the drafted sections slot in when the Claude call succeeded. The
+    verbatim selection-reasoning quote is copied as-is into a blockquote —
+    never paraphrased (it's the most maintainer-impactful content)."""
+    drafted = drafted or {}
+    lines: list[str] = []
+    lines.append(
+        f"## Outrider weekly summary — "
+        f"{window_start.strftime('%Y-%m-%d')} to "
+        f"{window_end.strftime('%Y-%m-%d')}"
+    )
+    lines.append("")
+    # Exact when every run's log parsed; explicitly partial otherwise —
+    # never report an estimate as exact.
+    cost_phrase = f"${agg['verified_cost']:.2f}"
+    if agg["unverified_runs"]:
+        cost_phrase += (
+            f" verified ({agg['unverified_runs']} run(s) outside log "
+            f"retention not counted)"
+        )
+    lines.append(
+        f"**Runs this week**: {agg['n_runs']} "
+        f"({agg['n_success']} successful, {agg['n_failed']} failed). "
+        f"Claude spend: {cost_phrase}."
+    )
+
+    if agg["rows"]:
+        lines += ["", "### Outcomes", "", "| Date | Status | Output |",
+                  "|---|---|---|"]
+        for row in agg["rows"]:
+            lines.append(
+                f"| {row['date']} | `{row['status']}` | {row['output']} |"
+            )
+
+    lines += ["", "### Selection-pass verdicts", ""]
+    bullets = drafted.get("verdict_bullets") or []
+    if isinstance(bullets, list) and bullets:
+        lines += [f"- {b}" for b in bullets if str(b).strip()]
+    elif agg["status_counts"]:
+        lines += [
+            f"- {n} run(s) ended `{s}`"
+            for s, n in sorted(agg["status_counts"].items())
+        ]
+    else:
+        lines.append("- No completed Outrider runs in this window.")
+    if agg["selection_quotes"]:
+        # Verbatim, most recent first — the rejection reasoning is the
+        # most maintainer-impactful content; never paraphrase it.
+        lines.append("")
+        for quote_line in agg["selection_quotes"][0].splitlines():
+            lines.append(f"> {quote_line}")
+
+    themes = drafted.get("refine_themes") or []
+    if isinstance(themes, list) and themes:
+        lines += ["", "### Refine-query themes the audit pass explored", "",
+                  "| Theme | Queries | Hit rate |", "|---|---|---|"]
+        for t in themes:
+            if not isinstance(t, dict):
+                continue
+            lines.append(
+                f"| {t.get('theme', '')} | {t.get('queries', '')} "
+                f"| {t.get('hit_rate', '')} |"
+            )
+    elif agg["refine_queries"]:
+        lines += ["", "### Refine queries the audit pass explored", ""]
+        seen_q: set[str] = set()
+        for q in agg["refine_queries"]:
+            if q not in seen_q:
+                seen_q.add(q)
+                lines.append(f"- `{q}`")
+
+    if agg["license_class_counts"]:
+        lines += ["", "### License gate findings", "",
+                  "| Class | Count |", "|---|---|"]
+        counts = agg["license_class_counts"]
+        ordered = [k for k in _LICENSE_CLASS_ORDER if counts.get(k)]
+        ordered += [k for k in counts if k not in _LICENSE_CLASS_ORDER]
+        for cls in ordered:
+            lines.append(f"| {cls} | {counts[cls]} |")
+
+    if open_issues:
+        next_actions = drafted.get("next_actions") or {}
+        lines += ["", "### Open Outrider Issues awaiting maintainer review",
+                  "", "| Issue | Title | Next action |", "|---|---|---|"]
+        for it in open_issues:
+            number = it.get("number")
+            title = (it.get("title") or "").replace("|", "\\|")[:100]
+            url = it.get("html_url") or ""
+            action = "—"
+            if isinstance(next_actions, dict):
+                action = str(
+                    next_actions.get(str(number), "—") or "—"
+                ).replace("|", "\\|")
+            lines.append(f"| [#{number}]({url}) | {title} | {action} |")
+
+    patterns = drafted.get("patterns") or []
+    if isinstance(patterns, list) and patterns:
+        lines += ["", "### Patterns worth attention", ""]
+        lines += [
+            f"{i}. {p}" for i, p in enumerate(
+                (str(p).strip() for p in patterns if str(p).strip()), start=1,
+            )
+        ]
+
+    lines += [
+        "", "---", "",
+        "_Generated by Outrider's weekly-summary mode. Data source: "
+        "GitHub Actions API + per-run logs; runs whose logs aged out of "
+        "retention are listed without details._",
+    ]
+    return "\n".join(lines)
+
+
+def run_weekly_summary(target: Target) -> dict:
+    """Aggregate the past week's runs and post the digest to the
+    configured Discussion. The weekly-mode counterpart to
+    ``process_target`` — main() routes here on ``mode: weekly-summary``."""
+    result: dict = {
+        "repo": target.repo, "mode": "weekly-summary", "status": "unknown",
+    }
+    raw_id = os.environ.get("REMYX_WEEKLY_DISCUSSION_ID", "").strip()
+    if not raw_id:
+        result["status"] = "weekly_summary_skipped_no_discussion_id"
+        log.info("  ✗ weekly-summary mode invoked without "
+                 "REMYX_WEEKLY_DISCUSSION_ID; nothing to post to")
+        return result
+    discussion_id = _resolve_discussion_id(target, raw_id)
+    window_end = dt.datetime.now(dt.timezone.utc)
+    window_start = window_end - dt.timedelta(days=WEEKLY_WINDOW_DAYS)
+    log.info(f"  → weekly summary over {target.repo} "
+             f"({window_start.date()} → {window_end.date()})")
+    entries = _fetch_week_runs(target, window_start)
+    open_issues = _remyx_issues(target, state="open")
+    agg = _aggregate_week(entries)
+    agg["repo"] = target.repo
+    drafted = _draft_weekly_narrative(agg, open_issues)
+    body = _compose_weekly_markdown(
+        window_start, window_end, agg, open_issues, drafted,
+    )
+    url = _post_discussion_comment(discussion_id, body)
+    result.update({
+        "status": "weekly_summary_posted",
+        "discussion_comment_url": url,
+        "runs_aggregated": len(entries),
+        "open_issues_listed": len(open_issues),
+        "narrative_drafted": drafted is not None,
+    })
+    log.info(f"  ✓ weekly_summary_posted: {url}")
+    return result
+
+
 def _write_step_summary(result: dict) -> None:
     """Render the run outcome as Markdown into $GITHUB_STEP_SUMMARY.
 
@@ -5303,6 +5977,10 @@ def _write_step_summary(result: dict) -> None:
     Sections (only what applies given the result's shape):
       - Headline: status + paper link
       - PR / Issue link if one was opened
+      - Engineering verdict + license verdict for the chosen candidate,
+        adjacent — two independent calls
+      - Pool composition (broad + refine, after dedup) and the pool's
+        license-class distribution on one line each
       - Why-this-paper reasoning (collapsed by default for brevity)
       - Cost + tokens
       - Selection rejected candidates (collapsed) for "what else did
@@ -5349,6 +6027,9 @@ def _write_step_summary(result: dict) -> None:
         "claude_failed":           "❌",
         "rejected_path_violations":"❌",
         "error":                   "❌",
+        "weekly_summary_posted":   "🟢",
+        "weekly_summary_skipped_no_discussion_id": "⏭️",
+        "weekly_summary_failed":   "❌",
     }.get(status, "ℹ️")
 
     lines: list[str] = []
@@ -5363,6 +6044,9 @@ def _write_step_summary(result: dict) -> None:
         lines.append(f"**PR**: {pr_url}\n")
     if issue_url:
         lines.append(f"**Issue**: {issue_url}\n")
+    discussion_url = result.get("discussion_comment_url") or ""
+    if discussion_url:
+        lines.append(f"**Discussion comment**: {discussion_url}\n")
 
     # When the dedup gate fires (open OR closed prior Issue), surface
     # the existing-Issue context inline so the maintainer sees at a
@@ -5381,6 +6065,57 @@ def _write_step_summary(result: dict) -> None:
                 f"**Already in flight**: {existing_url} (open — "
                 f"re-validated this run).\n"
             )
+
+    # Engineering verdict + license verdict for the chosen candidate,
+    # rendered adjacently so they read as two independent calls — a
+    # maintainer should be able to take the engineering analysis and the
+    # license risk separately. Each degrades
+    # silently when its fields are absent.
+    eng_shape = (result.get("selection_integration_shape") or "").strip()
+    eng_contract = (result.get("selection_contract_match") or "").strip()
+    eng_migration = (result.get("selection_migration_cost") or "").strip()
+    eng_tds = (result.get("selection_team_direction_signal") or "").strip()
+    eng_pcs = (result.get("selection_proposed_call_site") or "").strip()
+    if eng_contract or eng_migration or eng_tds or eng_pcs:
+        lines.append("**Engineering verdict**\n")
+        if eng_shape:
+            lines.append(f"- **Integration shape**: {eng_shape}")
+        if eng_contract:
+            lines.append(f"- **Contract match**: {eng_contract}")
+        if eng_migration:
+            lines.append(f"- **Migration cost**: {eng_migration}")
+        if eng_tds:
+            lines.append(f"- **Team-direction signal**: {eng_tds}")
+        if eng_pcs:
+            lines.append(f"- **Proposed call site**: {eng_pcs}")
+        lines.append("")
+    license_class = (result.get("license_class") or "").strip()
+    if license_class:
+        lic_emoji = _LICENSE_CLASS_EMOJI.get(license_class, "⚪")
+        lic_compat = result.get("license_compat", 0.0)
+        lic_spdx = result.get("paper_license") or "(none detected)"
+        lines.append(
+            f"**License verdict**: {lic_emoji} `{lic_spdx}` "
+            f"(class: `{license_class}`, compat: {lic_compat:.2f})\n"
+        )
+
+    # Pool composition + license-class distribution — run-level context
+    # for "what did Outrider actually look at". Surfaces the
+    # deep-search contribution and the license gate's coverage at a
+    # glance; both degrade silently when the fields are absent.
+    broad_n = result.get("broad_pool_size")
+    refine_n = result.get("refine_pool_size")
+    if broad_n is not None and refine_n is not None and (broad_n + refine_n):
+        lines.append(
+            f"**Candidate pool**: {broad_n} broad + {refine_n} refine "
+            f"candidate(s) considered (after dedup)\n"
+        )
+    license_counts = result.get("license_class_counts") or {}
+    if license_counts:
+        lines.append(
+            f"**License gate (pool)**: "
+            f"{_format_license_class_counts(license_counts)}\n"
+        )
 
     # Selection-pass narrative — "why this candidate (or skip)" from
     # the agentic selection. Distinct from rec.reasoning, which is the
@@ -5454,19 +6189,40 @@ def _write_step_summary(result: dict) -> None:
 
 
 def main():
+    # Mode dispatch: "recommend" is the classic
+    # scout-and-implement run; "weekly-summary" aggregates the past week
+    # and posts a digest comment to the configured Discussion. Customers
+    # opt in via a second scheduled job passing `mode: weekly-summary`.
+    mode = (
+        os.environ.get("REMYX_MODE")
+        or os.environ.get("INPUT_MODE")
+        or "recommend"
+    ).strip().lower().replace("_", "-")
+    if mode not in ("recommend", "weekly-summary"):
+        log.error(f"Unknown mode {mode!r}; must be 'recommend' or "
+                  f"'weekly-summary'.")
+        sys.exit(2)
+
     target = build_target_from_env()
     log.info(f"=== {target.repo} ===")
     log.info(f"  interest_id={target.interest_id}")
-    log.info(f"  min_confidence={target.min_confidence}  "
-             f"draft_mode={target.draft_mode}  "
-             f"rate_limit_days={target.rate_limit_days}")
+    if mode == "weekly-summary":
+        log.info("  mode=weekly-summary")
+        runner = run_weekly_summary
+        failure_status = "weekly_summary_failed"
+    else:
+        log.info(f"  min_confidence={target.min_confidence}  "
+                 f"draft_mode={target.draft_mode}  "
+                 f"rate_limit_days={target.rate_limit_days}")
+        runner = process_target
+        failure_status = "error"
 
     _reset_run_cost()
     try:
-        result = process_target(target)
+        result = runner(target)
     except Exception as e:
         log.exception(f"  ✗ unhandled error: {e}")
-        result = {"repo": target.repo, "status": "error", "error": str(e)}
+        result = {"repo": target.repo, "status": failure_status, "error": str(e)}
 
     # Token/cost totals across every Claude pass this run, captured even when
     # process_target raised.
@@ -5494,6 +6250,11 @@ def main():
                     f.write(f"pr_url={result['pr_url']}\n")
                 if "issue_url" in result:
                     f.write(f"issue_url={result['issue_url']}\n")
+                if "discussion_comment_url" in result:
+                    f.write(
+                        f"discussion_comment_url="
+                        f"{result['discussion_comment_url']}\n"
+                    )
                 if "arxiv" in result:
                     f.write(f"arxiv={result['arxiv']}\n")
                 if "tier" in result:

--- a/src/run.py
+++ b/src/run.py
@@ -976,23 +976,85 @@ class Recommendation:
 # ─── Helpers ───────────────────────────────────────────────────────────────
 
 
+# Run-scoped cache for the self-minted remyx[bot] token — one mint attempt
+# per run, success or failure. `permissions` carries the scopes the engine
+# actually granted so capability-aware callers (the Discussion post) can
+# branch instead of discovering a 403.
+_BOT_TOKEN = {"attempted": False, "token": "", "permissions": {}}
+
+
+def _mint_bot_token() -> str:
+    """Self-mint a short-lived remyx[bot] installation token from the engine.
+
+    The action already holds REMYX_API_KEY — exactly the credential the
+    engine's ``/github/installation-token`` endpoint authenticates — so
+    the bot identity must not depend on the customer's workflow YAML
+    carrying a mint step. Called lazily by ``_github_token``; one attempt
+    per run. Best-effort: any failure (engine unreachable, App not
+    installed, no provisioned action for this repo) returns ``""`` and
+    the caller falls back to GITHUB_TOKEN — the same graceful semantics
+    as the YAML mint step's ``|| token=""``.
+    """
+    if _BOT_TOKEN["attempted"]:
+        return _BOT_TOKEN["token"]
+    _BOT_TOKEN["attempted"] = True
+    api_key = (
+        os.environ.get("REMYX_API_KEY") or os.environ.get("REMYXAI_API_KEY")
+    )
+    repo = (os.environ.get("TARGET_REPO") or "").strip()
+    repo = repo.split("github.com/")[-1].strip("/")
+    if not api_key or "/" not in repo:
+        return ""
+    req = urllib.request.Request(
+        f"{REMYX_API_BASE}/api/v1.0/github/installation-token",
+        data=json.dumps({"repo": repo}).encode(),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            data = json.loads(r.read() or b"{}")
+    except Exception as e:
+        log.info(f"  bot-token self-mint unavailable ({e}); "
+                 f"falling back to GITHUB_TOKEN")
+        return ""
+    _BOT_TOKEN["token"] = (data.get("token") or "").strip()
+    _BOT_TOKEN["permissions"] = data.get("permissions") or {}
+    if _BOT_TOKEN["token"]:
+        log.info(f"  ✓ self-minted remyx[bot] token (scopes: "
+                 f"{sorted(_BOT_TOKEN['permissions']) or '(unreported)'})")
+    return _BOT_TOKEN["token"]
+
+
 def _github_token() -> str:
     """Resolve the GitHub token to use for git push + API calls.
 
     Preference order:
-      1. INPUT_GITHUB_TOKEN — explicit cross-repo PAT override
-      2. GITHUB_TOKEN — the workflow's built-in token (action.yml's
-         step env sets this from `${{ github.token }}`).
+      1. INPUT_GITHUB_TOKEN — explicit override: a cross-repo PAT, or a
+         bot token the workflow's own mint step passed via the
+         `github-token` input.
+      2. Self-minted remyx[bot] installation token (engine-issued; see
+         ``_mint_bot_token``). Makes the bot the DEFAULT author of every
+         artifact — PRs, Issues, Discussion comments — even when the
+         workflow YAML carries no mint step.
+      3. GITHUB_TOKEN — the workflow's built-in token (artifacts author
+         as github-actions[bot]).
 
     Two separate env vars rather than a single `${{ a || b }}` in
     action.yml because GitHub Actions' || operator on empty-string
     inputs returns '' instead of falling through (observed via v1.0.3
     git-push failure). Resolving in Python gives reliable semantics.
     """
-    return (
-        os.environ.get("INPUT_GITHUB_TOKEN", "").strip()
-        or os.environ.get("GITHUB_TOKEN", "").strip()
-    )
+    explicit = os.environ.get("INPUT_GITHUB_TOKEN", "").strip()
+    if explicit:
+        return explicit
+    minted = _mint_bot_token()
+    if minted:
+        return minted
+    return os.environ.get("GITHUB_TOKEN", "").strip()
 
 
 def gh_api(method: str, path: str, body: dict | None = None) -> Any:
@@ -1025,7 +1087,9 @@ def gh_api(method: str, path: str, body: dict | None = None) -> Any:
         raise RuntimeError(f"GitHub {method} {path} → HTTP {e.code}: {body_text}") from e
 
 
-def gh_graphql(query: str, variables: dict | None = None) -> dict:
+def gh_graphql(
+    query: str, variables: dict | None = None, token: str | None = None,
+) -> dict:
     """Minimal GitHub GraphQL wrapper — sibling of ``gh_api``.
 
     The Discussions API is GraphQL-only (no REST endpoint exists for
@@ -1034,9 +1098,11 @@ def gh_graphql(query: str, variables: dict | None = None) -> dict:
     ``gh_api``: raises RuntimeError on transport errors AND on
     GraphQL-level errors (GraphQL returns HTTP 200 with an ``errors``
     array; surfacing those as exceptions keeps the two helpers
-    behaviorally identical for callers). Returns the ``data`` object.
+    behaviorally identical for callers). ``token`` overrides the resolved
+    token — used by the Discussion-post permission fallback. Returns the
+    ``data`` object.
     """
-    token = _github_token()
+    token = token or _github_token()
     if not token:
         raise RuntimeError(
             "Neither INPUT_GITHUB_TOKEN nor GITHUB_TOKEN is set. The "
@@ -2796,6 +2862,7 @@ def _reset_run_cost() -> None:
         cache_read_input_tokens=0, num_turns=0, claude_calls=0,
     )
     _RUN_REFINE_QUERIES.clear()
+    _BOT_TOKEN.update(attempted=False, token="", permissions={})
 
 
 def _record_claude_usage(env: dict) -> None:
@@ -5587,13 +5654,40 @@ def _resolve_discussion_id(target: Target, raw: str) -> str:
 
 
 def _post_discussion_comment(discussion_id: str, body: str) -> str:
-    """Post ``body`` as a comment on the Discussion; return the comment URL."""
-    data = gh_graphql(
+    """Post ``body`` as a comment on the Discussion; return the comment URL.
+
+    Posts with the active token first — the self-minted remyx[bot] token
+    when available, so the digest is bot-authored by default. When that
+    token can't post Discussions (the App's Discussions permission isn't
+    granted/accepted on this install yet → GraphQL "Resource not
+    accessible"), falls back to the workflow's GITHUB_TOKEN so the digest
+    still ships — authored by github-actions[bot] rather than failing
+    the run.
+    """
+    mutation = (
         "mutation($id: ID!, $body: String!) {"
         " addDiscussionComment(input: {discussionId: $id, body: $body}) {"
-        " comment { url } } }",
-        {"id": discussion_id, "body": body},
+        " comment { url } } }"
     )
+    variables = {"id": discussion_id, "body": body}
+    try:
+        data = gh_graphql(mutation, variables)
+    except RuntimeError as e:
+        fallback = os.environ.get("GITHUB_TOKEN", "").strip()
+        permission_denied = (
+            "Resource not accessible" in str(e)
+            or "FORBIDDEN" in str(e)
+            or "403" in str(e)
+        )
+        if not (fallback and fallback != _github_token() and permission_denied):
+            raise
+        log.warning(
+            f"  weekly: active token can't post Discussions "
+            f"({str(e)[:120]}); retrying with GITHUB_TOKEN. Grant the "
+            f"Remyx App 'Discussions: Read and write' for a bot-authored "
+            f"digest."
+        )
+        data = gh_graphql(mutation, variables, token=fallback)
     comment = (data.get("addDiscussionComment") or {}).get("comment") or {}
     return comment.get("url") or ""
 

--- a/src/run.py
+++ b/src/run.py
@@ -2431,6 +2431,31 @@ def _all_remyx_issues(target: Target) -> list[dict]:
     return _remyx_issues(target, state="all")
 
 
+def _remyx_open_prs(target: Target) -> list[dict]:
+    """Open Outrider-opened PRs on the target repo.
+
+    The weekly digest's review checklist covers both artifact routes —
+    an idle draft PR is exactly as actionable as an open Issue. Ours =
+    head branch carries the recommendation prefix, or the title carries
+    the PR prefix. Best-effort, returns ``[]`` on fetch failure.
+    """
+    try:
+        prs = gh_api(
+            "GET", f"/repos/{target.repo}/pulls?state=open&per_page=100",
+        ) or []
+    except Exception as e:
+        log.debug(f"  fetch open PRs for {target.repo} failed: {e}")
+        return []
+    ours = []
+    for pr in prs:
+        title = pr.get("title") or ""
+        head_ref = ((pr.get("head") or {}).get("ref")) or ""
+        if (title.startswith(PR_TITLE_PREFIX)
+                or head_ref.startswith(BRANCH_PREFIX)):
+            ours.append(pr)
+    return ours
+
+
 def _arxiv_linked_issues(target: Target, state: str = "all") -> list[dict]:
     """All Issues on the target repo whose body links an arxiv paper,
     regardless of who opened them.
@@ -5573,6 +5598,34 @@ def _post_discussion_comment(discussion_id: str, body: str) -> str:
     return comment.get("url") or ""
 
 
+def _fetch_prior_digest_excerpt(discussion_id: str, max_chars: int = 3000) -> str:
+    """Most recent prior digest comment on the host Discussion, truncated.
+
+    Fed to the narrative call so research-stream trends can make
+    week-over-week claims ("up from 1 candidate last week") with zero
+    storage — the Discussion thread IS the history. Best-effort: ``""``
+    when the lookup fails or no prior digest exists.
+    """
+    try:
+        data = gh_graphql(
+            "query($id: ID!) { node(id: $id) { ... on Discussion {"
+            " comments(last: 5) { nodes { body } } } } }",
+            {"id": discussion_id},
+        )
+    except Exception as e:
+        log.debug(f"  weekly: prior-digest fetch failed: {e}")
+        return ""
+    nodes = (
+        ((data.get("node") or {}).get("comments") or {}).get("nodes")
+    ) or []
+    # `last: 5` returns oldest→newest; scan newest first.
+    for node in reversed(nodes):
+        body = (node or {}).get("body") or ""
+        if "Outrider weekly" in body:
+            return body[:max_chars]
+    return ""
+
+
 _LOG_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z ?")
 
 
@@ -5695,13 +5748,23 @@ def _aggregate_week(entries: list[dict]) -> dict:
         "n_runs": len(entries),
         "n_success": 0,
         "n_failed": 0,
+        "n_artifacts": 0,
+        "n_skips": 0,
+        "n_errors": 0,
+        "artifact_statuses": {},
         "status_counts": {},
         "verified_cost": 0.0,
         "unverified_runs": 0,
         "license_class_counts": {},
         "refine_queries": [],
         "selection_quotes": [],
+        # Distinct candidates the selection pass saw this week — title +
+        # outcome (chosen, or the rejection reason). Deduped across runs
+        # (the same pool repeats on daily crons); the research-stream
+        # trends in the narrative call are drawn from this corpus.
+        "candidates": [],
     }
+    seen_candidates: set[str] = set()
     for e in entries:
         run, summary = e["run"], e["summary"]
         date = (run.get("created_at") or "")[:10]
@@ -5711,6 +5774,8 @@ def _aggregate_week(entries: list[dict]) -> dict:
             agg["n_failed"] += 1
         if summary is None:
             agg["unverified_runs"] += 1
+            if run.get("conclusion") != "success":
+                agg["n_errors"] += 1
             agg["rows"].append({
                 "date": date,
                 "status": "(outside log retention — details unavailable)",
@@ -5721,9 +5786,17 @@ def _aggregate_week(entries: list[dict]) -> dict:
         agg["status_counts"][status] = agg["status_counts"].get(status, 0) + 1
         artifact = summary.get("pr_url") or summary.get("issue_url") or ""
         if artifact:
+            agg["n_artifacts"] += 1
+            agg["artifact_statuses"][status] = (
+                agg["artifact_statuses"].get(status, 0) + 1
+            )
             number = artifact.rstrip("/").split("/")[-1]
             output = f"[#{number}]({artifact})"
         else:
+            if status.startswith("skipped"):
+                agg["n_skips"] += 1
+            else:
+                agg["n_errors"] += 1
             output = "No artifact"
         agg["rows"].append({"date": date, "status": status, "output": output})
         agg["verified_cost"] += float(summary.get("cost_usd") or 0.0)
@@ -5735,62 +5808,109 @@ def _aggregate_week(entries: list[dict]) -> dict:
         reasoning = (summary.get("selection_reasoning") or "").strip()
         if status == "skipped_by_selection_verification" and reasoning:
             agg["selection_quotes"].append(reasoning)
+        # Candidate corpus — entries are newest-first, so the first
+        # occurrence carries the most recent outcome for that paper.
+        chosen_key = (
+            summary.get("arxiv") or summary.get("paper") or ""
+        ).strip().lower()
+        if artifact and chosen_key and chosen_key not in seen_candidates:
+            seen_candidates.add(chosen_key)
+            agg["candidates"].append({
+                "title": (summary.get("paper") or "")[:120],
+                "outcome": f"chosen → {status}",
+            })
+        for r in summary.get("selection_rejected") or []:
+            key = (
+                (r.get("arxiv_id") or "") or (r.get("title") or "")
+            ).strip().lower()
+            if not key or key in seen_candidates:
+                continue
+            seen_candidates.add(key)
+            agg["candidates"].append({
+                "title": (r.get("title") or "")[:120],
+                "outcome": f"rejected — {(r.get('reason') or '')[:160]}",
+            })
+    if len(agg["candidates"]) > 60:
+        log.info(f"  weekly: candidate corpus capped at 60 "
+                 f"(of {len(agg['candidates'])} distinct)")
+        agg["candidates"] = agg["candidates"][:60]
     return agg
 
 
 _WEEKLY_NARRATIVE_PROMPT_TEMPLATE = """\
-You are drafting the interpretive sections of Outrider's weekly summary
-for the repository __REPO__. Everything below is the week's aggregated
-run data plus the open Outrider Issues awaiting maintainer review. Your
-output supplements the data tables — do NOT restate them.
+You are drafting the interpretive sections of Outrider's weekly digest
+for the repository __REPO__. Below: the week's aggregated run data
+(including the distinct candidate papers the selection pass saw), the
+open Outrider artifacts awaiting maintainer review, and — when present —
+last week's digest. Your output supplements the data sections; do NOT
+restate them.
 
 Aggregated run data (JSON)
 --------------------------
 __AGG_JSON__
 
-Open Outrider Issues (number, title, body excerpt)
---------------------------------------------------
-__OPEN_ISSUES__
+Open Outrider artifacts awaiting review (number, title, body excerpt)
+---------------------------------------------------------------------
+__OPEN_ITEMS__
+
+Last week's digest (excerpt; may be empty)
+------------------------------------------
+__PRIOR_DIGEST__
 
 Produce strictly this JSON object (no prose wrapper):
 {
   "verdict_bullets": ["...", ...],
   "refine_themes": [{"theme": "...", "queries": N, "hit_rate": "..."}, ...],
   "patterns": ["...", ...],
-  "next_actions": {"<issue number>": "<one-line next action>", ...}
+  "research_trends": ["...", ...],
+  "next_actions": {"<artifact number>": "<short next action>", ...}
 }
 
+Style — every string is a terse fragment, NOT a full sentence. No
+trailing periods. The reader is skimming; distill each point to its
+essence.
+
 Rules:
-- verdict_bullets: 2-4 bullets summarizing what the selection pass did
-  this week (what it anchored on, what it rejected and why). Do not
-  paraphrase any verbatim reasoning quote — that is rendered separately.
-- refine_themes: cluster the refine queries into themes with a per-theme
-  query count and a one-phrase hit-rate assessment. Empty list if there
-  were no refine queries.
-- patterns: 3-5 entries. Each MUST lead with a noun, and each MUST end
-  with a concrete maintainer action. This is the only opinionated
-  section of the summary — interpretation, not data.
-- next_actions: for each open Issue where the body makes the next step
+- verdict_bullets: 2-3 fragments on what the selection pass did this
+  week — what it anchored on, what it rejected and why. Verbatim
+  reasoning quotes are rendered separately; never paraphrase them.
+  Quotes exist only for verification-skip runs, so their absence in a
+  week with PR/Issue outcomes is normal — NOT a wiring failure.
+- refine_themes: cluster the refine queries into themes; per-theme query
+  count + one-phrase hit-rate assessment. Empty list when no queries.
+- patterns: 3-5 entries about operating Outrider better. Format:
+  "**Noun phrase** — evidence → concrete maintainer action". Evidence
+  MUST cite numbers from the data.
+- research_trends: 2-4 entries on the research themes moving through
+  this repo's recommendation stream (NOT arxiv at large — the pool is
+  shaped by this repo's interest). Format: "**Theme** — N of M
+  candidates, what it means for this repo". Only claim a trend with
+  >= 2 supporting candidates; always cite the counts. Use last week's
+  digest for week-over-week deltas only when it actually supports the
+  claim. Do NOT duplicate content between patterns and research_trends:
+  patterns = operate the tool, research_trends = the field.
+- next_actions: for each open artifact whose body makes the next step
   obvious (a flag to flip, a license to re-check, a question to answer),
-  a one-line action. Omit Issues where no clear next action exists.
+  a short action fragment. Omit artifacts with no clear next action.
 """
 
 
 def _draft_weekly_narrative(
-    agg: dict, open_issues: list[dict],
+    agg: dict, open_items: list[dict], prior_digest: str = "",
 ) -> dict | None:
     """One Claude call drafting the interpretive sections. None on any
     failure — the digest degrades to data-only, never blocks the post."""
-    issues_block = "\n".join(
+    items_block = "\n".join(
         f"#{it.get('number')} {it.get('title', '')}\n"
         f"  {' '.join((it.get('body') or '').split())[:1200]}"
-        for it in open_issues
+        for it in open_items
     ) or "(none open)"
     prompt = (
         _WEEKLY_NARRATIVE_PROMPT_TEMPLATE
         .replace("__REPO__", agg.get("repo", ""))
         .replace("__AGG_JSON__", json.dumps(agg, indent=2)[:20000])
-        .replace("__OPEN_ISSUES__", issues_block)
+        .replace("__OPEN_ITEMS__", items_block)
+        .replace("__PRIOR_DIGEST__", prior_digest or "(no prior digest)")
     )
     timeout_s = int(os.environ.get("REMYX_WEEKLY_TIMEOUT_S", "180"))
     max_turns = int(os.environ.get("REMYX_WEEKLY_MAX_TURNS", "3"))
@@ -5808,58 +5928,167 @@ def _draft_weekly_narrative(
     return data
 
 
+def _short_artifact_title(title: str, max_len: int = 70) -> str:
+    """Checklist-friendly title: prefix stripped, word-boundary truncated."""
+    t = (title or "").strip()
+    if t.startswith(PR_TITLE_PREFIX):
+        t = t[len(PR_TITLE_PREFIX):].strip()
+    if len(t) > max_len:
+        t = t[:max_len].rsplit(" ", 1)[0].rstrip(",;:·-") + "…"
+    return t
+
+
+def _month_day(iso: str) -> str:
+    """``2026-06-10T…`` → ``Jun 10``; ``""`` when unparseable."""
+    try:
+        d = dt.datetime.fromisoformat((iso or "").replace("Z", "+00:00"))
+    except ValueError:
+        return ""
+    return f"{d.strftime('%b')} {d.day}"
+
+
+def _drafted_fragments(drafted: dict, key: str) -> list[str]:
+    """Non-empty string fragments under ``key``, or [] for any bad shape."""
+    raw = drafted.get(key)
+    if not isinstance(raw, list):
+        return []
+    return [str(x).strip() for x in raw if str(x).strip()]
+
+
+def _group_run_rows_by_date(rows: list[dict]) -> list[tuple[str, str, str]]:
+    """Collapse per-run rows into one table row per date.
+
+    A daily-cron week produces 7+ near-identical rows; one row per date
+    with per-status counts (``\\`error\\` ×3``) keeps the collapsed run
+    log skimmable without dropping the audit trail. Output cell joins
+    the date's artifact links, ``—`` when none.
+    """
+    by_date: dict[str, dict] = {}
+    order: list[str] = []
+    for row in rows:
+        date = row["date"][5:] if len(row["date"]) == 10 else row["date"]
+        if date not in by_date:
+            by_date[date] = {"order": [], "counts": {}, "outputs": []}
+            order.append(date)
+        g = by_date[date]
+        s = row["status"]
+        if s not in g["counts"]:
+            g["order"].append(s)
+        g["counts"][s] = g["counts"].get(s, 0) + 1
+        out = row.get("output") or ""
+        if out and out not in ("No artifact", "—"):
+            g["outputs"].append(out)
+    grouped = []
+    for date in order:
+        g = by_date[date]
+        status_cell = " · ".join(
+            f"`{s}`" + (f" ×{g['counts'][s]}" if g["counts"][s] > 1 else "")
+            for s in g["order"]
+        )
+        grouped.append((date, status_cell, " · ".join(g["outputs"]) or "—"))
+    return grouped
+
+
 def _compose_weekly_markdown(
     window_start: "dt.datetime",
     window_end: "dt.datetime",
     agg: dict,
-    open_issues: list[dict],
+    open_items: list[dict],
     drafted: dict | None,
 ) -> str:
-    """Assemble the Discussion-comment body. Data sections are mechanical;
-    the drafted sections slot in when the Claude call succeeded. The
-    verbatim selection-reasoning quote is copied as-is into a blockquote —
-    never paraphrased (it's the most maintainer-impactful content)."""
+    """Assemble the Discussion-comment body.
+
+    Layout: interpretive sections lead — patterns, then research-stream
+    trends — followed by a checkable review list of open artifacts; the
+    mechanical data sections support below, with the full run log
+    collapsed so a long week doesn't turn the digest into a scroll.
+    Everything renders as fragments, not sentences. The verbatim
+    selection-reasoning quote is copied as-is into a blockquote — never
+    paraphrased (it's the most maintainer-impactful content). Drafted
+    sections slot in when the narrative call succeeded; the digest is
+    data-only otherwise.
+    """
     drafted = drafted or {}
     lines: list[str] = []
     lines.append(
-        f"## Outrider weekly summary — "
-        f"{window_start.strftime('%Y-%m-%d')} to "
-        f"{window_end.strftime('%Y-%m-%d')}"
+        f"## 🧭 Outrider weekly — "
+        f"{window_start.strftime('%b')} {window_start.day} → "
+        f"{window_end.strftime('%b')} {window_end.day}"
     )
     lines.append("")
-    # Exact when every run's log parsed; explicitly partial otherwise —
-    # never report an estimate as exact.
-    cost_phrase = f"${agg['verified_cost']:.2f}"
+
+    # Stat line — zero segments are dropped; cost is exact when every
+    # run's log parsed and explicitly partial otherwise (never report an
+    # estimate as exact).
+    segments = [f"**{agg['n_runs']} runs**"]
+    if agg.get("n_artifacts"):
+        statuses = set(agg.get("artifact_statuses") or {})
+        plural = agg["n_artifacts"] != 1
+        if statuses == {"pr_opened_draft"}:
+            label = "draft PRs" if plural else "draft PR"
+        elif statuses and all(s.startswith("pr_opened") for s in statuses):
+            label = "PRs" if plural else "PR"
+        elif statuses and all(s.startswith("issue_opened") for s in statuses):
+            label = "Issues" if plural else "Issue"
+        else:
+            label = "artifacts" if plural else "artifact"
+        segments.append(f"✅ {agg['n_artifacts']} {label}")
+    if agg.get("n_skips"):
+        n = agg["n_skips"]
+        segments.append(f"⏭️ {n} skip{'s' if n != 1 else ''}")
+    if agg.get("n_errors"):
+        n = agg["n_errors"]
+        segments.append(f"❌ {n} error{'s' if n != 1 else ''}")
+    cost_seg = f"💸 ${agg['verified_cost']:.2f} verified"
     if agg["unverified_runs"]:
-        cost_phrase += (
-            f" verified ({agg['unverified_runs']} run(s) outside log "
-            f"retention not counted)"
+        cost_seg += (
+            f" · {agg['unverified_runs']} run(s) outside log retention "
+            f"not counted"
         )
-    lines.append(
-        f"**Runs this week**: {agg['n_runs']} "
-        f"({agg['n_success']} successful, {agg['n_failed']} failed). "
-        f"Claude spend: {cost_phrase}."
-    )
+    segments.append(cost_seg)
+    lines.append(" · ".join(segments))
 
-    if agg["rows"]:
-        lines += ["", "### Outcomes", "", "| Date | Status | Output |",
-                  "|---|---|---|"]
-        for row in agg["rows"]:
-            lines.append(
-                f"| {row['date']} | `{row['status']}` | {row['output']} |"
+    patterns = _drafted_fragments(drafted, "patterns")
+    if patterns:
+        lines += ["", "### ⚡ Patterns worth your attention", ""]
+        lines += [f"{i}. {p}" for i, p in enumerate(patterns, start=1)]
+
+    trends = _drafted_fragments(drafted, "research_trends")
+    if trends:
+        lines += ["", "### 📈 In the research stream", ""]
+        lines += [f"- {t}" for t in trends]
+
+    if open_items:
+        next_actions = drafted.get("next_actions")
+        if not isinstance(next_actions, dict):
+            next_actions = {}
+        lines += ["", "### 📥 Awaiting your review", ""]
+        for it in open_items:
+            number = it.get("number")
+            url = it.get("html_url") or ""
+            entry = (
+                f"- [ ] [#{number}]({url}) "
+                f"{_short_artifact_title(it.get('title') or '')}"
             )
+            opened = _month_day(it.get("created_at") or "")
+            if opened:
+                entry += f" · {opened}"
+            action = str(next_actions.get(str(number), "") or "").strip()
+            if action:
+                entry += f" — next: {action}"
+            lines.append(entry)
 
-    lines += ["", "### Selection-pass verdicts", ""]
-    bullets = drafted.get("verdict_bullets") or []
-    if isinstance(bullets, list) and bullets:
-        lines += [f"- {b}" for b in bullets if str(b).strip()]
+    lines += ["", "### 🔍 Selection-pass verdicts", ""]
+    bullets = _drafted_fragments(drafted, "verdict_bullets")
+    if bullets:
+        lines += [f"- {b}" for b in bullets]
     elif agg["status_counts"]:
         lines += [
             f"- {n} run(s) ended `{s}`"
             for s, n in sorted(agg["status_counts"].items())
         ]
     else:
-        lines.append("- No completed Outrider runs in this window.")
+        lines.append("- No completed Outrider runs in this window")
     if agg["selection_quotes"]:
         # Verbatim, most recent first — the rejection reasoning is the
         # most maintainer-impactful content; never paraphrase it.
@@ -5868,18 +6097,19 @@ def _compose_weekly_markdown(
             lines.append(f"> {quote_line}")
 
     themes = drafted.get("refine_themes") or []
-    if isinstance(themes, list) and themes:
-        lines += ["", "### Refine-query themes the audit pass explored", "",
-                  "| Theme | Queries | Hit rate |", "|---|---|---|"]
+    if isinstance(themes, list) and any(isinstance(t, dict) for t in themes):
+        lines += ["", "### 🔭 Refine-query themes the audit pass explored", ""]
         for t in themes:
             if not isinstance(t, dict):
                 continue
+            n_q = t.get("queries", "")
+            unit = "query" if str(n_q) == "1" else "queries"
             lines.append(
-                f"| {t.get('theme', '')} | {t.get('queries', '')} "
-                f"| {t.get('hit_rate', '')} |"
+                f"- {t.get('theme', '')} — {n_q} {unit} "
+                f"· {t.get('hit_rate', '')}"
             )
     elif agg["refine_queries"]:
-        lines += ["", "### Refine queries the audit pass explored", ""]
+        lines += ["", "### 🔭 Refine queries the audit pass explored", ""]
         seen_q: set[str] = set()
         for q in agg["refine_queries"]:
             if q not in seen_q:
@@ -5887,43 +6117,28 @@ def _compose_weekly_markdown(
                 lines.append(f"- `{q}`")
 
     if agg["license_class_counts"]:
-        lines += ["", "### License gate findings", "",
-                  "| Class | Count |", "|---|---|"]
-        counts = agg["license_class_counts"]
-        ordered = [k for k in _LICENSE_CLASS_ORDER if counts.get(k)]
-        ordered += [k for k in counts if k not in _LICENSE_CLASS_ORDER]
-        for cls in ordered:
-            lines.append(f"| {cls} | {counts[cls]} |")
-
-    if open_issues:
-        next_actions = drafted.get("next_actions") or {}
-        lines += ["", "### Open Outrider Issues awaiting maintainer review",
-                  "", "| Issue | Title | Next action |", "|---|---|---|"]
-        for it in open_issues:
-            number = it.get("number")
-            title = (it.get("title") or "").replace("|", "\\|")[:100]
-            url = it.get("html_url") or ""
-            action = "—"
-            if isinstance(next_actions, dict):
-                action = str(
-                    next_actions.get(str(number), "—") or "—"
-                ).replace("|", "\\|")
-            lines.append(f"| [#{number}]({url}) | {title} | {action} |")
-
-    patterns = drafted.get("patterns") or []
-    if isinstance(patterns, list) and patterns:
-        lines += ["", "### Patterns worth attention", ""]
         lines += [
-            f"{i}. {p}" for i, p in enumerate(
-                (str(p).strip() for p in patterns if str(p).strip()), start=1,
-            )
+            "", "### ⚖️ License gate findings", "",
+            f"`{_format_license_class_counts(agg['license_class_counts'])}`",
         ]
+
+    if agg["rows"]:
+        lines += [
+            "", "<details>",
+            f"<summary>📋 Full run log ({agg['n_runs']} "
+            f"run{'s' if agg['n_runs'] != 1 else ''})</summary>", "",
+            "| Date | Status | Output |", "|---|---|---|",
+        ]
+        for date, status_cell, output_cell in _group_run_rows_by_date(
+            agg["rows"]
+        ):
+            lines.append(f"| {date} | {status_cell} | {output_cell} |")
+        lines += ["", "</details>"]
 
     lines += [
         "", "---", "",
-        "_Generated by Outrider's weekly-summary mode. Data source: "
-        "GitHub Actions API + per-run logs; runs whose logs aged out of "
-        "retention are listed without details._",
+        "<sub>Outrider weekly-summary · data: GitHub Actions API + run "
+        "logs · out-of-retention runs listed without details</sub>",
     ]
     return "\n".join(lines)
 
@@ -5947,19 +6162,26 @@ def run_weekly_summary(target: Target) -> dict:
     log.info(f"  → weekly summary over {target.repo} "
              f"({window_start.date()} → {window_end.date()})")
     entries = _fetch_week_runs(target, window_start)
-    open_issues = _remyx_issues(target, state="open")
+    # Review checklist = open Outrider PRs + Issues, newest first — an
+    # idle draft PR is as actionable as an open Issue.
+    open_items = sorted(
+        _remyx_open_prs(target) + _remyx_issues(target, state="open"),
+        key=lambda it: it.get("created_at") or "",
+        reverse=True,
+    )
     agg = _aggregate_week(entries)
     agg["repo"] = target.repo
-    drafted = _draft_weekly_narrative(agg, open_issues)
+    prior_digest = _fetch_prior_digest_excerpt(discussion_id)
+    drafted = _draft_weekly_narrative(agg, open_items, prior_digest)
     body = _compose_weekly_markdown(
-        window_start, window_end, agg, open_issues, drafted,
+        window_start, window_end, agg, open_items, drafted,
     )
     url = _post_discussion_comment(discussion_id, body)
     result.update({
         "status": "weekly_summary_posted",
         "discussion_comment_url": url,
         "runs_aggregated": len(entries),
-        "open_issues_listed": len(open_issues),
+        "open_items_listed": len(open_items),
         "narrative_drafted": drafted is not None,
     })
     log.info(f"  ✓ weekly_summary_posted: {url}")

--- a/tests/test_axis_split.py
+++ b/tests/test_axis_split.py
@@ -1,0 +1,215 @@
+"""Tests for engineering-vs-license axis split.
+
+An A++ engineering analysis fused with a wrong license flag meant a reader 
+could miss either verdict. The fix renders the two as adjacent, independent 
+sections in both the downgrade-Issue body and the step summary:
+
+  - `_render_engineering_section` renders shape / contract / migration
+    (or the extension-shape fields) and returns "" with no signal
+  - `_open_downgrade_issue` places the engineering section immediately
+    above the license section
+  - `_record_verdict_fields` threads the chosen candidate's license axis
+    onto the result, skipping when enrichment never ran
+  - Step summary renders "Engineering verdict" + "License verdict"
+    adjacently, each degrading silently when its fields are absent
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Recommendation, Target  # noqa: E402
+
+
+def _rec(**kw):
+    base = dict(
+        paper_title="Sample Paper", arxiv_id="2601.00001", tier="high",
+        z_score=0.0, spec_md="", paper_abstract="abstract",
+        domain_summary="", raw_paper_md="",
+        relevance_score=0.92,
+        reasoning="paper anchors on the depth stage",
+        suggested_experiment="swap the backbone",
+        interest_name="ExampleInterest",
+    )
+    base.update(kw)
+    return Recommendation(**base)
+
+
+def _capture_issue(monkeypatch):
+    captured: dict = {}
+
+    def fake_open_issue(target, title, body, **kw):
+        captured["title"] = title
+        captured["body"] = body
+        captured["kwargs"] = kw
+        return "https://github.com/example/repo/issues/999"
+
+    monkeypatch.setattr(run, "open_issue", fake_open_issue)
+    return captured
+
+
+def _capture_summary(result, tmp_path, monkeypatch) -> str:
+    summary_file = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+    run._write_step_summary(result)
+    return summary_file.read_text()
+
+
+# ─── _render_engineering_section ──────────────────────────────────────────
+
+
+def test_engineering_section_renders_contract_fields():
+    out = run._render_engineering_section(
+        integration_shape="drop-in replacement",
+        contract_match="run(PIL) -> (depth, focal_px) preserved",
+        migration_cost="depth.py + requirements.txt",
+    )
+    assert out.startswith("## Engineering verdict")
+    assert "- **Integration shape**: drop-in replacement" in out
+    assert "- **Contract match**: run(PIL) -> (depth, focal_px) preserved" in out
+    assert "- **Migration cost**: depth.py + requirements.txt" in out
+
+
+def test_engineering_section_renders_extension_fields():
+    out = run._render_engineering_section(
+        integration_shape="out-of-pool extension (new capability)",
+        team_direction_signal="RFC #84 names this capability",
+        proposed_call_site="pipeline/localize.py",
+    )
+    assert "- **Team-direction signal**: RFC #84 names this capability" in out
+    assert "- **Proposed call site**: pipeline/localize.py" in out
+    assert "Contract match" not in out
+
+
+def test_engineering_section_empty_without_signal():
+    assert run._render_engineering_section() == ""
+    assert run._render_engineering_section(
+        integration_shape="  ", contract_match="",
+    ) == ""
+
+
+# ─── _open_downgrade_issue placement ──────────────────────────────────────
+
+
+def test_downgrade_body_engineering_adjacent_above_license(monkeypatch):
+    captured = _capture_issue(monkeypatch)
+    run._open_downgrade_issue(
+        Target(repo="example/repo", interest_id="iid"),
+        _rec(paper_license="CC-BY-NC-4.0", license_class="nc",
+             license_compat=0.10,
+             paper_github_url="https://github.com/x/y"),
+        reason="r", detail="d",
+        engineering_section=run._render_engineering_section(
+            integration_shape="drop-in replacement",
+            contract_match="contract preserved",
+            migration_cost="two files",
+        ),
+    )
+    body = captured["body"]
+    eng_idx = body.index("## Engineering verdict")
+    lic_idx = body.index("## License & code availability")
+    assert eng_idx < lic_idx
+    # Adjacent: no other section heading between the two verdicts.
+    between = body[eng_idx:lic_idx]
+    assert between.count("\n## ") == 0
+
+
+def test_downgrade_body_omits_engineering_when_empty(monkeypatch):
+    captured = _capture_issue(monkeypatch)
+    run._open_downgrade_issue(
+        Target(repo="example/repo", interest_id="iid"), _rec(),
+        reason="r", detail="d",
+    )
+    assert "## Engineering verdict" not in captured["body"]
+
+
+# ─── _record_verdict_fields ───────────────────────────────────────────────
+
+
+def test_record_verdict_fields_threads_license_axis():
+    result: dict = {}
+    run._record_verdict_fields(result, _rec(
+        paper_license="CC-BY-NC-4.0", license_class="nc",
+        license_compat=0.10,
+        paper_github_url="https://github.com/x/y",
+    ))
+    assert result == {
+        "license_class": "nc",
+        "license_compat": 0.10,
+        "paper_license": "CC-BY-NC-4.0",
+    }
+
+
+def test_record_verdict_fields_skips_when_enrichment_never_ran():
+    result: dict = {}
+    run._record_verdict_fields(result, _rec())  # all defaults
+    assert result == {}
+
+
+# ─── Step summary: adjacent verdict blocks ────────────────────────────────
+
+
+def test_summary_renders_both_verdicts_adjacent(tmp_path, monkeypatch):
+    out = _capture_summary({
+        "status": "issue_opened_substitution",
+        "paper": "Sample Paper",
+        "arxiv": "2601.00001",
+        "selection_integration_shape": "replacement",
+        "selection_contract_match": "contract preserved",
+        "selection_migration_cost": "two files",
+        "license_class": "nc",
+        "license_compat": 0.10,
+        "paper_license": "CC-BY-NC-4.0",
+    }, tmp_path, monkeypatch)
+    eng_idx = out.index("**Engineering verdict**")
+    lic_idx = out.index("**License verdict**")
+    assert eng_idx < lic_idx
+    assert "- **Contract match**: contract preserved" in out
+    assert "🔴 `CC-BY-NC-4.0` (class: `nc`, compat: 0.10)" in out
+
+
+def test_summary_license_verdict_alone(tmp_path, monkeypatch):
+    """License axis renders even when selection produced no engineering
+    fields (e.g. plain addition-shape PR run)."""
+    out = _capture_summary({
+        "status": "pr_opened_draft",
+        "license_class": "permissive",
+        "license_compat": 1.0,
+        "paper_license": "Apache-2.0",
+    }, tmp_path, monkeypatch)
+    assert "**License verdict**: 🟢 `Apache-2.0`" in out
+    assert "Engineering verdict" not in out
+
+
+def test_summary_engineering_verdict_extension_fields(tmp_path, monkeypatch):
+    out = _capture_summary({
+        "status": "issue_opened_substitution",
+        "selection_integration_shape": "extension",
+        "selection_team_direction_signal": "RFC #84",
+        "selection_proposed_call_site": "pipeline/localize.py",
+    }, tmp_path, monkeypatch)
+    assert "- **Team-direction signal**: RFC #84" in out
+    assert "- **Proposed call site**: pipeline/localize.py" in out
+
+
+def test_summary_omits_verdicts_without_fields(tmp_path, monkeypatch):
+    out = _capture_summary({
+        "status": "pr_opened_draft",
+        "paper": "x", "arxiv": "2601.00001",
+    }, tmp_path, monkeypatch)
+    assert "Engineering verdict" not in out
+    assert "License verdict" not in out
+
+
+def test_summary_shape_alone_does_not_render_engineering(tmp_path, monkeypatch):
+    """`selection_integration_shape` is set on every selection run; the
+    Engineering verdict block needs at least one substantive field
+    (contract / migration / extension signals) to be worth a section."""
+    out = _capture_summary({
+        "status": "pr_opened_draft",
+        "selection_integration_shape": "addition",
+    }, tmp_path, monkeypatch)
+    assert "Engineering verdict" not in out

--- a/tests/test_bot_token_default.py
+++ b/tests/test_bot_token_default.py
@@ -1,0 +1,186 @@
+"""Tests for default remyx[bot] identity via the self-minted token:
+
+  - `_github_token` preference: explicit `github-token` input > the
+    self-minted remyx[bot] installation token > GITHUB_TOKEN
+  - `_mint_bot_token` mints with REMYX_API_KEY + TARGET_REPO, caches a
+    single attempt per run (success or failure), normalizes URL-shaped
+    TARGET_REPO, and degrades to "" without the API key
+  - `_post_discussion_comment` retries with GITHUB_TOKEN when the active
+    (bot) token can't post Discussions, and re-raises everything else
+
+Run with: pytest tests/ -q
+"""
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+def _clean_env(monkeypatch, **env):
+    for var in ("INPUT_GITHUB_TOKEN", "GITHUB_TOKEN", "REMYX_API_KEY",
+                "REMYXAI_API_KEY", "TARGET_REPO"):
+        monkeypatch.delenv(var, raising=False)
+    for var, value in env.items():
+        monkeypatch.setenv(var, value)
+    run._BOT_TOKEN.update(attempted=False, token="", permissions={})
+
+
+class _FakeMintResponse:
+    def __init__(self, payload: dict):
+        self._raw = json.dumps(payload).encode()
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+# ─── _github_token preference order ───────────────────────────────────────
+
+
+def test_explicit_input_token_wins(monkeypatch):
+    _clean_env(
+        monkeypatch,
+        INPUT_GITHUB_TOKEN="pat-explicit",
+        GITHUB_TOKEN="builtin",
+        REMYX_API_KEY="rmxa_x",
+        TARGET_REPO="owner/name",
+    )
+    monkeypatch.setattr(run, "_mint_bot_token", lambda: pytest.fail(
+        "explicit input token must short-circuit the self-mint"
+    ))
+    assert run._github_token() == "pat-explicit"
+
+
+def test_self_minted_token_preferred_over_builtin(monkeypatch):
+    _clean_env(
+        monkeypatch,
+        GITHUB_TOKEN="builtin",
+        REMYX_API_KEY="rmxa_x",
+        TARGET_REPO="owner/name",
+    )
+    seen = {}
+
+    def fake_urlopen(req, timeout=15):
+        seen["url"] = req.full_url
+        seen["body"] = json.loads(req.data.decode())
+        seen["auth"] = req.headers.get("Authorization")
+        return _FakeMintResponse({
+            "token": "ghs_bot", "expires_at": "x",
+            "permissions": {"contents": "write"},
+        })
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert run._github_token() == "ghs_bot"
+    assert seen["url"].endswith("/api/v1.0/github/installation-token")
+    assert seen["body"] == {"repo": "owner/name"}
+    assert seen["auth"] == "Bearer rmxa_x"
+    assert run._BOT_TOKEN["permissions"] == {"contents": "write"}
+
+
+def test_falls_back_to_builtin_when_mint_fails(monkeypatch):
+    _clean_env(
+        monkeypatch,
+        GITHUB_TOKEN="builtin",
+        REMYX_API_KEY="rmxa_x",
+        TARGET_REPO="owner/name",
+    )
+    calls = {"n": 0}
+
+    def boom(req, timeout=15):
+        calls["n"] += 1
+        raise urllib.error.URLError("engine down")
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    assert run._github_token() == "builtin"
+    # One attempt per run — the failure is cached, not retried per call.
+    assert run._github_token() == "builtin"
+    assert calls["n"] == 1
+
+
+def test_mint_skipped_without_api_key(monkeypatch):
+    _clean_env(monkeypatch, GITHUB_TOKEN="builtin", TARGET_REPO="owner/name")
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: pytest.fail(
+        "must not call the engine without REMYX_API_KEY"
+    ))
+    assert run._github_token() == "builtin"
+
+
+def test_mint_normalizes_url_shaped_target_repo(monkeypatch):
+    _clean_env(
+        monkeypatch,
+        GITHUB_TOKEN="builtin",
+        REMYX_API_KEY="rmxa_x",
+        TARGET_REPO="https://github.com/owner/name/",
+    )
+    seen = {}
+
+    def fake_urlopen(req, timeout=15):
+        seen["body"] = json.loads(req.data.decode())
+        return _FakeMintResponse({"token": "ghs_bot", "permissions": {}})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert run._github_token() == "ghs_bot"
+    assert seen["body"] == {"repo": "owner/name"}
+
+
+# ─── Discussion-post permission fallback ──────────────────────────────────
+
+
+def test_discussion_post_falls_back_when_bot_lacks_discussions(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "builtin")
+    monkeypatch.setattr(run, "_github_token", lambda: "ghs_bot")
+    calls = []
+
+    def fake_graphql(query, variables=None, token=None):
+        calls.append(token)
+        if token is None:
+            raise RuntimeError(
+                "GitHub GraphQL errors: [{'type': 'FORBIDDEN', 'message': "
+                "'Resource not accessible by integration'}]"
+            )
+        return {"addDiscussionComment": {"comment": {"url": "https://x/#c1"}}}
+
+    monkeypatch.setattr(run, "gh_graphql", fake_graphql)
+    url = run._post_discussion_comment("D_node", "body")
+    assert url == "https://x/#c1"
+    assert calls == [None, "builtin"]
+
+
+def test_discussion_post_reraises_non_permission_errors(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "builtin")
+    monkeypatch.setattr(run, "_github_token", lambda: "ghs_bot")
+
+    def fake_graphql(query, variables=None, token=None):
+        raise RuntimeError("GitHub GraphQL → HTTP 502: bad gateway")
+
+    monkeypatch.setattr(run, "gh_graphql", fake_graphql)
+    with pytest.raises(RuntimeError, match="502"):
+        run._post_discussion_comment("D_node", "body")
+
+
+def test_discussion_post_no_fallback_when_already_on_builtin(monkeypatch):
+    """When the active token IS GITHUB_TOKEN (no bot token minted), a
+    permission error is terminal — retrying with the same token would
+    just fail again."""
+    monkeypatch.setenv("GITHUB_TOKEN", "builtin")
+    monkeypatch.setattr(run, "_github_token", lambda: "builtin")
+
+    def fake_graphql(query, variables=None, token=None):
+        raise RuntimeError(
+            "GitHub GraphQL errors: 'Resource not accessible by integration'"
+        )
+
+    monkeypatch.setattr(run, "gh_graphql", fake_graphql)
+    with pytest.raises(RuntimeError, match="Resource not accessible"):
+        run._post_discussion_comment("D_node", "body")

--- a/tests/test_pool_telemetry.py
+++ b/tests/test_pool_telemetry.py
@@ -1,0 +1,160 @@
+"""Tests for pool-composition + license-distribution telemetry:
+
+  - `_pool_composition` counts broad vs refine candidates via the
+    per-candidate `refine_query` provenance marker
+  - `_asset_to_recommendation` stamps that marker on refine candidates
+  - `_license_class_counts` tallies the pool's license classes
+  - `_format_license_class_counts` renders one line in canonical class
+    order, appends unexpected classes, omits zero counts
+  - Step summary renders the "Candidate pool" + "License gate (pool)"
+    lines when the result fields are populated and degrades silently
+    when they're absent
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Recommendation  # noqa: E402
+
+
+def _rec(**kw):
+    base = dict(
+        paper_title="Sample Paper", arxiv_id="2601.00001", tier="high",
+        z_score=0.0, spec_md="", paper_abstract="", domain_summary="",
+        raw_paper_md="",
+    )
+    base.update(kw)
+    return Recommendation(**base)
+
+
+def _capture(result, tmp_path, monkeypatch) -> str:
+    summary_file = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+    run._write_step_summary(result)
+    return summary_file.read_text()
+
+
+# ─── _pool_composition ────────────────────────────────────────────────────
+
+
+def test_pool_composition_counts_by_refine_marker():
+    pool = [
+        _rec(arxiv_id="2601.00001"),
+        _rec(arxiv_id="2601.00002"),
+        _rec(arxiv_id="2601.00003", refine_query="depth estimation successor"),
+    ]
+    assert run._pool_composition(pool) == (2, 1)
+
+
+def test_pool_composition_empty_pool():
+    assert run._pool_composition([]) == (0, 0)
+
+
+def test_asset_to_recommendation_stamps_refine_query():
+    rec = run._asset_to_recommendation(
+        {"arxiv_id": "2602.11111", "title": "T", "abstract": "A"},
+        refine_query="single pass joint depth intrinsics",
+        fallback_interest_name="i", interest_context="", experiment_history="",
+    )
+    assert rec.refine_query == "single pass joint depth intrinsics"
+
+
+def test_broad_candidates_default_to_empty_refine_query():
+    assert _rec().refine_query == ""
+
+
+# ─── _license_class_counts / _format_license_class_counts ────────────────
+
+
+def test_license_class_counts_tallies_pool():
+    pool = [
+        _rec(license_class="permissive"),
+        _rec(license_class="permissive"),
+        _rec(license_class="nc"),
+        _rec(),  # default "unknown"
+    ]
+    assert run._license_class_counts(pool) == {
+        "permissive": 2, "nc": 1, "unknown": 1,
+    }
+
+
+def test_format_counts_canonical_order():
+    line = run._format_license_class_counts(
+        {"missing": 30, "permissive": 4, "nc": 1}
+    )
+    # permissive before nc before missing, regardless of dict order.
+    assert line == "permissive: 4 · nc: 1 · missing: 30"
+
+
+def test_format_counts_appends_unexpected_class():
+    line = run._format_license_class_counts({"permissive": 1, "weird": 2})
+    assert line.startswith("permissive: 1")
+    assert "weird: 2" in line
+
+
+def test_format_counts_includes_no_code_link():
+    # `no-code-link` dominated real pools 
+    line = run._format_license_class_counts({"no-code-link": 7})
+    assert line == "no-code-link: 7"
+
+
+def test_format_counts_empty():
+    assert run._format_license_class_counts({}) == "(no candidates)"
+
+
+# ─── Step summary rendering ───────────────────────────────────────────────
+
+
+def test_summary_renders_pool_composition_line(tmp_path, monkeypatch):
+    out = _capture({
+        "status": "skipped_by_selection_verification",
+        "broad_pool_size": 25,
+        "refine_pool_size": 11,
+    }, tmp_path, monkeypatch)
+    assert (
+        "**Candidate pool**: 25 broad + 11 refine candidate(s) "
+        "considered (after dedup)"
+    ) in out
+
+
+def test_summary_omits_pool_line_when_fields_absent(tmp_path, monkeypatch):
+    out = _capture({"status": "pr_opened_draft"}, tmp_path, monkeypatch)
+    assert "Candidate pool" not in out
+
+
+def test_summary_omits_pool_line_when_pool_empty(tmp_path, monkeypatch):
+    out = _capture({
+        "status": "error", "broad_pool_size": 0, "refine_pool_size": 0,
+    }, tmp_path, monkeypatch)
+    assert "Candidate pool" not in out
+
+
+def test_summary_renders_license_distribution_line(tmp_path, monkeypatch):
+    out = _capture({
+        "status": "pr_opened_draft",
+        "license_class_counts": {"permissive": 4, "missing": 30, "nc": 1},
+    }, tmp_path, monkeypatch)
+    assert (
+        "**License gate (pool)**: permissive: 4 · nc: 1 · missing: 30"
+    ) in out
+
+
+def test_summary_omits_license_distribution_when_absent(tmp_path, monkeypatch):
+    out = _capture({"status": "pr_opened_draft"}, tmp_path, monkeypatch)
+    assert "License gate (pool)" not in out
+
+
+def test_summary_pool_lines_render_above_cost(tmp_path, monkeypatch):
+    out = _capture({
+        "status": "skipped_by_selection_verification",
+        "broad_pool_size": 3,
+        "refine_pool_size": 1,
+        "license_class_counts": {"permissive": 4},
+        "cost_usd": 1.0,
+    }, tmp_path, monkeypatch)
+    assert out.index("Candidate pool") < out.index("Cost & tokens")
+    assert out.index("License gate (pool)") < out.index("Cost & tokens")

--- a/tests/test_weekly_summary.py
+++ b/tests/test_weekly_summary.py
@@ -205,13 +205,31 @@ def test_aggregate_week_sums_and_merges():
 # ─── _compose_weekly_markdown ─────────────────────────────────────────────
 
 
-def _compose(agg=None, open_issues=None, drafted=None):
+def _compose(agg=None, open_items=None, drafted=None):
     agg = agg or run._aggregate_week([_entry(_SUMMARY)])
     start = dt.datetime(2026, 6, 2, tzinfo=dt.timezone.utc)
     end = dt.datetime(2026, 6, 9, tzinfo=dt.timezone.utc)
     return run._compose_weekly_markdown(
-        start, end, agg, open_issues or [], drafted,
+        start, end, agg, open_items or [], drafted,
     )
+
+
+def test_compose_headline_and_stat_line():
+    agg = run._aggregate_week([
+        _entry(_SUMMARY),
+        _entry({
+            "status": "pr_opened_draft",
+            "pr_url": "https://github.com/example/repo/pull/11",
+            "cost_usd": 1.0,
+        }),
+    ])
+    body = _compose(agg=agg)
+    assert body.startswith("## 🧭 Outrider weekly — Jun 2 → Jun 9")
+    stat_line = body.splitlines()[2]
+    assert "**2 runs**" in stat_line
+    assert "✅ 1 draft PR" in stat_line
+    assert "⏭️ 1 skip" in stat_line
+    assert "💸 $2.01 verified" in stat_line
 
 
 def test_compose_preserves_selection_quote_verbatim():
@@ -225,47 +243,158 @@ def test_compose_renders_retention_gap_row():
     assert "outside log retention — details unavailable" in body
 
 
+def test_compose_run_log_collapsed_and_grouped_by_date():
+    agg = run._aggregate_week([
+        _entry({"status": "error", "error": "x"}),
+        _entry({"status": "error", "error": "y"}),
+        _entry({
+            "status": "pr_opened_draft",
+            "pr_url": "https://github.com/example/repo/pull/7",
+        }, created="2026-06-07T14:00:00Z"),
+    ])
+    body = _compose(agg=agg)
+    assert "<summary>📋 Full run log (3 runs)</summary>" in body
+    # Two same-day errors collapse to one cell with a count.
+    assert "| 06-08 | `error` ×2 | — |" in body
+    assert "| 06-07 | `pr_opened_draft` | [#7](https://github.com/example/repo/pull/7) |" in body
+
+
 def test_compose_patterns_only_when_drafted():
     no_draft = _compose(drafted=None)
-    assert "Patterns worth attention" not in no_draft
+    assert "Patterns worth your attention" not in no_draft
     drafted = _compose(drafted={
-        "patterns": ["The dedup gate fired twice — review Issue #87."],
+        "patterns": ["**Dedup gate** — fired twice → review Issue #87"],
     })
-    assert "### Patterns worth attention" in drafted
-    assert "1. The dedup gate fired twice — review Issue #87." in drafted
+    assert "### ⚡ Patterns worth your attention" in drafted
+    assert "1. **Dedup gate** — fired twice → review Issue #87" in drafted
 
 
-def test_compose_open_issue_next_action_column():
+def test_compose_research_stream_only_when_drafted():
+    no_draft = _compose(drafted={"patterns": ["**X** — y → z"]})
+    assert "In the research stream" not in no_draft
+    body = _compose(drafted={
+        "research_trends": [
+            "**Eval-efficiency methods dominate** — 5 of 13 candidates",
+        ],
+    })
+    assert "### 📈 In the research stream" in body
+    assert "- **Eval-efficiency methods dominate** — 5 of 13 candidates" in body
+
+
+def test_compose_checklist_with_next_action_and_date():
     body = _compose(
-        open_issues=[{
-            "number": 93, "title": "CLIP4DM",
+        open_items=[{
+            "number": 93,
+            "title": "[Remyx Recommendation] CLIP4DM",
             "html_url": "https://github.com/example/repo/issues/93",
+            "created_at": "2026-06-08T10:00:00Z",
         }],
         drafted={"next_actions": {"93": "flip the default-False flag"}},
     )
-    assert "| [#93](https://github.com/example/repo/issues/93) " in body
-    assert "flip the default-False flag" in body
+    assert (
+        "- [ ] [#93](https://github.com/example/repo/issues/93) CLIP4DM "
+        "· Jun 8 — next: flip the default-False flag"
+    ) in body
 
 
-def test_compose_open_issue_without_next_action_gets_dash():
-    body = _compose(open_issues=[{
+def test_compose_checklist_without_next_action_or_date():
+    body = _compose(open_items=[{
         "number": 85, "title": "Beyond 3D VQAs",
         "html_url": "https://github.com/example/repo/issues/85",
     }])
-    assert "| [#85](https://github.com/example/repo/issues/85) | Beyond 3D VQAs | — |" in body
+    assert (
+        "- [ ] [#85](https://github.com/example/repo/issues/85) "
+        "Beyond 3D VQAs"
+    ) in body
+    assert "— next:" not in body
 
 
-def test_compose_license_table_canonical_order():
+def test_compose_license_findings_inline_canonical_order():
     body = _compose()
-    perm_idx = body.index("| permissive | 4 |")
-    missing_idx = body.index("| missing | 30 |")
-    assert perm_idx < missing_idx
+    assert "### ⚖️ License gate findings" in body
+    assert "`permissive: 4 · missing: 30`" in body
+
+
+def test_compose_refine_themes_as_bullets():
+    body = _compose(drafted={
+        "refine_themes": [
+            {"theme": "Eval-set compression", "queries": 1,
+             "hit_rate": "low hit rate"},
+        ],
+    })
+    assert "### 🔭 Refine-query themes the audit pass explored" in body
+    assert "- Eval-set compression — 1 query · low hit rate" in body
 
 
 def test_compose_flags_unverified_cost():
     agg = run._aggregate_week([_entry(_SUMMARY), _entry(None)])
     body = _compose(agg=agg)
     assert "1 run(s) outside log retention not counted" in body
+
+
+def test_compose_footer_is_small():
+    body = _compose()
+    assert body.rstrip().endswith("</sub>")
+
+
+# ─── candidate corpus + prior digest ──────────────────────────────────────
+
+
+def test_aggregate_week_candidate_corpus_dedups_across_runs():
+    rejected = [
+        {"arxiv_id": "2601.1", "title": "Paper A", "reason": "no call site"},
+        {"arxiv_id": "2601.2", "title": "Paper B", "reason": "off contract"},
+    ]
+    entries = [
+        _entry({
+            "status": "pr_opened_draft",
+            "pr_url": "https://github.com/example/repo/pull/11",
+            "paper": "Chosen Paper", "arxiv": "2601.9",
+            "selection_rejected": rejected,
+        }),
+        # Same pool the day before — must not double-count.
+        _entry({
+            "status": "error",
+            "selection_rejected": rejected,
+        }, created="2026-06-07T14:00:00Z"),
+    ]
+    agg = run._aggregate_week(entries)
+    titles = [c["title"] for c in agg["candidates"]]
+    assert titles == ["Chosen Paper", "Paper A", "Paper B"]
+    assert agg["candidates"][0]["outcome"] == "chosen → pr_opened_draft"
+    assert agg["candidates"][1]["outcome"] == "rejected — no call site"
+
+
+def test_fetch_prior_digest_excerpt_returns_newest_digest(monkeypatch):
+    monkeypatch.setattr(run, "gh_graphql", lambda q, v=None: {
+        "node": {"comments": {"nodes": [
+            {"body": "## 🧭 Outrider weekly — old digest"},
+            {"body": "a maintainer reply, not a digest"},
+            {"body": "## 🧭 Outrider weekly — newest digest"},
+        ]}},
+    })
+    excerpt = run._fetch_prior_digest_excerpt("D_node")
+    assert "newest digest" in excerpt
+
+
+def test_fetch_prior_digest_excerpt_empty_on_failure(monkeypatch):
+    def boom(q, v=None):
+        raise RuntimeError("GraphQL down")
+
+    monkeypatch.setattr(run, "gh_graphql", boom)
+    assert run._fetch_prior_digest_excerpt("D_node") == ""
+
+
+def test_remyx_open_prs_filters_to_ours(monkeypatch):
+    monkeypatch.setattr(run, "gh_api", lambda m, p: [
+        {"number": 1, "title": "[Remyx Recommendation] Ours by title",
+         "head": {"ref": "feature/x"}},
+        {"number": 2, "title": "Some other PR",
+         "head": {"ref": "remyx-recommendation/2601.1"}},
+        {"number": 3, "title": "Unrelated", "head": {"ref": "fix/y"}},
+    ])
+    ours = run._remyx_open_prs(_target())
+    assert [pr["number"] for pr in ours] == [1, 2]
 
 
 # ─── run_weekly_summary ───────────────────────────────────────────────────
@@ -284,7 +413,11 @@ def test_weekly_posts_and_threads_url(monkeypatch):
     monkeypatch.setattr(run, "_fetch_week_runs",
                         lambda target, since: [_entry(_SUMMARY)])
     monkeypatch.setattr(run, "_remyx_issues", lambda target, state: [])
-    monkeypatch.setattr(run, "_draft_weekly_narrative", lambda agg, oi: None)
+    monkeypatch.setattr(run, "_remyx_open_prs", lambda target: [])
+    monkeypatch.setattr(run, "_fetch_prior_digest_excerpt", lambda d: "")
+    monkeypatch.setattr(
+        run, "_draft_weekly_narrative", lambda agg, items, prior: None,
+    )
 
     def fake_post(discussion_id, body):
         posted["id"] = discussion_id
@@ -297,9 +430,9 @@ def test_weekly_posts_and_threads_url(monkeypatch):
     assert result["discussion_comment_url"].endswith("#comment-1")
     assert result["runs_aggregated"] == 1
     assert posted["id"] == "D_node"
-    assert "## Outrider weekly summary" in posted["body"]
+    assert "## 🧭 Outrider weekly" in posted["body"]
     # Data-only degrade: the digest still posted without drafted sections.
-    assert "Patterns worth attention" not in posted["body"]
+    assert "Patterns worth your attention" not in posted["body"]
 
 
 # ─── _fetch_run_log_text (zip handling) ───────────────────────────────────

--- a/tests/test_weekly_summary.py
+++ b/tests/test_weekly_summary.py
@@ -1,0 +1,343 @@
+"""Tests for weekly Discussion summary mode:
+
+  - `gh_graphql` posts to the GraphQL endpoint, returns `data`, and
+    raises on GraphQL-level errors (same error shape as gh_api)
+  - `_resolve_discussion_id` passes node IDs through and resolves
+    Discussion numbers via one GraphQL query
+  - `_extract_run_summary` parses the RUN SUMMARY JSON out of
+    timestamp-prefixed Actions log text
+  - `_aggregate_week` sums verified costs, merges license-class counts,
+    preserves selection-reasoning quotes verbatim, and counts
+    retention gaps instead of dropping them
+  - `_compose_weekly_markdown` renders the digest: verbatim blockquote,
+    honest retention rows, next-action column, patterns only when the
+    LLM call succeeded
+  - `run_weekly_summary` skips cleanly without REMYX_WEEKLY_DISCUSSION_ID
+    and posts + threads the comment URL when configured
+
+Run with: pytest tests/ -q
+"""
+import datetime as dt
+import io
+import json
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Target  # noqa: E402
+
+
+def _target():
+    return Target(repo="example/repo", interest_id="iid")
+
+
+# ─── gh_graphql ───────────────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._raw = json.dumps(payload).encode()
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_gh_graphql_returns_data(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "t0ken")
+    seen = {}
+
+    def fake_urlopen(req, timeout=30):
+        seen["url"] = req.full_url
+        seen["body"] = json.loads(req.data.decode())
+        seen["auth"] = req.headers.get("Authorization")
+        return _FakeResponse({"data": {"ok": True}})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    data = run.gh_graphql("query { viewer { login } }", {"a": 1})
+    assert data == {"ok": True}
+    assert seen["url"] == "https://api.github.com/graphql"
+    assert seen["body"]["query"].startswith("query")
+    assert seen["body"]["variables"] == {"a": 1}
+    assert seen["auth"] == "Bearer t0ken"
+
+
+def test_gh_graphql_raises_on_graphql_errors(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "t0ken")
+    monkeypatch.setattr(
+        urllib.request, "urlopen",
+        lambda req, timeout=30: _FakeResponse(
+            {"errors": [{"message": "Could not resolve to a node"}]}
+        ),
+    )
+    with pytest.raises(RuntimeError, match="GraphQL errors"):
+        run.gh_graphql("query { x }")
+
+
+def test_gh_graphql_requires_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("INPUT_GITHUB_TOKEN", raising=False)
+    with pytest.raises(RuntimeError, match="GITHUB_TOKEN"):
+        run.gh_graphql("query { x }")
+
+
+# ─── _resolve_discussion_id ───────────────────────────────────────────────
+
+
+def test_resolve_discussion_id_passes_node_id_through(monkeypatch):
+    monkeypatch.setattr(run, "gh_graphql", lambda *a, **k: pytest.fail(
+        "node IDs must not trigger a GraphQL lookup"
+    ))
+    assert run._resolve_discussion_id(_target(), "D_kwDOAbc123") == "D_kwDOAbc123"
+
+
+def test_resolve_discussion_id_resolves_number(monkeypatch):
+    def fake_graphql(query, variables=None):
+        assert variables == {"owner": "example", "name": "repo", "number": 19}
+        return {"repository": {"discussion": {"id": "D_resolved"}}}
+
+    monkeypatch.setattr(run, "gh_graphql", fake_graphql)
+    assert run._resolve_discussion_id(_target(), "19") == "D_resolved"
+
+
+def test_resolve_discussion_id_raises_when_number_missing(monkeypatch):
+    monkeypatch.setattr(
+        run, "gh_graphql",
+        lambda *a, **k: {"repository": {"discussion": None}},
+    )
+    with pytest.raises(RuntimeError, match="not found"):
+        run._resolve_discussion_id(_target(), "404")
+
+
+# ─── _extract_run_summary ─────────────────────────────────────────────────
+
+
+_SUMMARY = {
+    "repo": "example/repo",
+    "status": "skipped_by_selection_verification",
+    "selection_reasoning": "Every in-pool candidate is a VLM architecture.",
+    "cost_usd": 1.01,
+    "license_class_counts": {"permissive": 4, "missing": 30},
+    "refine_queries": ["depth successor single pass"],
+}
+
+
+def _log_text(summary: dict) -> str:
+    body = "\n".join(
+        f"2026-06-08T14:00:0{i % 10}.1234567Z {line}"
+        for i, line in enumerate(
+            ["some earlier output", "=== RUN SUMMARY ==="]
+            + json.dumps(summary, indent=2).splitlines()
+            + ["trailing line"]
+        )
+    )
+    return body
+
+
+def test_extract_run_summary_parses_timestamped_log():
+    assert run._extract_run_summary(_log_text(_SUMMARY)) == _SUMMARY
+
+
+def test_extract_run_summary_none_without_marker():
+    assert run._extract_run_summary("2026-06-08T14:00:00Z hello\n") is None
+
+
+def test_extract_run_summary_none_on_truncated_json():
+    text = _log_text(_SUMMARY)
+    truncated = text[: text.index('"cost_usd"')]
+    assert run._extract_run_summary(truncated) is None
+
+
+# ─── _aggregate_week ──────────────────────────────────────────────────────
+
+
+def _entry(summary, created="2026-06-08T14:00:00Z", conclusion="success"):
+    return {
+        "run": {"id": 1, "created_at": created, "conclusion": conclusion},
+        "summary": summary,
+    }
+
+
+def test_aggregate_week_sums_and_merges():
+    entries = [
+        _entry(_SUMMARY),
+        _entry({
+            "status": "issue_opened_preflight",
+            "issue_url": "https://github.com/example/repo/issues/92",
+            "cost_usd": 2.5,
+            "license_class_counts": {"permissive": 1, "nc": 2},
+        }, created="2026-06-07T14:00:00Z"),
+        _entry(None, created="2026-06-02T14:00:00Z", conclusion="failure"),
+    ]
+    agg = run._aggregate_week(entries)
+    assert agg["n_runs"] == 3
+    assert agg["n_success"] == 2
+    assert agg["n_failed"] == 1
+    assert agg["verified_cost"] == pytest.approx(3.51)
+    assert agg["unverified_runs"] == 1
+    assert agg["license_class_counts"] == {
+        "permissive": 5, "missing": 30, "nc": 2,
+    }
+    # Verbatim quote captured from the verification-skip run.
+    assert agg["selection_quotes"] == [
+        "Every in-pool candidate is a VLM architecture."
+    ]
+    assert agg["refine_queries"] == ["depth successor single pass"]
+    # Artifact URLs render as #-links; skips as "No artifact"; retention
+    # gaps as an explicit placeholder row.
+    outputs = [r["output"] for r in agg["rows"]]
+    assert "No artifact" in outputs
+    assert "[#92](https://github.com/example/repo/issues/92)" in outputs
+    assert "—" in outputs
+
+
+# ─── _compose_weekly_markdown ─────────────────────────────────────────────
+
+
+def _compose(agg=None, open_issues=None, drafted=None):
+    agg = agg or run._aggregate_week([_entry(_SUMMARY)])
+    start = dt.datetime(2026, 6, 2, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2026, 6, 9, tzinfo=dt.timezone.utc)
+    return run._compose_weekly_markdown(
+        start, end, agg, open_issues or [], drafted,
+    )
+
+
+def test_compose_preserves_selection_quote_verbatim():
+    body = _compose()
+    assert "> Every in-pool candidate is a VLM architecture." in body
+
+
+def test_compose_renders_retention_gap_row():
+    agg = run._aggregate_week([_entry(None, conclusion="failure")])
+    body = _compose(agg=agg)
+    assert "outside log retention — details unavailable" in body
+
+
+def test_compose_patterns_only_when_drafted():
+    no_draft = _compose(drafted=None)
+    assert "Patterns worth attention" not in no_draft
+    drafted = _compose(drafted={
+        "patterns": ["The dedup gate fired twice — review Issue #87."],
+    })
+    assert "### Patterns worth attention" in drafted
+    assert "1. The dedup gate fired twice — review Issue #87." in drafted
+
+
+def test_compose_open_issue_next_action_column():
+    body = _compose(
+        open_issues=[{
+            "number": 93, "title": "CLIP4DM",
+            "html_url": "https://github.com/example/repo/issues/93",
+        }],
+        drafted={"next_actions": {"93": "flip the default-False flag"}},
+    )
+    assert "| [#93](https://github.com/example/repo/issues/93) " in body
+    assert "flip the default-False flag" in body
+
+
+def test_compose_open_issue_without_next_action_gets_dash():
+    body = _compose(open_issues=[{
+        "number": 85, "title": "Beyond 3D VQAs",
+        "html_url": "https://github.com/example/repo/issues/85",
+    }])
+    assert "| [#85](https://github.com/example/repo/issues/85) | Beyond 3D VQAs | — |" in body
+
+
+def test_compose_license_table_canonical_order():
+    body = _compose()
+    perm_idx = body.index("| permissive | 4 |")
+    missing_idx = body.index("| missing | 30 |")
+    assert perm_idx < missing_idx
+
+
+def test_compose_flags_unverified_cost():
+    agg = run._aggregate_week([_entry(_SUMMARY), _entry(None)])
+    body = _compose(agg=agg)
+    assert "1 run(s) outside log retention not counted" in body
+
+
+# ─── run_weekly_summary ───────────────────────────────────────────────────
+
+
+def test_weekly_skips_cleanly_without_discussion_id(monkeypatch):
+    monkeypatch.delenv("REMYX_WEEKLY_DISCUSSION_ID", raising=False)
+    result = run.run_weekly_summary(_target())
+    assert result["status"] == "weekly_summary_skipped_no_discussion_id"
+
+
+def test_weekly_posts_and_threads_url(monkeypatch):
+    monkeypatch.setenv("REMYX_WEEKLY_DISCUSSION_ID", "D_node")
+    posted = {}
+
+    monkeypatch.setattr(run, "_fetch_week_runs",
+                        lambda target, since: [_entry(_SUMMARY)])
+    monkeypatch.setattr(run, "_remyx_issues", lambda target, state: [])
+    monkeypatch.setattr(run, "_draft_weekly_narrative", lambda agg, oi: None)
+
+    def fake_post(discussion_id, body):
+        posted["id"] = discussion_id
+        posted["body"] = body
+        return "https://github.com/example/repo/discussions/19#comment-1"
+
+    monkeypatch.setattr(run, "_post_discussion_comment", fake_post)
+    result = run.run_weekly_summary(_target())
+    assert result["status"] == "weekly_summary_posted"
+    assert result["discussion_comment_url"].endswith("#comment-1")
+    assert result["runs_aggregated"] == 1
+    assert posted["id"] == "D_node"
+    assert "## Outrider weekly summary" in posted["body"]
+    # Data-only degrade: the digest still posted without drafted sections.
+    assert "Patterns worth attention" not in posted["body"]
+
+
+# ─── _fetch_run_log_text (zip handling) ───────────────────────────────────
+
+
+class _FakeZipResponse:
+    def __init__(self, blob: bytes):
+        self._blob = blob
+
+    def read(self):
+        return self._blob
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_fetch_run_log_text_finds_summary_member(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "t0ken")
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("0_other.txt", "no marker here")
+        z.writestr("1_recommend.txt", _log_text(_SUMMARY))
+    monkeypatch.setattr(
+        urllib.request, "urlopen",
+        lambda req, timeout=60: _FakeZipResponse(buf.getvalue()),
+    )
+    text = run._fetch_run_log_text("example/repo", 42)
+    assert text is not None and "=== RUN SUMMARY ===" in text
+
+
+def test_fetch_run_log_text_none_on_http_error(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "t0ken")
+
+    def boom(req, timeout=60):
+        raise urllib.error.HTTPError(req.full_url, 410, "Gone", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    assert run._fetch_run_log_text("example/repo", 42) is None


### PR DESCRIPTION
## Run-telemetry surfacing + weekly Discussion digest mode
  
## Step summary + Issue bodies
  - Candidate-pool composition line (N broad + M refine, after dedup)
  - License-gate distribution line (per-class counts across the pool)
  - Engineering verdict (shape / contract match / migration cost) split into its own section, adjacent to the license verdict — two independent calls instead
  of interleaved prose
  
## Weekly Discussion digest (opt-in)
  - `mode: weekly-summary` + `weekly-discussion-id` inputs; a second weekly cron posts a 7-day digest to a designated Discussion (`discussions: write`
  required)
  - Aggregates outcomes, verified costs, license distribution, refine-query themes, and open Issues with a next-action column from the Actions API + run
  logs; out-of-retention runs listed honestly, selection reasoning quoted verbatim, one LLM call for the interpretive sections (data-only on failure)
  - New `gh_graphql` helper (Discussions API is GraphQL-only)

----
 
48 new tests; all 297 pass. 