### PR TITLE
Repo orientation pass + clean PR-title/branch defaults (REMYX-116 Phase 1 + 1c)

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -258,19 +258,65 @@ After the orchestrator validates your work, it checks the diff with
 set, the PR is rejected and your work is not committed.
 """
 
+_ORIENTATION_MD_TEMPLATE = """\
+# Repo orientation — conventions and patterns for this target repo
+
+The orchestrator already read the target repo's convention-defining files
+for you. Use the patterns below to shape your generated code, PR title,
+PR body, and commit messages. Do NOT re-explore these files yourself
+(that's redundant cost) — the relevant content is summarized here.
+
+{contributor_guides_block}
+{pr_template_block}
+{recent_merged_prs_block}
+{tooling_config_block}
+{verification_stack_block}
+{nearby_files_block}
+{nearby_tests_block}
+
+## How to use this orientation
+
+- **PR title**: match the convention shown in the recent merged PRs above
+  (the title pattern — e.g. `<scope>: <verb> <thing>` if that's what
+  recent merges follow). Do not use Remyx-prefixed titles.
+- **PR body**: if the PR template is shown above, conform to its section
+  structure. Otherwise produce a clean summary + test plan.
+- **Code style**: match what the existing nearby files do — import style
+  (relative vs absolute), naming, formatting. The lint config (if shown)
+  is the source of truth for what passes.
+- **Type checking**: if the repo uses mypy or pyright, the orientation
+  block lists the configured strictness. Match the patterns the existing
+  tests use for any TypedDict / async / union narrowing.
+- **Test design**: match the existing test patterns — go through public
+  interfaces, not internal attributes; use the same fixtures and helpers
+  the existing tests use.
+
+If the orientation block is empty or missing a section, that signal is
+informative: either the repo has no contributor guide / PR template /
+lint config (treat as no strict convention to follow) or the orchestrator
+couldn't read it (rare; surface in your summary if so).
+"""
+
 _INVOCATION_MD_TEMPLATE = """\
 You are a coding agent implementing a recommendation from the Remyx
 Recommendation pipeline (attribution URL: {attribution_url}).
 
 Read these files in order:
-  1. .remyx-recommendation/SPEC.md       — the implementation spec (paper,
-                                            why-this-paper, suggested
-                                            experiment, team's research-
-                                            focus body, abstract)
-  2. .remyx-recommendation/PAPER.md      — paper title + abstract
-  3. .remyx-recommendation/CONTEXT.md    — team context (recent merges,
-                                            if Remyx returned any)
-  4. .remyx-recommendation/GUARDRAILS.md — what you may and may not modify
+  1. .remyx-recommendation/SPEC.md         — the implementation spec (paper,
+                                              why-this-paper, suggested
+                                              experiment, team's research-
+                                              focus body, abstract)
+  2. .remyx-recommendation/PAPER.md        — paper title + abstract
+  3. .remyx-recommendation/CONTEXT.md      — team context (recent merges,
+                                              if Remyx returned any)
+  4. .remyx-recommendation/GUARDRAILS.md   — what you may and may not modify
+  5. .remyx-recommendation/ORIENTATION.md  — target repo's contributor guide,
+                                              PR template, recent-merged-PR
+                                              conventions, lint/type config,
+                                              and a few sample existing files
+                                              + tests near the planned call
+                                              site. Use these patterns
+                                              without re-exploring them.
 
 SPEC.md names a PROPOSED CALL SITE under "How this maps onto your repo"
 (the file + function the selection pass judged most implementable). Start
@@ -2806,6 +2852,335 @@ def detect_package_name(workdir: Path) -> str:
     return "src"
 
 
+def _orient_contributor_guides(workdir: Path, cap: int = 3000) -> str:
+    """Read contributor-guide files; concatenate and truncate to ``cap``."""
+    chunks: list[str] = []
+    for name in ("CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md"):
+        path = workdir / name
+        if not path.is_file():
+            continue
+        try:
+            body = path.read_text(errors="replace").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        snippet = body[:cap] + ("\n…[truncated]" if len(body) > cap else "")
+        chunks.append(f"### `{name}`\n\n{snippet}")
+    return "\n\n".join(chunks)
+
+
+def _orient_pr_template(workdir: Path, cap: int = 2000) -> str:
+    """Read PR templates from .github/PULL_REQUEST_TEMPLATE/ or root."""
+    candidates: list[Path] = []
+    tmpl_dir = workdir / ".github" / "PULL_REQUEST_TEMPLATE"
+    if tmpl_dir.is_dir():
+        candidates.extend(sorted(tmpl_dir.glob("*.md")))
+    root_tmpl = workdir / ".github" / "pull_request_template.md"
+    if root_tmpl.is_file():
+        candidates.append(root_tmpl)
+    chunks: list[str] = []
+    for path in candidates[:3]:  # at most 3 templates
+        try:
+            body = path.read_text(errors="replace").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        rel = path.relative_to(workdir).as_posix()
+        snippet = body[:cap] + ("\n…[truncated]" if len(body) > cap else "")
+        chunks.append(f"### `{rel}`\n\n```markdown\n{snippet}\n```")
+    return "\n\n".join(chunks)
+
+
+def _orient_recent_merged_prs(repo: str, limit: int = 10) -> str:
+    """Pull recent merged PRs via gh_api for title + body convention extraction."""
+    if not repo:
+        return ""
+    try:
+        params = f"state=closed&sort=updated&direction=desc&per_page={limit * 2}"
+        prs = gh_api("GET", f"repos/{repo}/pulls?{params}")
+    except Exception:
+        return ""
+    if not isinstance(prs, list):
+        return ""
+    merged = [p for p in prs if p.get("merged_at")][:limit]
+    if not merged:
+        return ""
+    lines = [f"Last {len(merged)} merged PRs on `{repo}` (most recent first):\n"]
+    for pr in merged:
+        num = pr.get("number")
+        title = (pr.get("title") or "").strip()
+        author = (pr.get("user") or {}).get("login", "?")
+        labels = [
+            (lab.get("name") or "").strip()
+            for lab in (pr.get("labels") or [])
+            if lab.get("name")
+        ]
+        label_str = f"  labels: [{', '.join(labels)}]" if labels else ""
+        lines.append(f"- #{num} (by @{author}): {title}{label_str}")
+    # Include the body of the 3 most-recent merges so the agent can see
+    # the section pattern (Summary / Test plan / etc).
+    lines.append("\nBody samples (3 most recent, truncated):")
+    for pr in merged[:3]:
+        num = pr.get("number")
+        body = (pr.get("body") or "").strip()
+        if not body:
+            continue
+        snippet = body[:800] + ("\n…[truncated]" if len(body) > 800 else "")
+        lines.append(f"\n#### PR #{num} body\n```markdown\n{snippet}\n```")
+    return "\n".join(lines)
+
+
+def _orient_tooling_config(workdir: Path) -> str:
+    """Extract lint/type/test config from common config files."""
+    chunks: list[str] = []
+    # pyproject.toml — extract [tool.X] sections only (keep budget tight)
+    pyproject = workdir / "pyproject.toml"
+    if pyproject.is_file():
+        try:
+            body = pyproject.read_text(errors="replace")
+        except OSError:
+            body = ""
+        if body:
+            tool_sections: list[str] = []
+            current_section: list[str] = []
+            in_tool_block = False
+            for line in body.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("["):
+                    if in_tool_block and current_section:
+                        tool_sections.append("\n".join(current_section))
+                    current_section = []
+                    in_tool_block = stripped.startswith("[tool.") or stripped.startswith(
+                        "[project.optional-dependencies"
+                    )
+                if in_tool_block:
+                    current_section.append(line)
+            if in_tool_block and current_section:
+                tool_sections.append("\n".join(current_section))
+            if tool_sections:
+                joined = "\n\n".join(tool_sections)
+                snippet = joined[:2500] + (
+                    "\n…[truncated]" if len(joined) > 2500 else ""
+                )
+                chunks.append(f"### `pyproject.toml` (tool sections)\n\n```toml\n{snippet}\n```")
+
+    # Standalone tool configs (just list presence + first 60 lines each)
+    for name in (".ruff.toml", "ruff.toml", "mypy.ini", "pyrightconfig.json", "tox.ini"):
+        path = workdir / name
+        if not path.is_file():
+            continue
+        try:
+            body = path.read_text(errors="replace")
+        except OSError:
+            continue
+        snippet = "\n".join(body.splitlines()[:60])
+        chunks.append(f"### `{name}`\n\n```\n{snippet}\n```")
+
+    # Makefile — list verification-flavored targets if any
+    mk = workdir / "Makefile"
+    if mk.is_file():
+        try:
+            body = mk.read_text(errors="replace")
+        except OSError:
+            body = ""
+        if body:
+            target_lines = [
+                line for line in body.splitlines()
+                if line and not line.startswith((" ", "\t", "#"))
+                and ":" in line
+            ]
+            verify_targets = [
+                line for line in target_lines
+                if any(kw in line.split(":")[0].lower() for kw in
+                       ("format", "lint", "typecheck", "type-check", "mypy",
+                        "pyright", "test", "check", "sync"))
+            ]
+            if verify_targets:
+                chunks.append(
+                    "### `Makefile` (verification-relevant targets)\n\n```make\n"
+                    + "\n".join(verify_targets) + "\n```"
+                )
+    return "\n\n".join(chunks)
+
+
+def _detect_verification_stack(workdir: Path) -> tuple[str, list[str]]:
+    """Detect package manager + verification commands from repo signals.
+
+    Returns ``(package_manager, commands)``. Commands are listed in the
+    order they should run. Empty list if no verification stack detected.
+    """
+    pkg_mgr = "pip"
+    if (workdir / "uv.lock").is_file():
+        pkg_mgr = "uv"
+    elif (workdir / "poetry.lock").is_file():
+        pkg_mgr = "poetry"
+    elif (workdir / "Pipfile.lock").is_file():
+        pkg_mgr = "pipenv"
+    elif (workdir / "pyproject.toml").is_file():
+        pkg_mgr = "pip+pyproject"
+
+    commands: list[str] = []
+
+    # 1. Makefile targets — most explicit signal
+    mk = workdir / "Makefile"
+    if mk.is_file():
+        try:
+            body = mk.read_text(errors="replace")
+        except OSError:
+            body = ""
+        targets_present = {
+            line.split(":")[0].strip()
+            for line in body.splitlines()
+            if line and not line.startswith((" ", "\t", "#")) and ":" in line
+        }
+        for target in ("format", "lint", "typecheck", "type-check", "tests", "test"):
+            if target in targets_present:
+                commands.append(f"make {target}")
+
+    # 2. tox / nox orchestration
+    if not commands:
+        if (workdir / "tox.ini").is_file():
+            commands.append("tox")
+        elif (workdir / "noxfile.py").is_file():
+            commands.append("nox")
+
+    # 3. Direct invocation from pyproject.toml signals
+    if not commands and (workdir / "pyproject.toml").is_file():
+        try:
+            body = (workdir / "pyproject.toml").read_text(errors="replace")
+        except OSError:
+            body = ""
+        if "[tool.ruff" in body:
+            commands.append("ruff format --check .")
+            commands.append("ruff check .")
+        elif "[tool.black" in body:
+            commands.append("black --check .")
+        if "[tool.mypy" in body:
+            commands.append("mypy .")
+        if (workdir / "pyrightconfig.json").is_file():
+            commands.append("pyright")
+        if "[tool.pytest" in body or "pytest" in body:
+            commands.append("pytest")
+
+    return pkg_mgr, commands
+
+
+def _orient_verification_stack(workdir: Path) -> str:
+    """Format detected verification stack as a markdown section.
+
+    Returns "" when no commands AND no specific package-manager signal
+    were detected (i.e. nothing useful to report). When commands are
+    detected, format as a markdown list. When only the package manager
+    is detected (no commands), report the package manager so the agent
+    knows the dependency-install path.
+    """
+    pkg_mgr, commands = _detect_verification_stack(workdir)
+    if not commands and pkg_mgr == "pip":
+        # Default fallback with no commands — no useful signal to report.
+        return ""
+    lines = [f"Package manager: `{pkg_mgr}`"]
+    if commands:
+        lines.extend(["", "Detected verification commands (run in order):"])
+        for cmd in commands:
+            lines.append(f"  - `{cmd}`")
+    return "\n".join(lines)
+
+
+def _orient_nearby_files(workdir: Path, package: str, cap_files: int = 5) -> str:
+    """List up to ``cap_files`` existing modules in the package root with first docstring line."""
+    pkg_dir = workdir / package
+    if not pkg_dir.is_dir():
+        return ""
+    py_files = sorted(pkg_dir.glob("*.py"))[:cap_files]
+    if not py_files:
+        return ""
+    lines: list[str] = []
+    for path in py_files:
+        rel = path.relative_to(workdir).as_posix()
+        first_lines = ""
+        try:
+            text = path.read_text(errors="replace")
+            doc = ast.get_docstring(ast.parse(text)) or ""
+            first_lines = doc.splitlines()[0] if doc else ""
+        except (SyntaxError, OSError):
+            pass
+        if first_lines:
+            lines.append(f"- `{rel}` — {first_lines[:90]}")
+        else:
+            lines.append(f"- `{rel}`")
+    return "\n".join(lines)
+
+
+def _orient_nearby_tests(workdir: Path, cap_files: int = 5) -> str:
+    """List up to ``cap_files`` test files; include the first ~30 lines of one as a pattern sample."""
+    tests_dir = workdir / "tests"
+    if not tests_dir.is_dir():
+        return ""
+    test_files = sorted(tests_dir.rglob("test_*.py"))[:cap_files]
+    if not test_files:
+        return ""
+    lines: list[str] = []
+    lines.append(f"{len(test_files)} test file(s) listed:")
+    for path in test_files:
+        rel = path.relative_to(workdir).as_posix()
+        lines.append(f"- `{rel}`")
+    # Include a sample of the first test file's imports and one test fn
+    sample = test_files[0]
+    try:
+        text = sample.read_text(errors="replace")
+    except OSError:
+        text = ""
+    if text:
+        sample_lines = text.splitlines()[:40]
+        snippet = "\n".join(sample_lines)
+        lines.append(
+            f"\nSample pattern from `{sample.relative_to(workdir).as_posix()}`:\n```python\n{snippet}\n```"
+        )
+    return "\n".join(lines)
+
+
+def _collect_repo_orientation(workdir: Path, target: Target, package: str) -> str:
+    """Assemble the repo orientation content for ORIENTATION.md.
+
+    Returns the formatted markdown body. Returns "" if no orientation
+    content could be gathered (e.g. fresh repo with no conventions).
+    """
+    def _section(title: str, body: str) -> str:
+        if not body.strip():
+            return ""
+        return f"## {title}\n\n{body}"
+
+    blocks = {
+        "contributor_guides_block": _section(
+            "Contributor guides", _orient_contributor_guides(workdir)
+        ),
+        "pr_template_block": _section("PR template(s)", _orient_pr_template(workdir)),
+        "recent_merged_prs_block": _section(
+            "Recent merged PRs (title + body convention)",
+            _orient_recent_merged_prs(target.repo) if target.repo else "",
+        ),
+        "tooling_config_block": _section(
+            "Tooling and lint/type config", _orient_tooling_config(workdir)
+        ),
+        "verification_stack_block": _section(
+            "Detected verification stack", _orient_verification_stack(workdir)
+        ),
+        "nearby_files_block": _section(
+            f"Existing modules in `{package}/`", _orient_nearby_files(workdir, package)
+        ),
+        "nearby_tests_block": _section(
+            "Existing tests (pattern corpus)", _orient_nearby_tests(workdir)
+        ),
+    }
+    # If every section came up empty, return "" so the caller can skip
+    # writing the file.
+    if not any(v.strip() for v in blocks.values()):
+        return ""
+    return _ORIENTATION_MD_TEMPLATE.format(**blocks)
+
+
 def write_spec_bundle(
     workdir: Path, target: Target, rec: Recommendation, package: str,
     selection_note: str = "",
@@ -2875,6 +3250,15 @@ def write_spec_bundle(
         attribution_url=CANONICAL_ATTRIBUTION_URL,
         issue_fallback_filename=ISSUE_FALLBACK_FILENAME,
     ))
+
+    # ORIENTATION.md — target repo's contributor guides, PR template, recent
+    # merged-PR conventions, lint/type config, detected verification stack,
+    # and a few sample nearby files/tests. Pre-read so the agent doesn't
+    # broad-explore the repo to rediscover conventions. Skipped entirely
+    # when no orientation content can be gathered.
+    orientation_body = _collect_repo_orientation(workdir, target, package)
+    if orientation_body:
+        (bundle / "ORIENTATION.md").write_text(orientation_body)
 
 
 # ─── Claude Code invocation ────────────────────────────────────────────────

--- a/src/run.py
+++ b/src/run.py
@@ -417,14 +417,14 @@ Required outputs:
    module, exercises the wiring edit you made, and asserts the
    integrated behavior.
 
-4. **README append**: a short "(Capability) — adapted from (Paper Title)"
-   section at the end. Attribute with this exact line (one Markdown
-   link to the customer-facing Remyx product page):
-
-       Contributed via [Remyx Recommendation]({attribution_url}).
-
-   Do NOT use a different URL. The orchestrator's source repo is
-   private; this link is the only one that resolves for external readers.
+4. **README documentation** (only if the repo's convention does this).
+   ORIENTATION.md shows the repo's existing README style — if the
+   convention is to mention new examples/modules in the README, add a
+   short "(Capability) — adapted from (Paper Title)" section in the same
+   shape as the existing entries. If the repo's README doesn't carry
+   per-feature documentation, DON'T add a section. Do NOT add marketing
+   attribution links to the codebase — attribution lives in the PR body
+   footer (handled by the orchestrator), not in the maintainer's repo.
 
 # Honesty rules
 
@@ -1226,6 +1226,32 @@ def gh_graphql(
 def slugify(s: str, max_len: int = 60) -> str:
     s = re.sub(r"[^A-Za-z0-9._-]+", "-", s.lower()).strip("-")
     return s[:max_len]
+
+
+def format_pr_title(rec: "Recommendation") -> str:
+    """Return a clean PR title for the recommendation, no Outrider prefix.
+
+    Drops the historical ``[Remyx Recommendation]`` prefix so the title
+    matches how a human contributor would title the PR. Outrider
+    attribution is preserved in the PR body footer; dedup falls back to
+    body-marker recognition (``"Remyx Recommendation" in body``) for
+    PRs created without the legacy title prefix.
+    """
+    return rec.paper_title
+
+
+def format_branch_name(rec: "Recommendation") -> str:
+    """Return a clean branch name for the recommendation, no Outrider prefix.
+
+    Drops the historical ``remyx-recommendation/`` prefix. Uses a
+    slugified paper title (more human-readable than the bare arxiv id)
+    with the arxiv id as a fallback identifier when the title is empty.
+    Dedup paths that previously matched against ``BRANCH_PREFIX`` now
+    fall back to identifying our PRs via the body marker.
+    """
+    if rec.paper_title:
+        return slugify(rec.paper_title)
+    return rec.arxiv_id or "paper-recommendation"
 
 
 def strip_html(s: str) -> str:
@@ -4986,7 +5012,7 @@ def _open_downgrade_issue(
         default attributes to coding-agent Issue-mode election (the
         legacy default); callers pass the routing-specific text.
     """
-    title = f"{PR_TITLE_PREFIX} {rec.paper_title}"
+    title = format_pr_title(rec)
 
     sections: list[str] = []
     sections.append(
@@ -5234,7 +5260,7 @@ def process_target(target: Target) -> dict:
         if TIER_RANK.get(c.tier.lower(), 0) < min_required:
             dropped_low_conf += 1
             continue
-        c_branch = f"{BRANCH_PREFIX}{c.arxiv_id or slugify(c.paper_title)}"
+        c_branch = format_branch_name(c)
         if existing_pr_for(target, c_branch):
             dropped_pr_exists += 1
             continue
@@ -5558,7 +5584,7 @@ def process_target(target: Target) -> dict:
         # 5. Spec bundle for the chosen candidate. Thread the selection
         # rationale through so pre-flight and the implementer evaluate the
         # same scoped framing the selection pass reasoned about.
-        branch = f"{BRANCH_PREFIX}{rec.arxiv_id or slugify(rec.paper_title)}"
+        branch = format_branch_name(rec)
         write_spec_bundle(
             workdir, target, rec, package,
             selection_note=result.get("selection_reasoning", ""),
@@ -5875,7 +5901,7 @@ def process_target(target: Target) -> dict:
             draft = tests_status != "passed"
 
         # 11. Commit + push + PR
-        pr_title = f"{PR_TITLE_PREFIX} {rec.paper_title}"
+        pr_title = format_pr_title(rec)
         pr_body = build_pr_body(
             target, rec, tests_status, test_output,
             review_section=review_section,

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1,0 +1,336 @@
+"""Tests for the repo-orientation pass that pre-reads target-repo conventions.
+
+The orientation pass writes `ORIENTATION.md` into the agent's bundle so the
+coding agent can adhere to the target repo's conventions (contributor guides,
+PR template, recent merged PRs, lint/type config, nearby files/tests, detected
+verification stack) without re-exploring those files itself.
+
+Covers:
+  - Each `_orient_*` helper reads its inputs correctly + returns "" when absent
+  - `_detect_verification_stack` returns the right package manager + commands
+    across uv / poetry / pip / Makefile-based / pyproject-based setups
+  - `_collect_repo_orientation` assembles a full markdown block when any input
+    is present and returns "" when all inputs are absent (graceful skip)
+
+Run with: pytest tests/test_orientation.py -q
+"""
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Target  # noqa: E402
+
+
+# ─── _orient_contributor_guides ───────────────────────────────────────────
+
+
+def test_contributor_guides_reads_all_three(tmp_path: Path) -> None:
+    (tmp_path / "CLAUDE.md").write_text("# Claude Guide\nUse the verification stack.\n")
+    (tmp_path / "AGENTS.md").write_text("# Agents Guide\nFollow these rules.\n")
+    (tmp_path / "CONTRIBUTING.md").write_text("# Contributing\nWelcome contributors.\n")
+
+    body = run._orient_contributor_guides(tmp_path)
+
+    assert "`CLAUDE.md`" in body
+    assert "Use the verification stack." in body
+    assert "`AGENTS.md`" in body
+    assert "Follow these rules." in body
+    assert "`CONTRIBUTING.md`" in body
+    assert "Welcome contributors." in body
+
+
+def test_contributor_guides_returns_empty_when_none_present(tmp_path: Path) -> None:
+    body = run._orient_contributor_guides(tmp_path)
+    assert body == ""
+
+
+def test_contributor_guides_truncates_at_cap(tmp_path: Path) -> None:
+    long_body = "X" * 10_000
+    (tmp_path / "CLAUDE.md").write_text(long_body)
+
+    body = run._orient_contributor_guides(tmp_path, cap=500)
+
+    assert "…[truncated]" in body
+    # The truncated body should be roughly the cap, not the full 10K.
+    assert len(body) < 2000
+
+
+# ─── _orient_pr_template ───────────────────────────────────────────────────
+
+
+def test_pr_template_from_directory(tmp_path: Path) -> None:
+    tmpl_dir = tmp_path / ".github" / "PULL_REQUEST_TEMPLATE"
+    tmpl_dir.mkdir(parents=True)
+    (tmpl_dir / "pull_request_template.md").write_text(
+        "### Summary\n<short summary>\n\n### Test plan\n<how tested>\n"
+    )
+
+    body = run._orient_pr_template(tmp_path)
+
+    assert ".github/PULL_REQUEST_TEMPLATE/pull_request_template.md" in body
+    assert "### Summary" in body
+    assert "### Test plan" in body
+
+
+def test_pr_template_from_root(tmp_path: Path) -> None:
+    gh_dir = tmp_path / ".github"
+    gh_dir.mkdir()
+    (gh_dir / "pull_request_template.md").write_text("## Description\nDescribe.\n")
+
+    body = run._orient_pr_template(tmp_path)
+
+    assert ".github/pull_request_template.md" in body
+    assert "## Description" in body
+
+
+def test_pr_template_returns_empty_when_absent(tmp_path: Path) -> None:
+    body = run._orient_pr_template(tmp_path)
+    assert body == ""
+
+
+# ─── _orient_tooling_config ────────────────────────────────────────────────
+
+
+def test_tooling_config_extracts_tool_sections(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "0.1"\n\n'
+        '[tool.ruff]\nline-length = 100\nselect = ["E", "F"]\n\n'
+        '[tool.mypy]\nstrict = true\n\n'
+        '[build-system]\nrequires = ["setuptools"]\n'
+    )
+
+    body = run._orient_tooling_config(tmp_path)
+
+    # Should include [tool.X] sections
+    assert "[tool.ruff]" in body
+    assert "line-length = 100" in body
+    assert "[tool.mypy]" in body
+    assert "strict = true" in body
+    # Should NOT include unrelated sections
+    assert "[project]" not in body
+    assert "[build-system]" not in body
+
+
+def test_tooling_config_includes_standalone_configs(tmp_path: Path) -> None:
+    (tmp_path / ".ruff.toml").write_text('line-length = 88\n')
+    (tmp_path / "mypy.ini").write_text("[mypy]\nstrict = True\n")
+
+    body = run._orient_tooling_config(tmp_path)
+
+    assert "`.ruff.toml`" in body
+    assert "line-length = 88" in body
+    assert "`mypy.ini`" in body
+    assert "strict = True" in body
+
+
+def test_tooling_config_makefile_targets(tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text(
+        "format:\n\truff format\n\n"
+        "lint:\n\truff check\n\n"
+        "typecheck:\n\tmypy .\n\n"
+        "tests:\n\tpytest\n\n"
+        "unrelated_target:\n\techo unrelated\n"
+    )
+
+    body = run._orient_tooling_config(tmp_path)
+
+    assert "format:" in body
+    assert "lint:" in body
+    assert "typecheck:" in body
+    assert "tests:" in body
+    # Truly-unrelated targets should be filtered out (heuristic by keyword)
+    assert "unrelated_target" not in body
+
+
+def test_tooling_config_returns_empty_when_no_configs(tmp_path: Path) -> None:
+    body = run._orient_tooling_config(tmp_path)
+    assert body == ""
+
+
+# ─── _detect_verification_stack ───────────────────────────────────────────
+
+
+def test_detect_uv_from_lockfile(tmp_path: Path) -> None:
+    (tmp_path / "uv.lock").write_text("# uv lock file")
+    pkg, _ = run._detect_verification_stack(tmp_path)
+    assert pkg == "uv"
+
+
+def test_detect_poetry_from_lockfile(tmp_path: Path) -> None:
+    (tmp_path / "poetry.lock").write_text("# poetry lock file")
+    pkg, _ = run._detect_verification_stack(tmp_path)
+    assert pkg == "poetry"
+
+
+def test_detect_pip_pyproject_fallback(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[build-system]\nrequires = ["setuptools"]\n')
+    pkg, _ = run._detect_verification_stack(tmp_path)
+    assert pkg == "pip+pyproject"
+
+
+def test_detect_commands_from_makefile(tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text(
+        "format:\n\truff format\n\nlint:\n\truff check\n\n"
+        "typecheck:\n\tmypy .\n\ntests:\n\tpytest\n"
+    )
+    _, commands = run._detect_verification_stack(tmp_path)
+    assert "make format" in commands
+    assert "make lint" in commands
+    assert "make typecheck" in commands
+    assert "make tests" in commands
+
+
+def test_detect_commands_falls_back_to_pyproject(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.ruff]\nline-length = 100\n\n'
+        '[tool.mypy]\nstrict = true\n\n'
+        '[tool.pytest.ini_options]\ntestpaths = ["tests"]\n'
+    )
+    _, commands = run._detect_verification_stack(tmp_path)
+    # Should detect ruff + mypy + pytest from the tool sections
+    assert any("ruff" in c for c in commands)
+    assert any("mypy" in c for c in commands)
+    assert any("pytest" in c for c in commands)
+
+
+def test_detect_commands_falls_back_to_tox(tmp_path: Path) -> None:
+    (tmp_path / "tox.ini").write_text("[tox]\nenvlist = py310\n")
+    _, commands = run._detect_verification_stack(tmp_path)
+    assert "tox" in commands
+
+
+def test_detect_no_signals_returns_empty_command_list(tmp_path: Path) -> None:
+    pkg, commands = run._detect_verification_stack(tmp_path)
+    assert pkg == "pip"
+    assert commands == []
+
+
+# ─── _orient_nearby_files ──────────────────────────────────────────────────
+
+
+def test_nearby_files_lists_modules_with_docstrings(tmp_path: Path) -> None:
+    pkg = tmp_path / "demo_pkg"
+    pkg.mkdir()
+    (pkg / "first.py").write_text('"""First module — does the first thing."""\nimport os\n')
+    (pkg / "second.py").write_text('"""Second module — does the second thing."""\n')
+    (pkg / "no_doc.py").write_text("import os\n")
+
+    body = run._orient_nearby_files(tmp_path, "demo_pkg")
+
+    assert "demo_pkg/first.py" in body
+    assert "First module — does the first thing." in body
+    assert "demo_pkg/second.py" in body
+    assert "demo_pkg/no_doc.py" in body
+
+
+def test_nearby_files_returns_empty_when_pkg_missing(tmp_path: Path) -> None:
+    body = run._orient_nearby_files(tmp_path, "nonexistent_pkg")
+    assert body == ""
+
+
+# ─── _orient_nearby_tests ──────────────────────────────────────────────────
+
+
+def test_nearby_tests_lists_files_and_samples_one(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_alpha.py").write_text(
+        '"""Alpha tests."""\nimport pytest\n\ndef test_one():\n    assert True\n'
+    )
+    (tests / "test_beta.py").write_text(
+        '"""Beta tests."""\ndef test_two():\n    assert 1 + 1 == 2\n'
+    )
+
+    body = run._orient_nearby_tests(tmp_path)
+
+    assert "tests/test_alpha.py" in body
+    assert "tests/test_beta.py" in body
+    # The first file should be included as a sample
+    assert "import pytest" in body or "def test_one" in body
+
+
+def test_nearby_tests_returns_empty_when_no_tests_dir(tmp_path: Path) -> None:
+    body = run._orient_nearby_tests(tmp_path)
+    assert body == ""
+
+
+# ─── _collect_repo_orientation ─────────────────────────────────────────────
+
+
+def _target(repo: str = "owner/repo") -> Target:
+    return Target(repo=repo, interest_id="iid")
+
+
+def test_collect_returns_empty_when_repo_has_no_signals(tmp_path: Path) -> None:
+    """A blank repo with no contributor guides, no pyproject, no tests,
+    and no recent PRs (mocked) returns an empty string so the caller
+    can skip writing ORIENTATION.md entirely."""
+    with patch.object(run, "_orient_recent_merged_prs", return_value=""):
+        body = run._collect_repo_orientation(tmp_path, _target(""), "demo_pkg")
+    assert body == ""
+
+
+def test_collect_assembles_full_orientation_block(tmp_path: Path) -> None:
+    """A realistic-shaped repo with multiple convention signals produces
+    the full orientation markdown block with each section rendered."""
+    # Contributor guide
+    (tmp_path / "CLAUDE.md").write_text("# Claude Guide\nverify with `make tests`\n")
+    # PR template
+    tmpl_dir = tmp_path / ".github" / "PULL_REQUEST_TEMPLATE"
+    tmpl_dir.mkdir(parents=True)
+    (tmpl_dir / "pull_request_template.md").write_text("### Summary\n### Test plan\n")
+    # Tooling
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.ruff]\nline-length = 100\n\n[tool.mypy]\nstrict = true\n'
+    )
+    # Makefile
+    (tmp_path / "Makefile").write_text(
+        "format:\n\truff format\nlint:\n\truff check\ntests:\n\tpytest\n"
+    )
+    # Package dir with a module
+    pkg = tmp_path / "demo_pkg"
+    pkg.mkdir()
+    (pkg / "core.py").write_text('"""Core demo module."""\n')
+    # Tests dir
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_core.py").write_text('"""Tests for core."""\ndef test_x():\n    pass\n')
+
+    with patch.object(run, "_orient_recent_merged_prs", return_value="- #1 (by @x): docs: fix typo"):
+        body = run._collect_repo_orientation(tmp_path, _target(), "demo_pkg")
+
+    # Each section should be present
+    assert "Contributor guides" in body
+    assert "PR template" in body
+    assert "Recent merged PRs" in body
+    assert "Tooling and lint/type config" in body
+    assert "Detected verification stack" in body
+    assert "Existing modules in `demo_pkg/`" in body
+    assert "Existing tests" in body
+    # Specific content should propagate through
+    assert "verify with `make tests`" in body
+    assert "### Summary" in body
+    assert "line-length = 100" in body
+    assert "make format" in body  # from verification stack detection
+    assert "demo_pkg/core.py" in body
+    assert "tests/test_core.py" in body
+    assert "docs: fix typo" in body
+
+
+def test_collect_omits_missing_sections(tmp_path: Path) -> None:
+    """When some sections are empty, the resulting block has only the
+    populated subsections — graceful partial degradation."""
+    # Only a contributor guide; no pyproject, no tests, no package
+    (tmp_path / "CONTRIBUTING.md").write_text("# Contributing\nbe nice\n")
+    with patch.object(run, "_orient_recent_merged_prs", return_value=""):
+        body = run._collect_repo_orientation(tmp_path, _target(""), "demo_pkg")
+
+    assert "Contributor guides" in body
+    assert "be nice" in body
+    # Missing sections should not appear as section headers
+    assert "## PR template" not in body
+    assert "## Tooling and lint/type config" not in body
+    assert "## Existing modules" not in body

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -334,3 +334,64 @@ def test_collect_omits_missing_sections(tmp_path: Path) -> None:
     assert "## PR template" not in body
     assert "## Tooling and lint/type config" not in body
     assert "## Existing modules" not in body
+
+
+# ─── Phase 1c — format_pr_title / format_branch_name ──────────────────────
+
+
+def _rec(title: str = "Paper Title", arxiv: str = "2310.12815v4"):
+    """Build a minimal Recommendation for title/branch formatting tests."""
+    return run.Recommendation(
+        paper_title=title,
+        arxiv_id=arxiv,
+        tier="high",
+        z_score=0.0,
+        spec_md="",
+        paper_abstract="",
+        domain_summary="",
+        raw_paper_md="",
+        relevance_score=0.95,
+        reasoning="",
+        suggested_experiment="",
+        interest_name="demo",
+    )
+
+
+def test_format_pr_title_drops_remyx_prefix() -> None:
+    """New PR titles use the paper title directly — no [Remyx Recommendation] prefix."""
+    title = run.format_pr_title(_rec("Formalizing Prompt Injection"))
+    assert title == "Formalizing Prompt Injection"
+    # Specifically, the old prefix should NOT appear
+    assert "[Remyx Recommendation]" not in title
+
+
+def test_format_branch_name_uses_slugified_paper_title() -> None:
+    """New branch names use the slugified paper title, no remyx-recommendation/ prefix."""
+    branch = run.format_branch_name(
+        _rec("Formalizing and Benchmarking Prompt Injection Attacks")
+    )
+    assert "remyx-recommendation/" not in branch
+    # Should be a slugified form of the paper title
+    assert "formalizing" in branch
+    assert "prompt-injection" in branch
+
+
+def test_format_branch_name_falls_back_to_arxiv_when_no_title() -> None:
+    branch = run.format_branch_name(_rec(title="", arxiv="2310.12815v4"))
+    assert branch == "2310.12815v4"
+
+
+def test_format_branch_name_final_fallback() -> None:
+    branch = run.format_branch_name(_rec(title="", arxiv=""))
+    assert branch == "paper-recommendation"
+
+
+def test_invocation_template_drops_marketing_link() -> None:
+    """The agent's INVOCATION.md no longer instructs adding a marketing link."""
+    template = run._INVOCATION_MD_TEMPLATE
+    # The historical marketing-link instruction should be gone
+    assert "Contributed via [Remyx Recommendation]" not in template
+    # But the README documentation guidance should remain (now conditional
+    # on the repo's convention as shown in ORIENTATION.md)
+    assert "README" in template
+    assert "ORIENTATION" in template


### PR DESCRIPTION
## What this PR does

Adds a **repo orientation pass** to the agent's `.remyx-recommendation/`
bundle so the implementation agent sees the target repo's contributor guide,
PR template, recent merged PRs, lint/type config, and a sample of nearby
files and tests before generating code. Drops `[Remyx Recommendation]`
title prefix, `remyx-recommendation/<arxiv-id>` branch prefix, and the
"Contributed via..." marketing link from generated README additions —
artifacts now go out as upstream-quality from the start.

## Motivation

REMYX-116 captures the gap between Outrider's demo-fork artifact quality
and what's upstream-ready. A hand-driven attempt to upstream the
openai-agents-python "Recuse Signal" PR hit 11 distinct manual-fix
categories. 9 of those 11 were convention-driven — caused by the agent
not reading the target repo's existing conventions before generating.

This PR captures Phase 1 + Phase 1c of REMYX-116:

- **Phase 1** — the agent reads the target repo's conventions via a
  pre-read pass that writes `ORIENTATION.md` into the bundle.
- **Phase 1c** — orchestrator-side defaults drop the Outrider scaffolding
  (title prefix, branch prefix, README marketing copy).

Phases 2 (orchestrator workflow fixes — real `gh repo fork`, committer
email format) and 3 (verification execution loop) are deferred to
follow-up PRs.

## What's in the orientation pass (Phase 1)

The agent's bundle gains a new file `.remyx-recommendation/ORIENTATION.md`
that includes:

- **Contributor guides** — `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`
  (truncated to 3K chars each)
- **PR template** — `.github/PULL_REQUEST_TEMPLATE/*.md` or
  `.github/pull_request_template.md`
- **Recent merged PRs** — last 10 via `gh_api`, with title + labels and
  3 sample bodies for section-pattern inference
- **Tooling config** — `pyproject.toml` `[tool.X]` sections, `.ruff.toml`,
  `mypy.ini`, `pyrightconfig.json`, `tox.ini`, Makefile verification
  targets
- **Detected verification stack** — package manager (uv/poetry/pip) +
  ordered command list (Makefile > tox/nox > tool-default invocations).
  Detection only — execution is deferred to Phase 3.
- **Nearby files** — up to 5 `.py` modules in the package root with
  first-line docstrings
- **Nearby tests** — up to 5 test files + a 30-line pattern sample

Each section is independently skip-able; if every section comes up
empty, `ORIENTATION.md` isn't written and existing bundle behavior is
unchanged.

`INVOCATION.md` is updated to read `ORIENTATION.md` before generating,
with guidance on how to use the patterns ("use these conventions
without re-exploring; the relevant content is summarized here").

## What's in the scaffolding cleanup (Phase 1c)

- **`format_pr_title(rec)`** — new helper returning `rec.paper_title`
  (no `[Remyx Recommendation]` prefix). PR-title construction at both
  the downgrade-Issue path and the main PR path use the helper.
- **`format_branch_name(rec)`** — new helper returning slugified paper
  title (arxiv-id fallback), no `remyx-recommendation/` prefix. Both
  branch-construction sites use the helper.
- **`_INVOCATION_MD_TEMPLATE` README append guidance** — now conditional
  on the repo's convention as visible in `ORIENTATION.md`. The
  "Contributed via [Remyx Recommendation]" attribution requirement is
  removed; attribution lives in the PR body footer (handled by the
  orchestrator), not in the maintainer's codebase.

**Dedup compatibility:** `PR_TITLE_PREFIX` and `BRANCH_PREFIX` constants
remain for backward-compat dedup of historical-format PRs/branches.
New-format PRs are caught by the existing body-marker check
(`"Remyx Recommendation" in body`), which fires from the orchestrator-
built PR body footer.

## Empirical validation

### Phase 1 A/B test

Triggered Outrider with the orientation-pass branch on
`smellslikeml/openai-agents-python-outrider-demo`. The agent picked a
different paper (Recuse Signal was dedup'd by the prior PR), and the
generated artifact showed clear orientation-pass effects:

- ✅ **Absolute imports** (`from examples.agent_patterns.prompt_injection_detector import ...`) — matched the repo's pattern. The original PR #2 had relative imports that broke script execution; this run produced upstream-style absolute paths.
- ✅ **Test design through public interface** (`await prompt_injection_guardrail.run(...)`) — matched the repo's existing test pattern, vs. the original PR's direct `.guardrail_function` poking.
- ✅ **No bare `except:`** (which would have failed ruff lint).
- ✅ **Modern Python style** — `from __future__ import annotations`, dataclass, type-hinted signatures.
- ✅ **Module docstring style** matched the existing example modules.

PR: smellslikeml/openai-agents-python-outrider-demo#3

### Phase 1c verification

The follow-up Phase 1c A/B run produced a clean
`skipped_by_selection_verification` outcome (validating the selection
pass still works correctly under the new orientation context — refused
all 30 candidates because none had clean integration shape against the
fork's currently-shipped retry-policy work).

Phase 1c orchestrator-side changes are deterministic string
transformations validated by unit tests:

- `format_pr_title` returns clean paper title
- `format_branch_name` returns slugified title with no prefix
- `_INVOCATION_MD_TEMPLATE` no longer contains the marketing link

These effects will materialize on the next PR-producing run
automatically.

## Test plan

```bash
pytest tests/ -q
# 354 passed (24 new orientation tests + 5 Phase 1c helper tests
#             + 325 pre-existing tests, all green)
```

The new tests in `tests/test_orientation.py` cover:

- Each `_orient_*` helper reads its inputs correctly and returns ""
  when absent
- `_detect_verification_stack` returns the right package manager +
  commands across uv / poetry / pip / Makefile / pyproject setups
- `_collect_repo_orientation` returns "" when no signals, full markdown
  when any input is present, omits empty sections gracefully
- `format_pr_title` drops the prefix
- `format_branch_name` produces slugified branch with no prefix
- `_INVOCATION_MD_TEMPLATE` no longer contains the marketing link

No existing tests fail; no behavior changes for callers that don't
exercise the new helpers (the legacy `PR_TITLE_PREFIX` / `BRANCH_PREFIX`
constants remain for dedup compatibility).

## Related

- **REMYX-116** — the parent ticket capturing upstream-PR-ready mode
- **REMYX-114** — discussion-summary lifecycle updates (shares the
  event-bus assumption; merged-upstream events from this PR's output
  will be surfaced by 114 once it ships)
- **REMYX-115** — licensing-and-code-availability watch (gates which
  candidates are viable inputs to this PR's polish)

## Deferred to follow-up PRs

- **Phase 2** (orchestrator workflow fixes): real `gh repo fork` for
  cross-repo PR enablement + git committer email format change for
  GitHub-Apps badge attribution. Resolves the remaining 2 of the
  original 11 manual fixes (#9 fork relationship, #10 committer
  attribution).
- **Phase 3** (verification execution loop): run the detected
  verification commands with iteration on failures, graceful
  degradation when verification can't run. Conditional on Phase 1 +
  Phase 2 portfolio results showing it's needed.

## Notes for review

- The orientation-pass implementation is colocated with `write_spec_bundle`
  in `src/run.py` (consistent with the monolith pattern).
- The orientation context is capped to ~5-15K tokens of prompt budget —
  each input source is independently truncated.
- Backward-compat is preserved via the legacy `PR_TITLE_PREFIX` /
  `BRANCH_PREFIX` constants for dedup recognition. If a follow-up
  deprecates those constants, the dedup paths need to migrate to the
  body-marker check as the primary identifier.
