### PR TITLE
Weekly summary: lifecycle events + newly-viable recommendations

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -6567,6 +6567,7 @@ def _compose_weekly_markdown(
     open_items: list[dict],
     drafted: dict | None,
     lifecycle_events: list[dict] | None = None,
+    newly_viable: list[dict] | None = None,
 ) -> str:
     """Assemble the Discussion-comment body.
 
@@ -6634,6 +6635,12 @@ def _compose_weekly_markdown(
     # (REMYX-114). Section omitted entirely when no events occurred.
     if lifecycle_events:
         lines += _render_lifecycle_events_section(lifecycle_events, window_end)
+
+    # Newly-viable recommendations — previously blocked at the license
+    # gate, now resolve to a permissive license. Sibling category to
+    # lifecycle events above; same omit-when-empty shape.
+    if newly_viable:
+        lines += _render_newly_viable_section(newly_viable)
 
     if open_items:
         next_actions = drafted.get("next_actions")
@@ -6939,6 +6946,221 @@ def _render_lifecycle_events_section(
     return lines
 
 
+# ─── License-watch: previously-blocked candidates becoming viable ─────────
+
+
+# Regex for the license line that ``_render_license_section`` always
+# writes into an Outrider Issue/PR body:
+#   - **License**: `<spdx>` (class: `<class>`, compat: <compat>[, source: `<src>`])
+_LICENSE_BODY_LINE_RE = re.compile(
+    r"\*\*License\*\*:\s*`(?P<spdx>[^`]*)`"
+    r"\s*\(class:\s*`(?P<klass>[^`]+)`,"
+    r"\s*compat:\s*(?P<compat>[0-9.]+)"
+    r"(?:,\s*source:\s*`(?P<source>[^`]+)`)?\)",
+    re.IGNORECASE,
+)
+
+# Regex for the code-URL line(s). Outrider writes either
+#   - **Code**: <github url>
+# or
+#   - **Model card**: <hf url>
+# (or both). When neither is found the body has a "no repository" note.
+_CODE_BODY_LINE_RE = re.compile(
+    r"\*\*Code\*\*:\s*(?P<url>https?://github\.com/\S+)",
+    re.IGNORECASE,
+)
+_MODEL_BODY_LINE_RE = re.compile(
+    r"\*\*Model card\*\*:\s*(?P<url>https?://huggingface\.co/\S+)",
+    re.IGNORECASE,
+)
+
+
+def _parse_license_state_from_issue_body(body: str) -> dict | None:
+    """Extract the license-at-recommendation snapshot from an Issue body.
+
+    Returns a dict with ``spdx``, ``klass``, ``compat`` (float),
+    ``code_url`` / ``model_url`` (optional), and ``source`` (optional).
+    Returns ``None`` if no license line can be parsed (e.g. the Issue
+    body shape is unfamiliar — graceful skip rather than crash).
+    """
+    if not body:
+        return None
+    m = _LICENSE_BODY_LINE_RE.search(body)
+    if not m:
+        return None
+    try:
+        compat = float(m.group("compat"))
+    except (TypeError, ValueError):
+        return None
+    snap: dict = {
+        "spdx": (m.group("spdx") or "").strip(),
+        "klass": (m.group("klass") or "").strip(),
+        "compat": compat,
+        "source": m.group("source"),
+    }
+    code = _CODE_BODY_LINE_RE.search(body)
+    if code:
+        snap["code_url"] = code.group("url").rstrip(".,")
+    model = _MODEL_BODY_LINE_RE.search(body)
+    if model:
+        snap["model_url"] = model.group("url").rstrip(".,")
+    return snap
+
+
+def _recheck_outrider_license_state(snap: dict) -> dict | None:
+    """Re-fetch license status for a recommendation given its snapshot.
+
+    ``snap`` is the output of ``_parse_license_state_from_issue_body``.
+    Re-resolves the upstream LICENSE via the existing helpers and
+    returns a parallel dict with the *current* spdx/klass/compat.
+    Returns ``None`` when no code URL is known and no fresh URL can be
+    discovered (nothing to check).
+    """
+    code_url = snap.get("code_url")
+    model_url = snap.get("model_url")
+
+    fresh: dict = {"spdx": "", "klass": "missing", "compat": 0.0, "source": ""}
+    if code_url:
+        owner_repo = code_url.split("github.com/", 1)[-1].rstrip("/")
+        owner_repo = "/".join(owner_repo.split("/")[:2])
+        try:
+            spdx = _fetch_repo_license(owner_repo)
+        except Exception:
+            spdx = ""
+        fresh["spdx"] = (spdx or "").strip()
+        fresh["klass"] = _classify_license(fresh["spdx"])
+        fresh["source"] = "github"
+    if model_url and (not code_url or fresh["klass"] in ("missing", "unknown")):
+        owner_model = model_url.split("huggingface.co/", 1)[-1].rstrip("/")
+        try:
+            spdx = _fetch_hf_license(owner_model)
+        except Exception:
+            spdx = ""
+        if spdx:
+            fresh["spdx"] = spdx.strip()
+            fresh["klass"] = _classify_license(fresh["spdx"])
+            fresh["source"] = "hf"
+    if not code_url and not model_url:
+        # The previous snapshot was "no code link found." Nothing to
+        # re-check until the agent re-discovers a URL — out of scope
+        # for the in-band watch.
+        return None
+    # Score against permissive target (the conservative default; the
+    # interest's actual target class isn't easily reachable here).
+    fresh["compat"] = _license_compat_score(fresh["klass"], "permissive")
+    return fresh
+
+
+def _is_license_newly_viable(prev: dict, curr: dict) -> bool:
+    """True if the recommendation transitioned from blocked to viable.
+
+    "Blocked" = compat < 0.50 (no-code-link, missing, or nc) at the
+    recommendation snapshot. "Viable" = compat >= 1.00 at the re-check
+    (permissive only — copyleft into a permissive target stays a
+    yellow flag, not a green one, and shouldn't fire as "newly viable").
+    """
+    return prev["compat"] < 0.5 <= 1.0 <= curr["compat"]
+
+
+def _arxiv_id_from_outrider_body(body: str) -> str:
+    """Extract the arxiv id from an Outrider Issue/PR body.
+
+    The body always links the paper as ``https://arxiv.org/abs/<id>``
+    near the top (set by the PR/Issue templates). Returns "" when no
+    arxiv link is found.
+    """
+    if not body:
+        return ""
+    m = re.search(r"https?://arxiv\.org/abs/([\w./-]+)", body)
+    return (m.group(1) if m else "").rstrip(").,")
+
+
+def _newly_viable_outrider_artifacts(
+    target: Target, max_items: int = 5,
+) -> list[dict]:
+    """Iterate open Outrider Issues; surface ones whose license transitioned
+    from blocked to viable since recommendation time.
+
+    Returns a list of dicts: ``number``, ``title``, ``url``,
+    ``arxiv_id``, ``prev`` snapshot, ``curr`` snapshot — capped at
+    ``max_items`` so the digest doesn't balloon if many recommendations
+    were unblocked in the same week.
+    """
+    try:
+        items = _remyx_issues(target, state="open") or []
+    except Exception as e:
+        log.debug(f"  newly-viable fetch for {target.repo} failed: {e}")
+        return []
+
+    out: list[dict] = []
+    for item in items:
+        body = item.get("body") or ""
+        prev = _parse_license_state_from_issue_body(body)
+        if not prev:
+            continue
+        # Only re-check Issues that were blocked at recommendation time.
+        if prev["compat"] >= 1.0:
+            continue
+        try:
+            curr = _recheck_outrider_license_state(prev)
+        except Exception as e:
+            log.debug(
+                f"  recheck failed for issue #{item.get('number')}: {e}"
+            )
+            continue
+        if not curr:
+            continue
+        if not _is_license_newly_viable(prev, curr):
+            continue
+        out.append({
+            "number": item.get("number"),
+            "title": item.get("title") or "",
+            "url": item.get("html_url") or "",
+            "arxiv_id": _arxiv_id_from_outrider_body(body),
+            "prev": prev,
+            "curr": curr,
+        })
+        if len(out) >= max_items:
+            break
+    return out
+
+
+def _render_newly_viable_section(transitions: list[dict]) -> list[str]:
+    """Render the "Newly viable recommendations" markdown lines.
+
+    Returns ``[]`` when no transitions — caller skips the section header
+    entirely (same shape as the lifecycle-events renderer).
+    """
+    if not transitions:
+        return []
+    lines: list[str] = [
+        "",
+        "### 🟢 Newly viable recommendations",
+        "",
+        "Recommendations previously blocked at the license/code-availability "
+        "gate now resolve to a permissive license. Worth reconsidering:",
+        "",
+    ]
+    for t in transitions:
+        prev = t["prev"]
+        curr = t["curr"]
+        prev_label = (
+            f"`{prev['spdx']}`" if prev["spdx"]
+            else "no declared license"
+        )
+        prev_klass = prev["klass"]
+        curr_spdx = curr["spdx"] or "(detected)"
+        lines.append(
+            f"- [Issue #{t['number']}]({t['url']}) "
+            f"{_short_artifact_title(t['title'])[:80]} — "
+            f"upstream now publishes `{curr_spdx}` "
+            f"(was: {prev_label}, class `{prev_klass}`, compat "
+            f"{prev['compat']:.2f}). Re-run selection to confirm "
+            f"structural fit, then decide whether to draft a PR."
+        )
+    return lines
+
+
 def run_weekly_summary(target: Target) -> dict:
     """Aggregate the past week's runs and post the digest to the
     configured Discussion. The weekly-mode counterpart to
@@ -6972,6 +7194,11 @@ def run_weekly_summary(target: Target) -> dict:
     lifecycle_events = _lifecycle_events_for_outrider_artifacts(
         target, window_start, window_end,
     )
+    # License-watch: re-check upstream license for open Outrider Issues
+    # that were originally blocked at the license/code-availability gate;
+    # surface ones that transitioned to viable (REMYX-115). Sibling
+    # category to the lifecycle events above — shares the same surface.
+    newly_viable = _newly_viable_outrider_artifacts(target)
     agg = _aggregate_week(entries)
     agg["repo"] = target.repo
     prior_digest = _fetch_prior_digest_excerpt(discussion_id)
@@ -6979,6 +7206,7 @@ def run_weekly_summary(target: Target) -> dict:
     body = _compose_weekly_markdown(
         window_start, window_end, agg, open_items, drafted,
         lifecycle_events=lifecycle_events,
+        newly_viable=newly_viable,
     )
     url = _post_discussion_comment(discussion_id, body)
     result.update({

--- a/src/run.py
+++ b/src/run.py
@@ -6566,6 +6566,7 @@ def _compose_weekly_markdown(
     agg: dict,
     open_items: list[dict],
     drafted: dict | None,
+    lifecycle_events: list[dict] | None = None,
 ) -> str:
     """Assemble the Discussion-comment body.
 
@@ -6628,6 +6629,11 @@ def _compose_weekly_markdown(
     if trends:
         lines += ["", "### 📈 In the research stream", ""]
         lines += [f"- {t}" for t in trends]
+
+    # Lifecycle events on Outrider Issues/PRs in the past 7 days
+    # (REMYX-114). Section omitted entirely when no events occurred.
+    if lifecycle_events:
+        lines += _render_lifecycle_events_section(lifecycle_events, window_end)
 
     if open_items:
         next_actions = drafted.get("next_actions")
@@ -6714,6 +6720,225 @@ def _compose_weekly_markdown(
     return "\n".join(lines)
 
 
+# ─── Lifecycle events for Outrider-authored artifacts (REMYX-114) ─────────
+
+
+def _is_bot_actor(user: dict | None) -> bool:
+    """True if a GitHub API ``user`` dict belongs to a bot account.
+
+    Filters our own follow-ups out of "lifecycle events" the weekly
+    summary surfaces — comments by ``remyx-ai[bot]`` or
+    ``github-actions[bot]`` aren't new signal for the maintainer.
+    """
+    if not user:
+        return True
+    if (user.get("type") or "").lower() == "bot":
+        return True
+    login = (user.get("login") or "").lower()
+    return login in {"remyx-ai[bot]", "github-actions[bot]", "app/remyx-ai"}
+
+
+def _is_outrider_artifact(item: dict) -> bool:
+    """True if a GitHub Issue/PR was opened by Outrider.
+
+    Matches both historical artifacts (``[Remyx Recommendation]`` title
+    prefix) and new-format artifacts (body marker from the orchestrator-
+    built PR body footer).
+    """
+    title = item.get("title") or ""
+    body = item.get("body") or ""
+    head_ref = (((item.get("pull_request") or {}).get("head") or {}).get("ref")
+                if item.get("pull_request") else None)
+    head_ref = head_ref or ((item.get("head") or {}).get("ref") if item.get("head") else "")
+    return (
+        title.startswith(PR_TITLE_PREFIX)
+        or "Remyx Recommendation" in body
+        or (head_ref and head_ref.startswith(BRANCH_PREFIX))
+    )
+
+
+def _parse_iso(s: str) -> "dt.datetime | None":
+    """Parse a GitHub ISO-8601 timestamp; return None on failure."""
+    if not s:
+        return None
+    try:
+        # GitHub returns 2026-06-12T15:30:00Z; Python's fromisoformat
+        # handles the Z suffix from 3.11+ but we replace for safety.
+        return dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def _relative_when(when: "dt.datetime", now: "dt.datetime") -> str:
+    """Format a recent past timestamp as 'today' / 'yesterday' / 'N days ago'.
+
+    Caps at 7 days since that's the weekly window — anything older would
+    be a bug (or a freshly-discovered event in a stale artifact).
+    """
+    delta = now - when
+    days = delta.days
+    if days < 0:
+        return "just now"
+    if days == 0:
+        return "today"
+    if days == 1:
+        return "yesterday"
+    return f"{days} days ago"
+
+
+def _lifecycle_events_for_outrider_artifacts(
+    target: Target, window_start: "dt.datetime", window_end: "dt.datetime",
+    max_events: int = 10,
+) -> list[dict]:
+    """Detect state-change events on Outrider-authored Issues/PRs in the window.
+
+    Single-pass over the target repo's recently-updated issues+PRs (the
+    REST ``issues`` endpoint returns both with ``pull_request`` set on
+    PRs), filtered to Outrider-authored. For each, emit events that
+    occurred in ``[window_start, window_end]``:
+
+    - Issue/PR closed or reopened
+    - PR merged (state=closed AND merged_at within window)
+    - New comments from non-bot actors
+    - PR reviews from non-bot actors
+
+    Returns events sorted by recency (newest first), capped at
+    ``max_events`` so the digest doesn't balloon. Terminal events
+    (merged/closed) are prioritized over intermediate ones when the cap
+    is reached.
+    """
+    since_iso = window_start.strftime("%Y-%m-%dT%H:%M:%SZ")
+    try:
+        items = gh_api(
+            "GET",
+            f"/repos/{target.repo}/issues"
+            f"?state=all&since={since_iso}&per_page=100",
+        ) or []
+    except Exception as e:
+        log.debug(f"  lifecycle events fetch for {target.repo} failed: {e}")
+        return []
+
+    events: list[dict] = []
+    for item in items:
+        if not _is_outrider_artifact(item):
+            continue
+
+        number = item.get("number")
+        title = item.get("title") or ""
+        html_url = item.get("html_url") or ""
+        is_pr = item.get("pull_request") is not None
+        kind_prefix = "PR" if is_pr else "Issue"
+
+        # Terminal state events
+        if item.get("state") == "closed":
+            closed_at = _parse_iso(item.get("closed_at") or "")
+            if closed_at and window_start <= closed_at <= window_end:
+                # PR merged is a distinct, higher-signal terminal event
+                merged_at_str = (item.get("pull_request") or {}).get("merged_at")
+                merged_at = _parse_iso(merged_at_str) if merged_at_str else None
+                if merged_at and window_start <= merged_at <= window_end:
+                    events.append({
+                        "number": number, "title": title, "url": html_url,
+                        "kind_prefix": kind_prefix, "kind": "merged",
+                        "when": merged_at, "actor": "maintainer",
+                        "priority": 0,  # terminal events go first
+                    })
+                else:
+                    closed_by = (item.get("closed_by") or {}).get("login") or "maintainer"
+                    events.append({
+                        "number": number, "title": title, "url": html_url,
+                        "kind_prefix": kind_prefix, "kind": "closed",
+                        "when": closed_at, "actor": closed_by,
+                        "priority": 0,
+                    })
+
+        # Recently-opened Outrider artifacts also count as activity
+        # (the maintainer wants to see "Outrider opened #N this week").
+        created_at = _parse_iso(item.get("created_at") or "")
+        if created_at and window_start <= created_at <= window_end:
+            events.append({
+                "number": number, "title": title, "url": html_url,
+                "kind_prefix": kind_prefix, "kind": "opened",
+                "when": created_at, "actor": "Outrider",
+                "priority": 2,  # informational
+            })
+
+        # Comments from non-bot actors in the window
+        try:
+            comments = gh_api(
+                "GET",
+                f"/repos/{target.repo}/issues/{number}/comments"
+                f"?since={since_iso}&per_page=50",
+            ) or []
+        except Exception:
+            comments = []
+        for c in comments:
+            user = c.get("user") or {}
+            if _is_bot_actor(user):
+                continue
+            when = _parse_iso(c.get("created_at") or "")
+            if not when or when < window_start or when > window_end:
+                continue
+            body = (c.get("body") or "").strip()
+            # First non-empty line as a one-glance summary
+            summary_line = next(
+                (ln.strip() for ln in body.splitlines() if ln.strip()), ""
+            )
+            events.append({
+                "number": number, "title": title, "url": html_url,
+                "kind_prefix": kind_prefix, "kind": "comment",
+                "when": when, "actor": user.get("login") or "?",
+                "summary": summary_line[:120],
+                "priority": 1,
+            })
+
+    # Sort by (priority asc, when desc) — terminal events first within
+    # each artifact, then newest events overall.
+    events.sort(key=lambda e: (e.get("priority", 9), -(e["when"].timestamp())))
+    return events[:max_events]
+
+
+def _render_lifecycle_events_section(
+    events: list[dict], now: "dt.datetime",
+) -> list[str]:
+    """Render the Outrider-artifact lifecycle events as markdown lines.
+
+    Returns ``[]`` when no events were detected — caller skips the
+    section header entirely (no "nothing happened" noise per the
+    REMYX-114 acceptance criteria).
+    """
+    if not events:
+        return []
+    lines: list[str] = [
+        "",
+        "### 🔁 Recent activity on Outrider Issues/PRs",
+        "",
+    ]
+    for e in events:
+        when_label = _relative_when(e["when"], now)
+        actor = e.get("actor") or "?"
+        kind = e.get("kind")
+        prefix = e.get("kind_prefix") or "Item"
+        number = e.get("number")
+        url = e.get("url")
+        short_title = _short_artifact_title(e.get("title") or "")[:80]
+        head = f"- [{prefix} #{number}]({url}) ({short_title})"
+        if kind == "merged":
+            lines.append(f"{head} — merged {when_label}")
+        elif kind == "closed":
+            lines.append(f"{head} — closed by @{actor} {when_label}")
+        elif kind == "opened":
+            lines.append(f"{head} — opened by Outrider {when_label}")
+        elif kind == "comment":
+            summary = (e.get("summary") or "").rstrip(":") or "(no summary)"
+            lines.append(
+                f"{head} — comment by @{actor} {when_label}: {summary}"
+            )
+        else:
+            lines.append(f"{head} — {kind} {when_label}")
+    return lines
+
+
 def run_weekly_summary(target: Target) -> dict:
     """Aggregate the past week's runs and post the digest to the
     configured Discussion. The weekly-mode counterpart to
@@ -6740,12 +6965,20 @@ def run_weekly_summary(target: Target) -> dict:
         key=lambda it: it.get("created_at") or "",
         reverse=True,
     )
+    # Lifecycle events on Outrider-authored Issues/PRs in the window —
+    # state transitions + maintainer comments since the prior digest
+    # (REMYX-114). Empty list when nothing changed; the render code
+    # then omits the section header entirely.
+    lifecycle_events = _lifecycle_events_for_outrider_artifacts(
+        target, window_start, window_end,
+    )
     agg = _aggregate_week(entries)
     agg["repo"] = target.repo
     prior_digest = _fetch_prior_digest_excerpt(discussion_id)
     drafted = _draft_weekly_narrative(agg, open_items, prior_digest)
     body = _compose_weekly_markdown(
         window_start, window_end, agg, open_items, drafted,
+        lifecycle_events=lifecycle_events,
     )
     url = _post_discussion_comment(discussion_id, body)
     result.update({

--- a/src/run.py
+++ b/src/run.py
@@ -7117,11 +7117,56 @@ def _arxiv_id_from_outrider_body(body: str) -> str:
     return (m.group(1) if m else "").rstrip(").,")
 
 
+def _discover_code_url_from_comments(
+    target: Target, issue_number: int,
+) -> str | None:
+    """Scan an Outrider Issue's comments for a code URL the agent didn't
+    surface in the body.
+
+    Maintainer-written discussion often names the upstream code repo
+    even when the original recommendation came through as ``no-code-link``
+    (e.g. a licensing-audit comment that enumerates the upstream
+    repo's missing LICENSE). Returns the first non-Remyx GitHub URL
+    found, or ``None``.
+
+    Best-effort: any API failure returns ``None`` so the caller
+    proceeds without the comment-discovered URL.
+    """
+    if not issue_number:
+        return None
+    try:
+        comments = gh_api(
+            "GET",
+            f"/repos/{target.repo}/issues/{issue_number}/comments?per_page=50",
+        ) or []
+    except Exception:
+        return None
+    for c in comments:
+        body = c.get("body") or ""
+        slugs = [
+            s for s in _extract_github_urls(body)
+            if not s.lower().startswith(("remyxai/", "smellslikeml/"))
+        ]
+        if slugs:
+            return f"https://github.com/{slugs[0]}"
+    return None
+
+
 def _newly_viable_outrider_artifacts(
     target: Target, max_items: int = 5,
 ) -> list[dict]:
     """Iterate open Outrider Issues; surface ones whose license transitioned
     from blocked to viable since recommendation time.
+
+    Lookup order for each Issue:
+
+    1. Parse the structured License line from the body (current-format
+       Outrider Issues written by ``_render_license_section``).
+    2. Fallback: scan the body for any GitHub/HF URLs (older-format
+       Issues where the URL appears outside a structured section).
+    3. Fallback: scan the Issue's comments for a GitHub URL maintainers
+       referenced after recommendation time (e.g. licensing-audit
+       comments that name the upstream repo).
 
     Returns a list of dicts: ``number``, ``title``, ``url``,
     ``arxiv_id``, ``prev`` snapshot, ``curr`` snapshot — capped at
@@ -7138,6 +7183,26 @@ def _newly_viable_outrider_artifacts(
     for item in items:
         body = item.get("body") or ""
         prev = _parse_license_state_from_issue_body(body)
+        # Comment-scan fallback: when the body parse fails OR when the
+        # parsed snapshot has no code URL to re-check against (e.g.
+        # a no-code-link snapshot), look in the comments for one.
+        if (prev is None
+                or (not prev.get("code_url") and not prev.get("model_url"))):
+            discovered = _discover_code_url_from_comments(
+                target, item.get("number"),
+            )
+            if discovered:
+                if prev is None:
+                    prev = {
+                        "spdx": "", "klass": "no-enrichment",
+                        "compat": 0.30, "source": "comments-scan",
+                    }
+                else:
+                    prev["source"] = (
+                        f"{prev.get('source') or 'body'}+comments-scan"
+                    )
+                prev["code_url"] = discovered
+
         if not prev:
             continue
         # Only re-check Issues that were blocked at recommendation time.

--- a/src/run.py
+++ b/src/run.py
@@ -6980,30 +6980,72 @@ def _parse_license_state_from_issue_body(body: str) -> dict | None:
 
     Returns a dict with ``spdx``, ``klass``, ``compat`` (float),
     ``code_url`` / ``model_url`` (optional), and ``source`` (optional).
-    Returns ``None`` if no license line can be parsed (e.g. the Issue
-    body shape is unfamiliar — graceful skip rather than crash).
+
+    Two paths:
+
+    - **Structured**: matches the License line that ``_render_license_section``
+      writes ("**License**: ``<spdx>`` (class: ``<klass>``, compat: <c>...)").
+      This is the normal path for current-format Outrider Issues.
+    - **Body-scan fallback**: when the structured line is absent (older
+      Issue formats from before license enrichment was always-on), scan
+      the body for any GitHub or HuggingFace URLs and synthesize a
+      "no-enrichment" snapshot with ``klass="no-enrichment"`` and
+      ``compat=0.30`` (treated as blocked, same severity as
+      ``no-code-link``). The license-watch can then re-check the
+      upstream URL and surface the Issue if the current state is
+      permissive.
+
+    Returns ``None`` only when neither path yields anything usable.
     """
     if not body:
         return None
     m = _LICENSE_BODY_LINE_RE.search(body)
-    if not m:
+    if m:
+        try:
+            compat = float(m.group("compat"))
+        except (TypeError, ValueError):
+            return None
+        snap: dict = {
+            "spdx": (m.group("spdx") or "").strip(),
+            "klass": (m.group("klass") or "").strip(),
+            "compat": compat,
+            "source": m.group("source"),
+        }
+        code = _CODE_BODY_LINE_RE.search(body)
+        if code:
+            snap["code_url"] = code.group("url").rstrip(".,")
+        model = _MODEL_BODY_LINE_RE.search(body)
+        if model:
+            snap["model_url"] = model.group("url").rstrip(".,")
+        return snap
+
+    # Fallback: no structured License section, but the body may still
+    # reference a code URL the agent linked elsewhere (e.g. older Issue
+    # bodies opened before license enrichment was always-on, or agent-
+    # written Issue bodies that linked the repo from a free-form section).
+    # ``_extract_github_urls`` / ``_extract_huggingface_urls`` return
+    # ``owner/repo`` slugs; prepend the host so downstream consumers
+    # (``_recheck_outrider_license_state``) get the full URL shape they
+    # expect.
+    github_slugs = [
+        s for s in _extract_github_urls(body)
+        # Skip Remyx's own URLs — these appear in the orchestrator
+        # footer / call-to-action lines, not the paper's reference repo.
+        if not s.lower().startswith(("remyxai/", "smellslikeml/"))
+    ]
+    hf_slugs = _extract_huggingface_urls(body)
+    if not github_slugs and not hf_slugs:
         return None
-    try:
-        compat = float(m.group("compat"))
-    except (TypeError, ValueError):
-        return None
-    snap: dict = {
-        "spdx": (m.group("spdx") or "").strip(),
-        "klass": (m.group("klass") or "").strip(),
-        "compat": compat,
-        "source": m.group("source"),
+    snap = {
+        "spdx": "",
+        "klass": "no-enrichment",
+        "compat": 0.30,
+        "source": "body-scan",
     }
-    code = _CODE_BODY_LINE_RE.search(body)
-    if code:
-        snap["code_url"] = code.group("url").rstrip(".,")
-    model = _MODEL_BODY_LINE_RE.search(body)
-    if model:
-        snap["model_url"] = model.group("url").rstrip(".,")
+    if github_slugs:
+        snap["code_url"] = f"https://github.com/{github_slugs[0]}"
+    if hf_slugs:
+        snap["model_url"] = f"https://huggingface.co/{hf_slugs[0]}"
     return snap
 
 

--- a/tests/test_license_watch.py
+++ b/tests/test_license_watch.py
@@ -1,0 +1,334 @@
+"""Tests for the licensing-watch helpers (weekly-summary side).
+
+Covers parsing the license snapshot from Outrider Issue bodies + the
+transition logic that fires when a previously-blocked recommendation's
+upstream license becomes permissive.
+
+Run with: pytest tests/test_license_watch.py -q
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Target  # noqa: E402
+
+
+# Sample issue body shapes that match the templates Outrider writes via
+# `_render_license_section`.
+
+ISSUE_BODY_BLOCKED_NO_CODE = """\
+**Recommended paper**: [Some Paper](https://arxiv.org/abs/2310.99999v1)
+**Confidence**: 🟡 moderate (Remyx relevance 0.65)
+
+## License & code availability
+
+🟡 No code repository surfaced — couldn't fetch a LICENSE to evaluate.
+
+- **Code / model**: no repository or model URL surfaced in the paper.
+- **License**: `(none detected)` (class: `no-code-link`, compat: 0.30)
+"""
+
+ISSUE_BODY_BLOCKED_MISSING_LICENSE = """\
+**Recommended paper**: [Other Paper](https://arxiv.org/abs/2606.11111v2)
+**Confidence**: 🟡 moderate (Remyx relevance 0.72)
+
+## License & code availability
+
+🟠 **No LICENSE file detected** — no legal permission to redistribute.
+
+- **Code**: https://github.com/some-author/some-repo
+- **License**: `(none detected)` (class: `missing`, compat: 0.00, source: `github`)
+"""
+
+ISSUE_BODY_PERMISSIVE = """\
+**Recommended paper**: [Permissive Paper](https://arxiv.org/abs/2606.22222v1)
+
+## License & code availability
+
+🟢 Permissive license — safe to adopt.
+
+- **Code**: https://github.com/some-author/permissive-repo
+- **License**: `Apache-2.0` (class: `permissive`, compat: 1.00, source: `github`)
+"""
+
+ISSUE_BODY_NO_LICENSE_SECTION = """\
+This is an Issue that doesn't have the License section
+(maybe an older Outrider format or a stub Issue).
+"""
+
+
+# ─── _parse_license_state_from_issue_body ─────────────────────────────────
+
+
+def test_parse_extracts_blocked_no_code() -> None:
+    snap = run._parse_license_state_from_issue_body(ISSUE_BODY_BLOCKED_NO_CODE)
+    assert snap is not None
+    assert snap["spdx"] == "(none detected)"
+    assert snap["klass"] == "no-code-link"
+    assert snap["compat"] == 0.30
+    assert "code_url" not in snap  # no URL surfaced
+    assert "model_url" not in snap
+
+
+def test_parse_extracts_blocked_missing_license_with_code() -> None:
+    snap = run._parse_license_state_from_issue_body(
+        ISSUE_BODY_BLOCKED_MISSING_LICENSE
+    )
+    assert snap is not None
+    assert snap["klass"] == "missing"
+    assert snap["compat"] == 0.00
+    assert snap["source"] == "github"
+    assert snap["code_url"] == "https://github.com/some-author/some-repo"
+
+
+def test_parse_extracts_permissive() -> None:
+    snap = run._parse_license_state_from_issue_body(ISSUE_BODY_PERMISSIVE)
+    assert snap is not None
+    assert snap["spdx"] == "Apache-2.0"
+    assert snap["klass"] == "permissive"
+    assert snap["compat"] == 1.00
+
+
+def test_parse_returns_none_on_unrecognized_body() -> None:
+    assert run._parse_license_state_from_issue_body(
+        ISSUE_BODY_NO_LICENSE_SECTION
+    ) is None
+    assert run._parse_license_state_from_issue_body("") is None
+    assert run._parse_license_state_from_issue_body(None) is None  # type: ignore[arg-type]
+
+
+# ─── _is_license_newly_viable ─────────────────────────────────────────────
+
+
+def test_transition_blocked_to_permissive_fires() -> None:
+    prev = {"compat": 0.30, "klass": "no-code-link", "spdx": ""}
+    curr = {"compat": 1.00, "klass": "permissive", "spdx": "MIT"}
+    assert run._is_license_newly_viable(prev, curr)
+
+
+def test_transition_missing_to_permissive_fires() -> None:
+    prev = {"compat": 0.00, "klass": "missing", "spdx": ""}
+    curr = {"compat": 1.00, "klass": "permissive", "spdx": "Apache-2.0"}
+    assert run._is_license_newly_viable(prev, curr)
+
+
+def test_no_transition_when_was_already_permissive() -> None:
+    prev = {"compat": 1.00, "klass": "permissive", "spdx": "MIT"}
+    curr = {"compat": 1.00, "klass": "permissive", "spdx": "MIT"}
+    assert not run._is_license_newly_viable(prev, curr)
+
+
+def test_no_transition_when_still_blocked() -> None:
+    prev = {"compat": 0.30, "klass": "no-code-link", "spdx": ""}
+    curr = {"compat": 0.30, "klass": "no-code-link", "spdx": ""}
+    assert not run._is_license_newly_viable(prev, curr)
+
+
+def test_no_transition_to_copyleft_only() -> None:
+    """Copyleft into a permissive-target repo stays a yellow flag, not green —
+    don't fire 'newly viable' for AGPL/GPL added to upstream."""
+    prev = {"compat": 0.30, "klass": "no-code-link", "spdx": ""}
+    curr = {"compat": 0.50, "klass": "copyleft", "spdx": "AGPL-3.0"}
+    assert not run._is_license_newly_viable(prev, curr)
+
+
+# ─── _arxiv_id_from_outrider_body ─────────────────────────────────────────
+
+
+def test_arxiv_id_extracted_from_body() -> None:
+    assert run._arxiv_id_from_outrider_body(ISSUE_BODY_BLOCKED_NO_CODE) == "2310.99999v1"
+    assert run._arxiv_id_from_outrider_body(ISSUE_BODY_PERMISSIVE) == "2606.22222v1"
+
+
+def test_arxiv_id_empty_when_no_link() -> None:
+    assert run._arxiv_id_from_outrider_body("just some text without arxiv link") == ""
+    assert run._arxiv_id_from_outrider_body("") == ""
+
+
+# ─── _recheck_outrider_license_state ──────────────────────────────────────
+
+
+def test_recheck_returns_none_when_no_code_url(monkeypatch) -> None:
+    """A previously-no-code-link snapshot has nothing to re-check
+    in-band — return None so caller skips."""
+    snap = {"spdx": "", "klass": "no-code-link", "compat": 0.30, "source": None}
+    assert run._recheck_outrider_license_state(snap) is None
+
+
+def test_recheck_picks_up_newly_added_github_license(monkeypatch) -> None:
+    """Snapshot had missing license; upstream now publishes Apache-2.0."""
+    monkeypatch.setattr(
+        run, "_fetch_repo_license",
+        lambda owner_repo: "Apache-2.0" if owner_repo == "some-author/some-repo" else "",
+    )
+    snap = {
+        "spdx": "", "klass": "missing", "compat": 0.00, "source": "github",
+        "code_url": "https://github.com/some-author/some-repo",
+    }
+    curr = run._recheck_outrider_license_state(snap)
+    assert curr is not None
+    assert curr["spdx"] == "Apache-2.0"
+    assert curr["klass"] == "permissive"
+    assert curr["compat"] == 1.00
+
+
+def test_recheck_handles_fetch_failure(monkeypatch) -> None:
+    """If _fetch_repo_license raises, recheck still returns a structured
+    result with klass='missing' instead of crashing."""
+
+    def boom(owner_repo):
+        raise RuntimeError("simulated transport error")
+
+    monkeypatch.setattr(run, "_fetch_repo_license", boom)
+    snap = {
+        "spdx": "", "klass": "missing", "compat": 0.00, "source": "github",
+        "code_url": "https://github.com/x/y",
+    }
+    curr = run._recheck_outrider_license_state(snap)
+    assert curr is not None
+    assert curr["klass"] == "missing"
+    assert curr["compat"] == 0.00
+
+
+# ─── _newly_viable_outrider_artifacts ─────────────────────────────────────
+
+
+def _target() -> Target:
+    return Target(repo="owner/repo", interest_id="iid")
+
+
+def test_newly_viable_surfaces_transition(monkeypatch) -> None:
+    """End-to-end: open Outrider Issue with missing-license snapshot, upstream
+    now publishes MIT — should surface as newly viable."""
+    monkeypatch.setattr(
+        run, "_remyx_issues",
+        lambda target, state="open": [
+            {
+                "number": 87,
+                "title": "[Remyx Recommendation] InstructSAM",
+                "html_url": "https://github.com/o/r/issues/87",
+                "body": ISSUE_BODY_BLOCKED_MISSING_LICENSE,
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        run, "_fetch_repo_license",
+        lambda owner_repo: "MIT",
+    )
+
+    out = run._newly_viable_outrider_artifacts(_target())
+    assert len(out) == 1
+    item = out[0]
+    assert item["number"] == 87
+    assert item["arxiv_id"] == "2606.11111v2"
+    assert item["prev"]["klass"] == "missing"
+    assert item["curr"]["klass"] == "permissive"
+    assert item["curr"]["spdx"] == "MIT"
+
+
+def test_newly_viable_skips_already_permissive(monkeypatch) -> None:
+    """An Issue whose body recorded compat=1.00 at recommendation time
+    isn't blocked — should NOT be re-checked or surfaced."""
+    monkeypatch.setattr(
+        run, "_remyx_issues",
+        lambda target, state="open": [
+            {
+                "number": 5,
+                "title": "[Remyx Recommendation] Already Permissive",
+                "html_url": "https://github.com/o/r/issues/5",
+                "body": ISSUE_BODY_PERMISSIVE,
+            },
+        ],
+    )
+    # Even if we mock _fetch_repo_license to MIT, the filter should
+    # skip before reaching the re-check.
+    monkeypatch.setattr(run, "_fetch_repo_license", lambda owner_repo: "MIT")
+
+    out = run._newly_viable_outrider_artifacts(_target())
+    assert out == []
+
+
+def test_newly_viable_skips_no_license_section(monkeypatch) -> None:
+    """An Issue body without the License section parses to None and is skipped."""
+    monkeypatch.setattr(
+        run, "_remyx_issues",
+        lambda target, state="open": [
+            {
+                "number": 9,
+                "title": "[Remyx Recommendation] Old-format Issue",
+                "html_url": "https://github.com/o/r/issues/9",
+                "body": ISSUE_BODY_NO_LICENSE_SECTION,
+            },
+        ],
+    )
+    monkeypatch.setattr(run, "_fetch_repo_license", lambda owner_repo: "MIT")
+
+    out = run._newly_viable_outrider_artifacts(_target())
+    assert out == []
+
+
+def test_newly_viable_no_transition_no_event(monkeypatch) -> None:
+    """Issue had no-code-link snapshot; current re-check finds nothing
+    (recheck returns None) — no event surfaces."""
+    monkeypatch.setattr(
+        run, "_remyx_issues",
+        lambda target, state="open": [
+            {
+                "number": 12,
+                "title": "[Remyx Recommendation] No Code",
+                "html_url": "https://github.com/o/r/issues/12",
+                "body": ISSUE_BODY_BLOCKED_NO_CODE,
+            },
+        ],
+    )
+
+    out = run._newly_viable_outrider_artifacts(_target())
+    assert out == []
+
+
+def test_newly_viable_caps_at_max(monkeypatch) -> None:
+    """With many transitioning Issues, the cap is enforced."""
+    issues = [
+        {
+            "number": 100 + i,
+            "title": f"[Remyx Recommendation] Paper {i}",
+            "html_url": f"https://github.com/o/r/issues/{100 + i}",
+            "body": ISSUE_BODY_BLOCKED_MISSING_LICENSE,
+        }
+        for i in range(10)
+    ]
+    monkeypatch.setattr(run, "_remyx_issues", lambda target, state="open": issues)
+    monkeypatch.setattr(run, "_fetch_repo_license", lambda owner_repo: "MIT")
+
+    out = run._newly_viable_outrider_artifacts(_target(), max_items=3)
+    assert len(out) == 3
+
+
+# ─── _render_newly_viable_section ─────────────────────────────────────────
+
+
+def test_render_empty_transitions_returns_empty() -> None:
+    assert run._render_newly_viable_section([]) == []
+
+
+def test_render_newly_viable_section_shape() -> None:
+    transitions = [{
+        "number": 87,
+        "title": "[Remyx Recommendation] InstructSAM",
+        "url": "https://github.com/o/r/issues/87",
+        "arxiv_id": "2606.11111v2",
+        "prev": {"spdx": "", "klass": "missing", "compat": 0.00, "source": "github"},
+        "curr": {"spdx": "Apache-2.0", "klass": "permissive", "compat": 1.00, "source": "github"},
+    }]
+    lines = run._render_newly_viable_section(transitions)
+    body = "\n".join(lines)
+    assert "Newly viable recommendations" in body
+    assert "Issue #87" in body
+    assert "Apache-2.0" in body
+    assert "no declared license" in body  # prev_label fallback for empty spdx
+    assert "missing" in body  # prev_klass
+    assert "Re-run selection" in body

--- a/tests/test_license_watch.py
+++ b/tests/test_license_watch.py
@@ -348,6 +348,91 @@ def test_newly_viable_no_transition_no_event(monkeypatch) -> None:
     assert out == []
 
 
+def test_newly_viable_picks_up_url_from_comments(monkeypatch) -> None:
+    """When the Issue body has no parseable License section AND no body
+    URLs, but a maintainer's comment names the upstream repo, the
+    comment-scan fallback should discover the URL and re-check it.
+
+    Models the InstructSAM case: Issue #87 body has no License section,
+    but the maintainer's licensing-audit comment names
+    `github.com/CircleRadon/InstructSAM` — if that repo now publishes
+    a permissive LICENSE, the watch surfaces it as newly viable."""
+
+    issue = {
+        "number": 87,
+        "title": "[Remyx Recommendation] InstructSAM",
+        "html_url": "https://github.com/o/r/issues/87",
+        # Body lacks the structured License section entirely
+        "body": ISSUE_BODY_NO_LICENSE_SECTION,
+    }
+    monkeypatch.setattr(run, "_remyx_issues", lambda target, state="open": [issue])
+
+    def fake_gh_api(method, path):
+        if "/issues/87/comments" in path:
+            return [
+                {
+                    "user": {"login": "smellslikeml"},
+                    "body": (
+                        "## Licensing block — InstructSAM has no declared license\n\n"
+                        "Checked the redistribution surface:\n\n"
+                        "| Source | License |\n"
+                        "|--|--|\n"
+                        "| [CircleRadon/InstructSAM repo root]"
+                        "(https://github.com/CircleRadon/InstructSAM) | No LICENSE file |"
+                    ),
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    monkeypatch.setattr(
+        run, "_fetch_repo_license",
+        lambda owner_repo: "Apache-2.0" if owner_repo == "CircleRadon/InstructSAM" else "",
+    )
+
+    out = run._newly_viable_outrider_artifacts(_target())
+    assert len(out) == 1
+    assert out[0]["number"] == 87
+    assert out[0]["prev"]["source"] == "comments-scan"
+    assert "CircleRadon/InstructSAM" in out[0]["prev"]["code_url"]
+    assert out[0]["curr"]["klass"] == "permissive"
+
+
+def test_newly_viable_comments_scan_filters_remyx_self_urls(monkeypatch) -> None:
+    """Comments often reference the orchestrator's own URLs (e.g.
+    'see github.com/remyxai/outrider/discussions/19 for more'). Those
+    must be filtered out so we don't false-positive on a Remyx repo."""
+
+    issue = {
+        "number": 1, "title": "[Remyx Recommendation] Paper",
+        "html_url": "https://github.com/o/r/issues/1",
+        "body": ISSUE_BODY_NO_LICENSE_SECTION,
+    }
+    monkeypatch.setattr(run, "_remyx_issues", lambda target, state="open": [issue])
+
+    def fake_gh_api(method, path):
+        if "/issues/1/comments" in path:
+            return [
+                {
+                    "user": {"login": "smellslikeml"},
+                    "body": (
+                        "See https://github.com/remyxai/outrider/discussions/19 "
+                        "for the broader thread."
+                    ),
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    monkeypatch.setattr(
+        run, "_fetch_repo_license", lambda owner_repo: "Apache-2.0",
+    )
+
+    out = run._newly_viable_outrider_artifacts(_target())
+    # No paper-code URL found in comments → no transition surfaces
+    assert out == []
+
+
 def test_newly_viable_caps_at_max(monkeypatch) -> None:
     """With many transitioning Issues, the cap is enforced."""
     issues = [

--- a/tests/test_license_watch.py
+++ b/tests/test_license_watch.py
@@ -101,6 +101,64 @@ def test_parse_returns_none_on_unrecognized_body() -> None:
     assert run._parse_license_state_from_issue_body(None) is None  # type: ignore[arg-type]
 
 
+# ─── Fallback: body-scan when structured License section is absent ───────
+
+
+def test_parse_fallback_picks_up_github_url_without_license_section() -> None:
+    """Older Issue bodies opened before license enrichment was always-on
+    may reference the paper's code repo without the structured License
+    section. The fallback returns a synthetic 'no-enrichment' snapshot
+    with the discovered URL, so the watch can re-check it."""
+    body = (
+        "**Recommended paper**: [Some Paper](https://arxiv.org/abs/2606.99999v1)\n"
+        "## Why this paper is interesting\n\n"
+        "The reference implementation is at https://github.com/some-author/some-repo "
+        "and it covers exactly this approach.\n"
+    )
+    snap = run._parse_license_state_from_issue_body(body)
+    assert snap is not None
+    assert snap["klass"] == "no-enrichment"
+    assert snap["compat"] == 0.30
+    assert snap["source"] == "body-scan"
+    assert snap["code_url"] == "https://github.com/some-author/some-repo"
+
+
+def test_parse_fallback_filters_remyx_self_urls() -> None:
+    """The orchestrator's footer references github.com/remyxai/... links
+    (e.g. the Outrider repo discussions URL). Those should NOT be used
+    as the paper's reference repo — filter them out."""
+    body = (
+        "**Recommended paper**: [Paper](https://arxiv.org/abs/2606.11111v1)\n"
+        "Some discussion at https://github.com/remyxai/outrider/discussions/19.\n"
+    )
+    assert run._parse_license_state_from_issue_body(body) is None
+
+
+def test_parse_fallback_picks_up_hf_model_url() -> None:
+    """HuggingFace model card URLs in the body should also trigger the
+    fallback path."""
+    body = (
+        "**Recommended paper**: [Paper](https://arxiv.org/abs/2606.22222v1)\n"
+        "The released checkpoint is at https://huggingface.co/some-org/some-model\n"
+    )
+    snap = run._parse_license_state_from_issue_body(body)
+    assert snap is not None
+    assert snap["klass"] == "no-enrichment"
+    assert snap["model_url"] == "https://huggingface.co/some-org/some-model"
+
+
+def test_parse_fallback_no_urls_returns_none() -> None:
+    """Body with no License section AND no code URLs → graceful None
+    (matches the canonical 'paper without code release' Issue shape
+    where there's nothing to watch)."""
+    body = (
+        "**Recommended paper**: [Theory-only Paper](https://arxiv.org/abs/2606.33333v1)\n"
+        "Pure theory paper — no code release. The maintainer should decide whether "
+        "the conceptual contribution is worth a write-up.\n"
+    )
+    assert run._parse_license_state_from_issue_body(body) is None
+
+
 # ─── _is_license_newly_viable ─────────────────────────────────────────────
 
 

--- a/tests/test_lifecycle_events.py
+++ b/tests/test_lifecycle_events.py
@@ -1,0 +1,359 @@
+"""Tests for the weekly-summary lifecycle-events helpers (REMYX-114).
+
+Covers:
+  - `_is_bot_actor` — bot detection across the GitHub user-dict shapes
+  - `_is_outrider_artifact` — title prefix + body marker + branch prefix
+    identification, including new-format (no title prefix) artifacts
+  - `_parse_iso` + `_relative_when` — timestamp helpers
+  - `_lifecycle_events_for_outrider_artifacts` — main detector against
+    mocked `gh_api` responses (Outrider Issue closed in window, new
+    maintainer comments, PR merged, non-Outrider items filtered out)
+  - `_render_lifecycle_events_section` — markdown shape per event kind +
+    empty-list short-circuit
+
+Run with: pytest tests/test_lifecycle_events.py -q
+"""
+from __future__ import annotations
+
+import datetime as dt
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Target  # noqa: E402
+
+
+# ─── _is_bot_actor ────────────────────────────────────────────────────────
+
+
+def test_is_bot_actor_type_bot() -> None:
+    assert run._is_bot_actor({"login": "someone", "type": "Bot"})
+    assert run._is_bot_actor({"login": "someone", "type": "bot"})
+
+
+def test_is_bot_actor_known_bot_logins() -> None:
+    assert run._is_bot_actor({"login": "remyx-ai[bot]", "type": "User"})
+    assert run._is_bot_actor({"login": "github-actions[bot]", "type": "User"})
+
+
+def test_is_bot_actor_human_user() -> None:
+    assert not run._is_bot_actor({"login": "smellslikeml", "type": "User"})
+
+
+def test_is_bot_actor_none_or_empty() -> None:
+    assert run._is_bot_actor(None)
+    assert run._is_bot_actor({})
+
+
+# ─── _is_outrider_artifact ────────────────────────────────────────────────
+
+
+def test_is_outrider_artifact_title_prefix() -> None:
+    item = {"title": "[Remyx Recommendation] Some Paper", "body": ""}
+    assert run._is_outrider_artifact(item)
+
+
+def test_is_outrider_artifact_body_marker_new_format() -> None:
+    # New-format PRs (post-v1.5.4) have no title prefix but the body
+    # always contains the marker via the orchestrator-built footer.
+    item = {
+        "title": "Some Paper Title",
+        "body": (
+            "## Summary\n...\n\n_Opened by the [Remyx Recommendation]"
+            "(https://engine.remyx.ai) orchestrator._"
+        ),
+    }
+    assert run._is_outrider_artifact(item)
+
+
+def test_is_outrider_artifact_branch_prefix_legacy() -> None:
+    # Historical PRs with the legacy branch prefix.
+    item = {
+        "title": "Some Title", "body": "",
+        "pull_request": {"head": {"ref": "remyx-recommendation/2606.06460v1"}},
+    }
+    assert run._is_outrider_artifact(item)
+
+
+def test_is_outrider_artifact_unrelated_pr_excluded() -> None:
+    item = {
+        "title": "Bump dependency X to v2.0", "body": "Standard dep bump",
+        "pull_request": {"head": {"ref": "deps/bump-x"}},
+    }
+    assert not run._is_outrider_artifact(item)
+
+
+# ─── _parse_iso + _relative_when ──────────────────────────────────────────
+
+
+def test_parse_iso_handles_z_suffix() -> None:
+    when = run._parse_iso("2026-06-12T15:30:00Z")
+    assert when is not None
+    assert when.year == 2026 and when.month == 6 and when.day == 12
+
+
+def test_parse_iso_handles_offset_suffix() -> None:
+    when = run._parse_iso("2026-06-12T15:30:00+00:00")
+    assert when is not None
+
+
+def test_parse_iso_returns_none_on_empty() -> None:
+    assert run._parse_iso("") is None
+    assert run._parse_iso(None) is None  # type: ignore[arg-type]
+    assert run._parse_iso("not a date") is None
+
+
+def test_relative_when_labels() -> None:
+    now = dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=dt.timezone.utc)
+    assert run._relative_when(now, now) == "today"
+    assert (
+        run._relative_when(now - dt.timedelta(days=1), now) == "yesterday"
+    )
+    assert run._relative_when(now - dt.timedelta(days=3), now) == "3 days ago"
+    assert run._relative_when(now - dt.timedelta(days=7), now) == "7 days ago"
+
+
+# ─── _lifecycle_events_for_outrider_artifacts ────────────────────────────
+
+
+def _target() -> Target:
+    return Target(repo="owner/repo", interest_id="iid")
+
+
+def test_lifecycle_events_picks_up_outrider_artifacts(monkeypatch) -> None:
+    """Mock gh_api to return one Outrider Issue with a maintainer comment
+    + one unrelated Issue; verify only the Outrider one shows up."""
+    window_end = dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=dt.timezone.utc)
+    window_start = window_end - dt.timedelta(days=7)
+
+    def fake_gh_api(method, path):
+        if "/comments" in path and "/issues/42/" in path:
+            return [
+                {
+                    "user": {"login": "smellslikeml", "type": "User"},
+                    "created_at": "2026-06-10T14:00:00Z",
+                    "body": "Looks great — adopting next sprint.",
+                }
+            ]
+        if "/comments" in path and "/issues/" in path:
+            return []
+        # The issues-list endpoint
+        return [
+            {
+                "number": 42,
+                "title": "[Remyx Recommendation] Some Paper",
+                "body": "...",
+                "html_url": "https://github.com/owner/repo/issues/42",
+                "state": "open",
+                "created_at": "2026-05-15T10:00:00Z",  # outside window
+                "user": {"login": "remyx-ai[bot]"},
+                "pull_request": None,
+            },
+            {
+                "number": 99,
+                "title": "Unrelated maintainer issue",
+                "body": "Regular community bug report",
+                "html_url": "https://github.com/owner/repo/issues/99",
+                "state": "open",
+                "created_at": "2026-06-11T10:00:00Z",
+                "user": {"login": "community-member"},
+                "pull_request": None,
+            },
+        ]
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+
+    events = run._lifecycle_events_for_outrider_artifacts(
+        _target(), window_start, window_end,
+    )
+
+    # Only the Outrider Issue's maintainer comment should surface
+    assert len(events) == 1
+    assert events[0]["number"] == 42
+    assert events[0]["kind"] == "comment"
+    assert events[0]["actor"] == "smellslikeml"
+    assert "adopting next sprint" in events[0]["summary"]
+
+
+def test_lifecycle_events_surfaces_merged_pr(monkeypatch) -> None:
+    window_end = dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=dt.timezone.utc)
+    window_start = window_end - dt.timedelta(days=7)
+
+    def fake_gh_api(method, path):
+        if "/comments" in path:
+            return []
+        return [
+            {
+                "number": 14,
+                "title": "[Remyx Recommendation] FlashAttention v3 integration",
+                "body": "...",
+                "html_url": "https://github.com/owner/repo/pull/14",
+                "state": "closed",
+                "created_at": "2026-05-20T10:00:00Z",
+                "closed_at": "2026-06-10T10:00:00Z",
+                "user": {"login": "remyx-ai[bot]"},
+                "pull_request": {
+                    "merged_at": "2026-06-10T10:00:00Z",
+                    "head": {"ref": "remyx-recommendation/2510.99999"},
+                },
+            },
+        ]
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    events = run._lifecycle_events_for_outrider_artifacts(
+        _target(), window_start, window_end,
+    )
+
+    assert len(events) == 1
+    assert events[0]["number"] == 14
+    assert events[0]["kind"] == "merged"
+    assert events[0]["kind_prefix"] == "PR"
+
+
+def test_lifecycle_events_filters_bot_comments(monkeypatch) -> None:
+    """A comment by github-actions[bot] should NOT show up as a lifecycle
+    event — that's our own follow-up, not a maintainer signal."""
+    window_end = dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=dt.timezone.utc)
+    window_start = window_end - dt.timedelta(days=7)
+
+    def fake_gh_api(method, path):
+        if "/comments" in path:
+            return [
+                {
+                    "user": {"login": "github-actions[bot]", "type": "Bot"},
+                    "created_at": "2026-06-11T10:00:00Z",
+                    "body": "CI passed",
+                }
+            ]
+        return [{
+            "number": 1, "title": "[Remyx Recommendation] Paper", "body": "",
+            "html_url": "https://github.com/o/r/issues/1", "state": "open",
+            "created_at": "2026-05-01T10:00:00Z",
+            "user": {"login": "remyx-ai[bot]"},
+            "pull_request": None,
+        }]
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    events = run._lifecycle_events_for_outrider_artifacts(
+        _target(), window_start, window_end,
+    )
+
+    assert events == []
+
+
+def test_lifecycle_events_handles_gh_api_failure(monkeypatch) -> None:
+    """If the issues-list call fails, return [] cleanly — the digest
+    should still post without the lifecycle section."""
+
+    def fake_gh_api(method, path):
+        raise RuntimeError("simulated 503")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    window_end = dt.datetime(2026, 6, 12, tzinfo=dt.timezone.utc)
+    events = run._lifecycle_events_for_outrider_artifacts(
+        _target(), window_end - dt.timedelta(days=7), window_end,
+    )
+    assert events == []
+
+
+def test_lifecycle_events_caps_at_max(monkeypatch) -> None:
+    """With many events, the cap is enforced and terminal events
+    (priority 0 — merged/closed) are preserved over intermediate ones."""
+    window_end = dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=dt.timezone.utc)
+    window_start = window_end - dt.timedelta(days=7)
+
+    # Build many Outrider artifacts — 3 with closed events + many with
+    # comment events. The cap should keep the 3 terminal events plus
+    # fill with the most recent comments.
+    items = []
+    for i in range(3):
+        items.append({
+            "number": 1000 + i,
+            "title": "[Remyx Recommendation] Closed paper",
+            "body": "", "html_url": f"https://github.com/o/r/issues/{1000 + i}",
+            "state": "closed",
+            "created_at": "2026-05-01T10:00:00Z",
+            "closed_at": f"2026-06-{8 + i:02d}T12:00:00Z",
+            "user": {"login": "remyx-ai[bot]"},
+            "pull_request": None,
+        })
+    for i in range(20):
+        items.append({
+            "number": 2000 + i,
+            "title": "[Remyx Recommendation] Open paper with comment",
+            "body": "", "html_url": f"https://github.com/o/r/issues/{2000 + i}",
+            "state": "open",
+            "created_at": "2026-05-01T10:00:00Z",
+            "user": {"login": "remyx-ai[bot]"},
+            "pull_request": None,
+        })
+
+    def fake_gh_api(method, path):
+        if "/comments" in path:
+            num = int(path.split("/issues/")[1].split("/")[0])
+            if num >= 2000:
+                return [
+                    {
+                        "user": {"login": "smellslikeml", "type": "User"},
+                        "created_at": "2026-06-11T10:00:00Z",
+                        "body": f"comment on {num}",
+                    }
+                ]
+            return []
+        return items
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    events = run._lifecycle_events_for_outrider_artifacts(
+        _target(), window_start, window_end, max_events=5,
+    )
+
+    assert len(events) == 5
+    # The 3 closed events (priority 0) should be in the first 3 slots
+    closed_count = sum(1 for e in events if e["kind"] == "closed")
+    assert closed_count == 3
+
+
+# ─── _render_lifecycle_events_section ─────────────────────────────────────
+
+
+def test_render_empty_events_returns_empty_list() -> None:
+    """No events -> no section header (skipped entirely per acceptance criteria)."""
+    now = dt.datetime(2026, 6, 12, tzinfo=dt.timezone.utc)
+    assert run._render_lifecycle_events_section([], now) == []
+
+
+def test_render_merged_pr() -> None:
+    now = dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=dt.timezone.utc)
+    events = [{
+        "number": 14, "title": "FlashAttention v3 integration",
+        "url": "https://github.com/o/r/pull/14",
+        "kind_prefix": "PR", "kind": "merged",
+        "when": now - dt.timedelta(days=2), "actor": "maintainer",
+        "priority": 0,
+    }]
+    lines = run._render_lifecycle_events_section(events, now)
+    body = "\n".join(lines)
+    assert "Recent activity on Outrider Issues/PRs" in body
+    assert "PR #14" in body
+    assert "merged 2 days ago" in body
+
+
+def test_render_comment_event() -> None:
+    now = dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=dt.timezone.utc)
+    events = [{
+        "number": 87, "title": "InstructSAM recommendation",
+        "url": "https://github.com/o/r/issues/87",
+        "kind_prefix": "Issue", "kind": "comment",
+        "when": now - dt.timedelta(days=1), "actor": "smellslikeml",
+        "summary": "licensing audit showing InstructSAM has no declared license",
+        "priority": 1,
+    }]
+    lines = run._render_lifecycle_events_section(events, now)
+    body = "\n".join(lines)
+    assert "Issue #87" in body
+    assert "@smellslikeml" in body
+    assert "yesterday" in body
+    assert "licensing audit" in body


### PR DESCRIPTION
## What this PR does

Adds a **"Recent activity on Outrider Issues/PRs"** section to the weekly Discussion digest, surfacing state-change events on Outrider-authored artifacts in the past 7 days: merged/closed PRs, recently-opened items, and new maintainer comments (bot follow-ups filtered out).

Layers on the existing `mode: weekly-summary` flow (introduced in #30) — no new workflow input, no new state store. The 7-day cron window doubles as the "since last summary" boundary, and per-artifact event timestamps come from the GitHub API.

## Motivation

The weekly digest currently reports *what Outrider ran* during the week. Lifecycle deltas turn it into *what's happened since* — a single scannable view of maintainer engagement on previously-opened recommendations.

Today, when a maintainer comments substantively on an Outrider Issue (licensing audit, reference implementation, request-for-changes review), the digest doesn't surface that. The maintainer's own work-in-progress is invisible to subscribers unless they manually scroll Issues.

Example: an Outrider-opened Issue with a maintainer-written licensing audit + reference implementation across two days. Today's digest would not mention it. With this PR, the next digest renders:

```markdown
### 🔁 Recent activity on Outrider Issues/PRs

- [Issue #87](...) (InstructSAM recommendation) — comment by @maintainer yesterday: empirical validation of two-pass enumerate-then-segment workflow...
- [Issue #87](...) (InstructSAM recommendation) — comment by @maintainer 2 days ago: licensing audit showing InstructSAM has no declared license...
```

## Implementation

All additions in `src/run.py`:

- **`_is_bot_actor(user)`** — filter bot follow-ups (`type == "Bot"` + known bot logins). Our own comments don't count as maintainer signal.
- **`_is_outrider_artifact(item)`** — recognize Outrider-authored Issues/PRs via title prefix (historical), body marker (new format), or branch prefix (legacy). Same identifiers as the existing dedup helpers.
- **`_parse_iso`** + **`_relative_when`** — ISO-8601 parser with `Z`-suffix tolerance + relative-time formatter (`today` / `yesterday` / `N days ago`).
- **`_lifecycle_events_for_outrider_artifacts(target, window_start, window_end, max_events=10)`** — main detector:
  - One `GET /repos/{owner}/{repo}/issues?state=all&since=<iso>` to scope to recently-updated items
  - Filter to Outrider-authored
  - Per-artifact: extract terminal events (PR merged, Issue/PR closed) from item metadata; fetch comments since the window start; filter out bot comments
  - Sort by `(priority asc, when desc)` — terminal events first, then newest comments
  - Cap at `max_events`, preserving terminal-event priority
  - `gh_api` failure returns `[]` cleanly so the digest still posts
- **`_render_lifecycle_events_section(events, now)`** — markdown formatter. Returns `[]` for empty events so the caller skips the section header entirely (no "nothing happened" noise).
- **`run_weekly_summary`** calls the detector after open-items fetch
- **`_compose_weekly_markdown`** accepts a new `lifecycle_events` parameter, renders the section between "In the research stream" and "Awaiting your review" (narrative: what changed → what's still open)

Per-artifact comment fetches only fire for items matched as Outrider-authored — bounded by the number of Outrider artifacts on the repo (typically <20), well within rate limits.

## Test plan

```bash
pytest tests/ -q
# 374 passed (20 new + 354 pre-existing)
```

The 20 new tests in `tests/test_lifecycle_events.py` cover:

- `_is_bot_actor` across `type=Bot`, known bot logins, human users, `None`/empty
- `_is_outrider_artifact` across title prefix, body marker, branch prefix, and unrelated-PR exclusion
- `_parse_iso` handles `Z` suffix, offset suffix, empty/`None`, malformed
- `_relative_when` produces correct labels for today / yesterday / N days ago
- `_lifecycle_events_for_outrider_artifacts` end-to-end with mocked `gh_api`:
  - picks up Outrider Issue with maintainer comment; filters unrelated items
  - surfaces merged PRs with the correct `kind_prefix`
  - filters bot-actor comments
  - returns `[]` cleanly on `gh_api` exception
  - enforces `max_events` cap with priority preservation (terminal events kept)
- `_render_lifecycle_events_section` returns `[]` for empty events; renders merged + comment events correctly

## Notes for review

- Section is opt-in via the existing `mode: weekly-summary` flag; no new workflow input.
- No state persistence introduced — the 7-day cron window defines the boundary; GitHub event timestamps provide the per-artifact signal.
- Event cap default of 10 is conservative; tunable via `max_events` if a heavy-traffic repo needs more.
- Followups worth considering: surfacing license/code-availability transitions on previously-blocked candidates (sibling "Newly viable" section using the same detector pattern); TODO detection in code/comments tied to specific recommendations; cross-thread mention linking.
