### PR TITLE
v1.5.3: scrub .remyx-recommendation/ scratchpad from downgrade-Issue diff

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -4450,8 +4450,18 @@ def _capture_implementation_diff(
             ["git", "add", "-A"], cwd=workdir, check=True,
             capture_output=True, timeout=30,
         )
+        # Exclude the orchestrator's scratchpad files from the user-facing
+        # diff. `.remyx-recommendation/` holds CONTEXT.md, GUARDRAILS.md,
+        # INVOCATION.md, PAPER.md, SPEC.md — internal agent prompts that
+        # leak orchestrator phrasing into the Issue body otherwise. The
+        # pathspec exclusion runs inside git, so the diff captured is
+        # already clean — no post-parse filtering needed.
         proc = subprocess.run(
-            ["git", "diff", "--staged"], cwd=workdir,
+            [
+                "git", "diff", "--staged", "--",
+                ".", ":(exclude).remyx-recommendation",
+            ],
+            cwd=workdir,
             capture_output=True, text=True, timeout=30,
         )
         if proc.returncode != 0:

--- a/tests/test_downgrade_diff.py
+++ b/tests/test_downgrade_diff.py
@@ -104,6 +104,42 @@ def test_capture_diff_returns_empty_when_no_changes(tmp_path):
     assert diff == ""
 
 
+def test_capture_diff_excludes_remyx_recommendation_scratchpad(tmp_path):
+    """The orchestrator writes internal agent-facing prompts under
+    `.remyx-recommendation/` (CONTEXT.md, GUARDRAILS.md, etc.). These
+    must NOT appear in the diff embedded in downgrade-Issue bodies —
+    they leak orchestrator phrasing into a maintainer-facing artifact
+    (REMYX-112). The actual code contribution alongside them MUST still
+    appear."""
+    _init_git_repo(tmp_path)
+    # Real code contribution the agent wrote
+    (tmp_path / "new_module.py").write_text(
+        "def cooperative_guardrail():\n    return 'ok'\n"
+    )
+    # Orchestrator scratchpad files that must be stripped
+    scratchpad = tmp_path / ".remyx-recommendation"
+    scratchpad.mkdir()
+    (scratchpad / "CONTEXT.md").write_text(
+        "# Team's recent shipping history\n- Some experiment\n"
+    )
+    (scratchpad / "GUARDRAILS.md").write_text(
+        "# Honesty rules\n- Don't scaffold\n"
+    )
+    (scratchpad / "PAPER.md").write_text("# Recommended paper\nDoesn't matter\n")
+
+    diff = run._capture_implementation_diff(tmp_path)
+
+    # Real code is included
+    assert "new_module.py" in diff
+    assert "+def cooperative_guardrail()" in diff
+    # Scratchpad files are NOT
+    assert ".remyx-recommendation" not in diff
+    assert "CONTEXT.md" not in diff
+    assert "GUARDRAILS.md" not in diff
+    assert "Honesty rules" not in diff
+    assert "Team's recent shipping history" not in diff
+
+
 # ─── _render_implementation_diff_section ──────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Filter out `.remyx-recommendation/*` files from the diff captured for embedding in downgrade-Issue bodies. The orchestrator writes internal agent-facing prompts (CONTEXT.md, GUARDRAILS.md, INVOCATION.md, PAPER.md, SPEC.md) under that path; they leaked into the user-facing diff before this fix.

Implementation: git pathspec exclusion at `git diff --staged` time (`:(exclude).remyx-recommendation`). No post-parse filtering, no API change.

## Test plan

- [x] `pytest tests/test_downgrade_diff.py -q` — 12 pass (11 existing + 1 new test asserting `.remyx-recommendation/*` is excluded while real code IS included)
- [x] Full suite `pytest tests/ -q` — 325 pass
- [ ] After merge: tag v1.5.3 + Release + move @v1
- [ ] Verify on smellslikeml/pytorch_geometric-outrider-demo re-run

Closes REMYX-112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)