### PR TITLE
Switch self-dogfooding interest to ExperimentHistory-derived one

### DIFF
--- a/.github/workflows/outrider.yml
+++ b/.github/workflows/outrider.yml
@@ -35,6 +35,6 @@ jobs:
           echo "token=$token" >> "$GITHUB_OUTPUT"
       - uses: ./
         with:
-          interest-id: '054bb25c-ff68-4d10-bd65-762df0aca8e8'
+          interest-id: '29ca03e7-454d-446c-9941-32c96c53d95d'
           # remyx[bot] token (empty → action falls back to GITHUB_TOKEN).
           github-token: ${{ steps.remyx-bot.outputs.token }}


### PR DESCRIPTION
## Summary

Switches the self-dogfooding workflow's `interest-id` from `054bb25c` (Code Recommendation, 735-char manual description) to `29ca03e7` (outrider, 4201-char ExperimentHistory-derived context).

A side-by-side comparison of the three Outrider-related interests showed:

| Interest | Context | Pool top scores | Pool shape |
|---|---|---|---|
| outrider (ExperimentHistory) | 4201 chars | 0.83–0.95 | Directly on-target (risk gates, agent harness, code-quality uncertainty, self-improvement) |
| Code Recommendation (stub) | 79 chars | 0.95–0.99 | Score-inflated, broader drift |
| Code Recommendation (manual desc) | 735 chars | 0.83–0.96 | Drifts to physical AI / web agents / RL |

Pool overlap across all three is zero. The ExperimentHistory interest's pool contains papers that map directly onto Outrider's actual subsystems (Code2LoRA, Code Is More Than Text, Socratic-SWE, Self-Harness, FASE, AutoMegaKernel). The other two pools mix some relevant papers with off-topic ones.

## Test plan

- [ ] Next scheduled run (Monday 14:00 UTC) picks from the more focused pool
- [ ] After ~1 week of stable runs, retire the two unused interests