### PR TITLE
Selection-pass exploration telemetry + gh-graph

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -190,6 +190,16 @@ runs:
       shell: bash
       run: pip install pytest remyxai
 
+    - name: Install gh-graph selection-pass tool on PATH
+      shell: bash
+      # Dependency-navigation helper the selection agent calls via its Bash
+      # tool (`gh-graph <file>`) to walk a module's imports + reverse-imports.
+      # /usr/local/bin is already on PATH in the runner; the agent runs with
+      # cwd = the cloned target repo, so paths resolve repo-relative.
+      run: |
+        install -m 0755 "${{ github.action_path }}/src/gh_graph.py" /usr/local/bin/gh-graph
+        gh-graph --selftest
+
     - name: Configure git identity
       shell: bash
       # Global fallback identity. The branch head is normally re-authored

--- a/src/gh_graph.py
+++ b/src/gh_graph.py
@@ -30,25 +30,67 @@ import subprocess
 import sys
 
 
-def _module_candidates(rel_path: str) -> tuple[str, str, str]:
-    """Derive the importable names for a repo-relative ``.py`` path.
+def _module_info(abs_path: str) -> tuple[str, str, str, str | None]:
+    """Derive the importable name for a ``.py`` file from its package layout.
 
-    Returns ``(full, parent, leaf)`` where, for ``vqasynth/localize.py``:
-      full   = "vqasynth.localize"   (dotted module path)
-      parent = "vqasynth"            (containing package, "" at repo root)
-      leaf   = "localize"            (module name; package name for __init__)
+    Returns ``(full, parent, leaf, top_pkg_dir)``. The dotted name is built by
+    walking *up* through directories that contain ``__init__.py``, so a
+    src-layout file ``src/agents/agent.py`` yields ``full="agents.agent"`` —
+    not ``"src.agents.agent"``, which nothing imports. ``top_pkg_dir`` is the
+    outermost package directory (used to scope relative-import search); it is
+    None when the file isn't inside any package.
 
-    A package ``vqasynth/__init__.py`` collapses to full="vqasynth",
-    parent="", leaf="vqasynth" so reverse-import search keys on the package.
+    For ``pkg/localize.py`` (pkg is a package): full="pkg.localize",
+    parent="pkg", leaf="localize". For a package's own ``__init__.py``: full
+    and leaf collapse to the package name.
     """
-    parts = rel_path[:-3].split(os.sep) if rel_path.endswith(".py") else \
-        rel_path.split(os.sep)
-    if parts and parts[-1] == "__init__":
-        parts = parts[:-1]
-    full = ".".join(parts)
-    leaf = parts[-1] if parts else ""
-    parent = ".".join(parts[:-1]) if len(parts) > 1 else ""
-    return full, parent, leaf
+    abs_path = os.path.abspath(abs_path)
+    stem = os.path.basename(abs_path)
+    stem = stem[:-3] if stem.endswith(".py") else stem
+    comps: list[str] = []
+    top_pkg_dir: str | None = None
+    d = os.path.dirname(abs_path)
+    while os.path.isfile(os.path.join(d, "__init__.py")):
+        comps.insert(0, os.path.basename(d))
+        top_pkg_dir = d
+        d = os.path.dirname(d)
+    if stem == "__init__":
+        full = ".".join(comps)
+        leaf = comps[-1] if comps else ""
+        parent = ".".join(comps[:-1]) if len(comps) > 1 else ""
+    else:
+        full = ".".join(comps + [stem]) if comps else stem
+        leaf = stem
+        parent = ".".join(comps) if comps else ""
+    return full, parent, leaf, top_pkg_dir
+
+
+def _grep_imports(patterns: list[str], where: str) -> list[tuple[str, int]]:
+    """Run ``grep -rnE`` for ``patterns`` under ``where``; return (abs_file,
+    lineno) pairs. grep exit 1 (no matches) is not an error; >1 is.
+    """
+    if not patterns:
+        return []
+    cmd = ["grep", "-rnE", "--include=*.py"]
+    for pat in patterns:
+        cmd += ["-e", pat]
+    cmd.append(where)
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode > 1:
+        return []
+    out: list[tuple[str, int]] = []
+    for line in proc.stdout.splitlines():
+        bits = line.split(":", 2)
+        if len(bits) < 2:
+            continue
+        try:
+            out.append((os.path.abspath(bits[0]), int(bits[1])))
+        except ValueError:
+            continue
+    return out
 
 
 def forward_imports(path: str) -> list[tuple[str, int]]:
@@ -80,54 +122,47 @@ def forward_imports(path: str) -> list[tuple[str, int]]:
 def reverse_imports(rel_path: str, root: str) -> list[tuple[str, int]]:
     """Files under ``root`` that import the module at ``rel_path``.
 
-    Returns ``(repo_relative_file, lineno)`` pairs, excluding the file
-    itself. Implemented with ``grep -rnE`` over ``*.py`` so it stays cheap
-    and dependency-free; matches the three common import spellings:
+    Returns ``(repo_relative_file, lineno)`` pairs, excluding the file itself.
+    Implemented with ``grep -rnE`` over ``*.py`` so it stays cheap and
+    dependency-free. Matches both absolute spellings —
 
-      from <full> import ...      import <full>
-      from <parent> import <leaf>
+      from <full> import ...      import <full>      from <parent> import <leaf>
 
-    Relative imports (``from . import x``) are not resolved — an accepted
-    limitation of the grep approach.
+    — and the intra-package relative spellings (``from .<leaf> import …``,
+    ``from . import <leaf>``, and deeper ``from ..<leaf>``), scoped to the
+    file's package so a same-named module elsewhere doesn't false-match.
     """
-    full, parent, leaf = _module_candidates(rel_path)
-    if not full:
+    root = root or "."
+    abs_path = os.path.join(root, rel_path)
+    full, parent, leaf, top_pkg_dir = _module_info(abs_path)
+    if not full and not leaf:
         return []
-    patterns = [
-        rf"^[[:space:]]*(from|import)[[:space:]]+{full}([[:space:]]|$|\.|,)",
-    ]
+
+    found: list[tuple[str, int]] = []
+    # Absolute imports, across the whole tree.
+    abs_pats: list[str] = []
+    if full:
+        abs_pats.append(
+            rf"^[[:space:]]*(from|import)[[:space:]]+{full}([[:space:]]|$|\.|,)")
     if parent and leaf:
-        patterns.append(
-            rf"^[[:space:]]*from[[:space:]]+{parent}[[:space:]]+import[[:space:]].*\b{leaf}\b"
-        )
-    cmd = ["grep", "-rnE", "--include=*.py"]
-    for pat in patterns:
-        cmd += ["-e", pat]
-    cmd.append(root or ".")
-    try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except (OSError, subprocess.TimeoutExpired):
-        return []
-    # grep exit 1 == "no matches" (not an error); >1 is a real failure.
-    if proc.returncode > 1:
-        return []
-    self_abs = os.path.abspath(os.path.join(root or ".", rel_path))
+        abs_pats.append(
+            rf"^[[:space:]]*from[[:space:]]+{parent}[[:space:]]+import[[:space:]].*\b{leaf}\b")
+    found += _grep_imports(abs_pats, root)
+    # Relative imports, scoped to the package directory (where they're valid).
+    if top_pkg_dir and leaf:
+        rel_pats = [
+            rf"^[[:space:]]*from[[:space:]]+\.+{leaf}([[:space:]]|$|\.|,)",
+            rf"^[[:space:]]*from[[:space:]]+\.+[[:space:]]+import[[:space:]].*\b{leaf}\b",
+        ]
+        found += _grep_imports(rel_pats, top_pkg_dir)
+
+    self_abs = os.path.abspath(abs_path)
     out: list[tuple[str, int]] = []
     seen: set[tuple[str, int]] = set()
-    for line in proc.stdout.splitlines():
-        # grep -rn format: <file>:<lineno>:<matched text>
-        bits = line.split(":", 2)
-        if len(bits) < 2:
+    for fabs, lineno in found:
+        if fabs == self_abs:
             continue
-        fname, lineno_s = bits[0], bits[1]
-        if os.path.abspath(fname) == self_abs:
-            continue
-        try:
-            lineno = int(lineno_s)
-        except ValueError:
-            continue
-        rel = os.path.relpath(fname, root or ".")
-        key = (rel, lineno)
+        key = (os.path.relpath(fabs, root), lineno)
         if key in seen:
             continue
         seen.add(key)

--- a/src/gh_graph.py
+++ b/src/gh_graph.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+gh_graph.py — dependency-navigation helper for the Outrider selection pass.
+
+Exposed to the selection agent as the `gh-graph <file_path>` tool. Given a
+Python file, it lists:
+
+  * the modules that file imports (forward imports, via ``ast``), and
+  * the files in the repo that import *it* (reverse imports, via ``grep``).
+
+The reverse-imports query is the load-bearing part: shell-style navigation
+lets the agent grep *inward* from a name, but not walk *outward* from a
+module to the call sites that depend on it. Surfacing imported-by edges
+gives the agent the structural step it needs to find where a module plugs in
+and verify the I/O contract against real callers.
+
+Usage:
+    gh-graph <file_path>      # path is resolved relative to the cwd (repo root)
+    gh-graph --selftest       # smoke check, exits 0
+
+Scope: Python-only (v1.5.x). Non-Python files, missing files, and syntax
+errors degrade gracefully — a one-line note and exit 0, never a crash, so a
+bad path never derails the agent's Bash call.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+
+
+def _module_candidates(rel_path: str) -> tuple[str, str, str]:
+    """Derive the importable names for a repo-relative ``.py`` path.
+
+    Returns ``(full, parent, leaf)`` where, for ``vqasynth/localize.py``:
+      full   = "vqasynth.localize"   (dotted module path)
+      parent = "vqasynth"            (containing package, "" at repo root)
+      leaf   = "localize"            (module name; package name for __init__)
+
+    A package ``vqasynth/__init__.py`` collapses to full="vqasynth",
+    parent="", leaf="vqasynth" so reverse-import search keys on the package.
+    """
+    parts = rel_path[:-3].split(os.sep) if rel_path.endswith(".py") else \
+        rel_path.split(os.sep)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    full = ".".join(parts)
+    leaf = parts[-1] if parts else ""
+    parent = ".".join(parts[:-1]) if len(parts) > 1 else ""
+    return full, parent, leaf
+
+
+def forward_imports(path: str) -> list[tuple[str, int]]:
+    """Modules ``path`` imports, as ``(module, lineno)`` sorted by line.
+
+    Relative imports keep their leading dots (``.depth``). Returns ``[]`` on
+    unreadable / unparseable files — the caller decides how to surface that.
+    """
+    try:
+        src = open(path, encoding="utf-8", errors="replace").read()
+        tree = ast.parse(src)
+    except (OSError, SyntaxError, ValueError):
+        return []
+    out: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                out.append((alias.name, node.lineno))
+        elif isinstance(node, ast.ImportFrom):
+            mod = ("." * (node.level or 0)) + (node.module or "")
+            out.append((mod, node.lineno))
+    # De-dup while preserving first-seen line, then sort by line number.
+    seen: dict[str, int] = {}
+    for mod, line in out:
+        seen.setdefault(mod, line)
+    return sorted(((m, l) for m, l in seen.items()), key=lambda t: t[1])
+
+
+def reverse_imports(rel_path: str, root: str) -> list[tuple[str, int]]:
+    """Files under ``root`` that import the module at ``rel_path``.
+
+    Returns ``(repo_relative_file, lineno)`` pairs, excluding the file
+    itself. Implemented with ``grep -rnE`` over ``*.py`` so it stays cheap
+    and dependency-free; matches the three common import spellings:
+
+      from <full> import ...      import <full>
+      from <parent> import <leaf>
+
+    Relative imports (``from . import x``) are not resolved — an accepted
+    limitation of the grep approach.
+    """
+    full, parent, leaf = _module_candidates(rel_path)
+    if not full:
+        return []
+    patterns = [
+        rf"^[[:space:]]*(from|import)[[:space:]]+{full}([[:space:]]|$|\.|,)",
+    ]
+    if parent and leaf:
+        patterns.append(
+            rf"^[[:space:]]*from[[:space:]]+{parent}[[:space:]]+import[[:space:]].*\b{leaf}\b"
+        )
+    cmd = ["grep", "-rnE", "--include=*.py"]
+    for pat in patterns:
+        cmd += ["-e", pat]
+    cmd.append(root or ".")
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    # grep exit 1 == "no matches" (not an error); >1 is a real failure.
+    if proc.returncode > 1:
+        return []
+    self_abs = os.path.abspath(os.path.join(root or ".", rel_path))
+    out: list[tuple[str, int]] = []
+    seen: set[tuple[str, int]] = set()
+    for line in proc.stdout.splitlines():
+        # grep -rn format: <file>:<lineno>:<matched text>
+        bits = line.split(":", 2)
+        if len(bits) < 2:
+            continue
+        fname, lineno_s = bits[0], bits[1]
+        if os.path.abspath(fname) == self_abs:
+            continue
+        try:
+            lineno = int(lineno_s)
+        except ValueError:
+            continue
+        rel = os.path.relpath(fname, root or ".")
+        key = (rel, lineno)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return sorted(out)
+
+
+def render(path: str, root: str | None = None) -> str:
+    """Format the imports / imported-by block for ``path``.
+
+    Non-Python or missing paths return a single explanatory line so the
+    agent gets an actionable note rather than an empty result.
+    """
+    root = root or os.getcwd()
+    if not path.endswith(".py"):
+        return f"gh-graph: {path} is not a Python file (Python-only for now)."
+    if not os.path.isfile(path):
+        return f"gh-graph: {path} not found (resolved against {root})."
+
+    rel_path = os.path.relpath(path, root)
+    fwd = forward_imports(path)
+    rev = reverse_imports(rel_path, root)
+
+    lines = ["Imports (this file uses):"]
+    if fwd:
+        lines += [f"  - {mod} (line {ln})" for mod, ln in fwd]
+    else:
+        lines.append("  (none found)")
+    lines.append("Imported-by (files that use this file):")
+    if rev:
+        lines += [f"  - {f} (line {ln})" for f, ln in rev]
+    else:
+        lines.append("  (none found)")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        print("usage: gh-graph <file_path>", file=sys.stderr)
+        return 2
+    if argv[0] == "--selftest":
+        print("gh-graph: ok")
+        return 0
+    print(render(argv[0]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/run.py
+++ b/src/run.py
@@ -3958,10 +3958,11 @@ def _apply_coverage_gate(
     the agent batches its shell calls; ``file_reads`` / ``searches`` ride along
     as telemetry only. Mode via ``REMYX_SELECTION_COVERAGE_GATE``:
     ``observe`` (default) flags without blocking; ``enforce`` downgrades an
-    under-explored pick to a skip (``chosen_index=-1`` + ``under_explored``
-    marker, which the caller maps to ``skipped_under_explored``); ``off``
-    disables the check entirely. Always mutates ``coverage`` with the
-    ``under_explored`` verdict (unless ``off``).
+    under-explored pick to a skip (``chosen_index=-1``), which the caller
+    routes through the existing ``skipped_by_selection_verification`` status
+    so the user-facing step summary is unchanged; ``off`` disables the check
+    entirely. The under-explored verdict is recorded on ``coverage`` (unless
+    ``off``) for internal telemetry only.
     """
     mode = os.environ.get(
         "REMYX_SELECTION_COVERAGE_GATE", "observe"
@@ -3981,7 +3982,7 @@ def _apply_coverage_gate(
         log.info(
             f"  selection coverage gate (enforce): visible_lines="
             f"{coverage.get('visible_lines')} < floor {floor}; downgrading "
-            f"verdict to skip (skipped_under_explored)"
+            f"verdict to a skip"
         )
         data["chosen_index"] = -1
         data["under_explored"] = True
@@ -5723,25 +5724,22 @@ def process_target(target: Target) -> dict:
                         selection["selection_context_efficiency"]
                     )
             if selection is not None and selection.get("chosen_index") == -1:
-                # Agentic selection rejected every candidate after verification.
-                # The honest signal is "skip this run" — not "fall back to the
-                # top-ranked candidate," because that's precisely what
-                # verification just rejected. When the coverage gate (enforce
-                # mode) is what forced the -1, distinguish it as
-                # skipped_under_explored so the telemetry separates "verified
-                # and rejected" from "didn't read enough to decide."
-                if selection.get("under_explored"):
-                    result["status"] = "skipped_under_explored"
-                    log.info("  ✗ skipped_under_explored: coverage gate "
-                             "downgraded an under-explored verdict")
-                else:
-                    result["status"] = "skipped_by_selection_verification"
-                    log.info("  ✗ skipped_by_selection_verification: every "
-                             "candidate failed verification")
+                # Agentic selection rejected every candidate after verification
+                # (or, in coverage-gate enforce mode, an under-explored pick
+                # was downgraded to a skip). Either way the user-facing outcome
+                # is the same skip status — the under-explored reason is kept
+                # only in the internal selection_coverage telemetry, never the
+                # user-facing step summary.
+                result["status"] = "skipped_by_selection_verification"
                 result["selection_reasoning"] = selection.get("reasoning", "")
                 result["selection_rejected"] = _enrich_selection_rejected(
                     selection.get("rejected") or [], viable
                 )
+                if selection.get("under_explored"):
+                    log.info("  ✗ skipped (coverage gate: under-explored)")
+                else:
+                    log.info("  ✗ skipped_by_selection_verification: every "
+                             "candidate failed verification")
                 return result
             if selection is not None and selection.get("chosen_index") == -2:
                 # External pick — selection surfaced an out-of-pool candidate
@@ -7792,7 +7790,6 @@ def _write_step_summary(result: dict) -> None:
         "skipped_issue_exists":    "⏭️",
         "skipped_external_issue_exists": "⏭️",
         "skipped_by_selection_verification": "⏭️",
-        "skipped_under_explored":            "⏭️",
         "issue_opened_substitution": "🔁",
         "skipped_test_failure":    "⏭️",
         "claude_failed":           "❌",

--- a/src/run.py
+++ b/src/run.py
@@ -50,6 +50,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -707,6 +708,11 @@ verification bar — explain why in `reasoning`.
 Tools available:
   - `gh code-search "<query>" --repo <repo>` — find call sites
   - `gh api repos/<repo>/contents/<path>` — read a file by path
+  - `gh-graph <file_path>` — list a Python file's imports AND the files
+    that import it (its call sites). After you locate a candidate's likely
+    module, run `gh-graph` on it to walk *outward* to the call sites that
+    depend on it, then read those to verify the I/O contract — this is the
+    fastest way to ground "what plugs into what" rather than guessing.
   - `gh issue list/view` — see open maintainer concerns
   - `remyxai papers list/get` — inspect the ranker pool with reasoning
   - `remyxai interests get` — see the interest's project-summary context
@@ -3393,6 +3399,62 @@ def _run_claude_json(
     return proc.returncode == 0, output
 
 
+def _run_claude_stream(
+    cmd_prefix: list[str], prompt: str, cwd: Path, timeout_s: int
+) -> tuple[bool, str, list[dict]]:
+    """Like ``_run_claude_json`` but with the full tool transcript.
+
+    Runs ``claude … --output-format stream-json --verbose -p <prompt>`` and
+    parses the JSONL event stream. Returns ``(ok, text, events)`` where
+    ``text`` is the final result event's answer string (same string the json
+    envelope's ``result`` field carries, so verdict parsing is unchanged) and
+    ``events`` is every parsed stream event — the selection coverage parser
+    walks the ``tool_use`` / ``tool_result`` blocks in it.
+
+    Token/cost usage is recorded exactly once, off the terminal
+    ``{"type": "result", …}`` event (same shape as the json envelope), so
+    accounting matches ``_run_claude_json``. ``--verbose`` is required by the
+    CLI when ``stream-json`` is paired with ``-p``.
+    """
+    cmd = [*cmd_prefix, "--output-format", "stream-json", "--verbose",
+           "-p", prompt]
+    try:
+        proc = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"claude CLI timed out after {timeout_s}s", []
+    except FileNotFoundError:
+        return False, ("claude CLI not found on PATH "
+                       "(install: npm install -g @anthropic-ai/claude-code)"), []
+    events: list[dict] = []
+    for line in (proc.stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(ev, dict):
+            events.append(ev)
+    final = next(
+        (e for e in reversed(events) if e.get("type") == "result"), None
+    )
+    if final is not None:
+        _record_claude_usage(final)
+        text = final.get("result") or ""
+        is_error = bool(final.get("is_error")) or proc.returncode != 0
+        if not text and proc.stderr:
+            text = proc.stderr
+        return (not is_error), text, events
+    # No terminal result event — preserve a usable failure signal.
+    output = (proc.stdout or "") + (
+        "\n--- STDERR ---\n" + proc.stderr if proc.stderr else ""
+    )
+    return proc.returncode == 0, output, events
+
+
 def invoke_claude_code(workdir: Path, timeout_s: int = 900) -> tuple[bool, str]:
     """Invoke the Claude Code CLI in headless mode with the workdir as context.
 
@@ -3432,6 +3494,23 @@ def _run_claude_oneshot(
     if max_turns is not None:
         cmd += ["--max-turns", str(max_turns)]
     return _run_claude_json(cmd, prompt, workdir, timeout_s)
+
+
+def _run_claude_oneshot_streaming(
+    workdir: Path, prompt: str, timeout_s: int, max_turns: int | None = None
+) -> tuple[bool, str, list[dict]]:
+    """Streaming variant of ``_run_claude_oneshot`` used by the selection pass.
+
+    Returns ``(ok, text, events)`` — same contract as ``_run_claude_oneshot``
+    plus the parsed tool transcript, so the selection pass can compute
+    exploration-coverage telemetry from the agent's actual actions. Only the
+    selection pass uses this; the other one-shot callers (pre-flight,
+    self-review, audit) stay on the cheaper single-envelope runner.
+    """
+    cmd = ["claude", "--dangerously-skip-permissions"]
+    if max_turns is not None:
+        cmd += ["--max-turns", str(max_turns)]
+    return _run_claude_stream(cmd, prompt, workdir, timeout_s)
 
 
 def _extract_json_object(s: str) -> dict | None:
@@ -3717,6 +3796,198 @@ def _render_candidate_brief(
     return "\n\n".join(blocks)
 
 
+# ─── Selection-pass exploration telemetry ──────────────────────────────────
+#
+# The selection pass explores the target repo (searches + file reads) before
+# committing to a verdict. An agent can reach the right files yet stop before
+# reading enough lines to verify the integration shape. These helpers parse
+# the agent's tool transcript into per-run coverage (searches, file reads,
+# lines seen), compute a context-efficiency proxy, and optionally gate a
+# verdict reached on too little reading. The coverage and efficiency fields
+# are added to the run's JSON output for later analysis.
+
+# Shell-segment separators: `||`/`&&` before `|` so the two-char ops win.
+_SHELL_SEGMENT_RE = re.compile(r"\|\||&&|;|\||\n")
+
+# `<path>.py:<line>` citations in the verdict reasoning — the context-
+# efficiency numerator. Anchored to a boundary so it doesn't fire mid-token.
+_CITATION_RE = re.compile(r"""(?:^|[\s(`'"=>])([\w./-]+\.py):(\d+)""")
+
+
+def _classify_shell_segment(seg: str) -> str | None:
+    """Classify one shell segment as ``"search"``, ``"file_read"``, or None.
+
+    Segment-aware so a batched command (``grep …; sed -n FILE; cmd | head``)
+    is scored stage-by-stage: the search and the file read each count, and a
+    pipe-fed pager/filter reading stdin (``… | head``, ``… | grep``) counts
+    as neither. ``gh-graph`` is navigation, not a content read — also neither.
+    """
+    seg = seg.strip()
+    if not seg:
+        return None
+    try:
+        toks = shlex.split(seg)
+    except ValueError:
+        toks = seg.split()
+    if not toks:
+        return None
+    binname = os.path.basename(toks[0])
+    args = toks[1:]
+    nonopt = [a for a in args if not a.startswith("-")]
+    if binname == "gh":
+        if args[:2] == ["search", "code"] or (args and args[0] == "code-search"):
+            return "search"
+        if args and args[0] == "api":
+            joined = " ".join(args)
+            if "/contents/" in joined or joined.rstrip().endswith("/contents"):
+                return "file_read"
+        return None
+    if binname == "gh-graph":
+        return None
+    if binname in ("grep", "rg", "ag"):
+        # pattern + path(s) → searching files; pattern alone → reads stdin.
+        return "search" if len(nonopt) >= 2 else None
+    if binname == "cat":
+        return "file_read" if nonopt else None
+    if binname in ("head", "tail"):
+        # a non-numeric positional is a file; bare/`-n N` reads stdin.
+        return "file_read" if any(not a.isdigit() for a in nonopt) else None
+    if binname == "sed":
+        # `sed -n '1,50p' FILE` carries script + file; script alone = stdin.
+        return "file_read" if len(nonopt) >= 2 else None
+    return None
+
+
+def _classify_shell_command(cmd: str) -> list[str]:
+    """All non-None segment classifications for a Bash command string."""
+    if not cmd:
+        return []
+    out: list[str] = []
+    for seg in _SHELL_SEGMENT_RE.split(cmd):
+        cls = _classify_shell_segment(seg)
+        if cls:
+            out.append(cls)
+    return out
+
+
+def _classify_tool_use(name: str, inp: dict) -> list[str]:
+    """Classifications for one ``tool_use`` block (Bash, Read, Grep, …)."""
+    if name == "Bash":
+        return _classify_shell_command((inp or {}).get("command") or "")
+    if name in ("Read", "WebFetch"):
+        return ["file_read"]
+    if name in ("Grep", "Glob"):
+        return ["search"]
+    return []
+
+
+def _count_result_lines(content: object) -> int:
+    """Line count of a ``tool_result`` payload (string or text-block list)."""
+    if content is None:
+        return 0
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        text = "\n".join(
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    else:
+        text = str(content)
+    return len(text.splitlines()) if text else 0
+
+
+def _selection_coverage_from_events(events: list[dict]) -> dict:
+    """Parse a stream-json transcript into per-run exploration coverage.
+
+    Pairs each file-read ``tool_use`` with its ``tool_result`` by id so
+    ``visible_lines`` reflects content the agent actually saw. Returns
+    ``searches`` / ``file_reads`` / ``visible_lines`` / ``search_to_read_ratio``.
+    """
+    searches = 0
+    file_reads = 0
+    visible_lines = 0
+    read_ids: set[str] = set()
+    for ev in events:
+        msg = ev.get("message") if isinstance(ev, dict) else None
+        content = (msg or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "tool_use":
+                classes = _classify_tool_use(
+                    block.get("name") or "", block.get("input") or {}
+                )
+                searches += classes.count("search")
+                reads = classes.count("file_read")
+                file_reads += reads
+                if reads and block.get("id"):
+                    read_ids.add(block["id"])
+            elif btype == "tool_result":
+                if block.get("tool_use_id") in read_ids:
+                    visible_lines += _count_result_lines(block.get("content"))
+    return {
+        "searches": searches,
+        "file_reads": file_reads,
+        "visible_lines": visible_lines,
+        "search_to_read_ratio": round(searches / max(file_reads, 1), 2),
+    }
+
+
+def _selection_context_efficiency(text: str, visible_lines: int) -> float:
+    """Context-efficiency proxy: distinct ``path:line`` citations in the
+    verdict reasoning over total visible lines. A high-coverage /
+    low-efficiency run = "read a lot, used little." 0.0 when nothing was
+    cited.
+    """
+    if not text:
+        return 0.0
+    pairs = set(_CITATION_RE.findall(text))
+    return round(len(pairs) / max(visible_lines, 1), 4)
+
+
+def _apply_coverage_gate(
+    data: dict, coverage: dict, *, higher_floor: bool
+) -> dict:
+    """Flag (and, in enforce mode, block) an under-explored verdict.
+
+    Gates on ``visible_lines`` — the content-grounding signal, robust to how
+    the agent batches its shell calls; ``file_reads`` / ``searches`` ride along
+    as telemetry only. Mode via ``REMYX_SELECTION_COVERAGE_GATE``:
+    ``observe`` (default) flags without blocking; ``enforce`` downgrades an
+    under-explored pick to a skip (``chosen_index=-1`` + ``under_explored``
+    marker, which the caller maps to ``skipped_under_explored``); ``off``
+    disables the check entirely. Always mutates ``coverage`` with the
+    ``under_explored`` verdict (unless ``off``).
+    """
+    mode = os.environ.get(
+        "REMYX_SELECTION_COVERAGE_GATE", "observe"
+    ).lower().strip()
+    if mode == "off":
+        return data
+    if higher_floor:
+        floor = int(os.environ.get(
+            "REMYX_SELECTION_MIN_VISIBLE_LINES_EXTENSION", "300"))
+    else:
+        floor = int(os.environ.get(
+            "REMYX_SELECTION_MIN_VISIBLE_LINES", "150"))
+    under = coverage.get("visible_lines", 0) < floor
+    coverage["under_explored"] = under
+    coverage["min_visible_lines"] = floor
+    if under and mode == "enforce":
+        log.info(
+            f"  selection coverage gate (enforce): visible_lines="
+            f"{coverage.get('visible_lines')} < floor {floor}; downgrading "
+            f"verdict to skip (skipped_under_explored)"
+        )
+        data["chosen_index"] = -1
+        data["under_explored"] = True
+    return data
+
+
 def select_recommendation(
     workdir: Path, package: str, candidates: list[Recommendation],
     target: "Target | None" = None,
@@ -3776,7 +4047,9 @@ def select_recommendation(
         f"  → agentic selection over {len(candidates)} candidates "
         f"(max-turns={max_turns}, timeout={timeout_s}s)"
     )
-    ok, output = _run_claude_oneshot(workdir, prompt, timeout_s, max_turns=max_turns)
+    ok, output, events = _run_claude_oneshot_streaming(
+        workdir, prompt, timeout_s, max_turns=max_turns,
+    )
     if not ok:
         log.warning(f"  selection call failed: {output[:200]}; "
                     f"falling back to top-ranked candidate")
@@ -3815,7 +4088,7 @@ def select_recommendation(
         retry_max_turns = int(
             os.environ.get("REMYX_SELECTION_RETRY_MAX_TURNS", "5")
         )
-        ok, output = _run_claude_oneshot(
+        ok, output, events = _run_claude_oneshot_streaming(
             workdir, retry_prompt, retry_timeout, max_turns=retry_max_turns,
         )
         if not ok:
@@ -3828,6 +4101,39 @@ def select_recommendation(
                         f"raw: {output[:300]!r}; falling back")
             return None
         log.info("  selection: JSON-parse retry succeeded")
+    # Exploration-coverage telemetry. Computed from the transcript
+    # of whichever attempt produced the parseable verdict, then attached to
+    # `data` BEFORE the branch logic so every return path (in-pool, extension,
+    # external -2, skip -1) carries it. The gate may downgrade an under-
+    # explored pick to -1 in enforce mode; observe (default) only records.
+    coverage = _selection_coverage_from_events(events)
+    reasoning_text = " ".join(
+        str(data.get(k) or "") for k in (
+            "reasoning", "verification_summary",
+            "chosen_call_site", "proposed_call_site",
+        )
+    )
+    context_efficiency = _selection_context_efficiency(
+        reasoning_text, coverage["visible_lines"]
+    )
+    try:
+        _idx_raw = int(data.get("chosen_index"))
+    except (TypeError, ValueError):
+        _idx_raw = None
+    _higher_floor = (
+        (data.get("integration_shape") or "").lower().strip() == "extension"
+        or _idx_raw == -2
+    )
+    _apply_coverage_gate(data, coverage, higher_floor=_higher_floor)
+    data["selection_coverage"] = coverage
+    data["selection_context_efficiency"] = context_efficiency
+    log.info(
+        f"  selection coverage: {coverage['searches']} searches, "
+        f"{coverage['file_reads']} file reads, "
+        f"{coverage['visible_lines']} lines visible, "
+        f"context-efficiency {context_efficiency} "
+        f"(under_explored={coverage.get('under_explored')})"
+    )
     try:
         idx = int(data.get("chosen_index"))
     except (TypeError, ValueError):
@@ -5405,18 +5711,37 @@ def process_target(target: Target) -> dict:
                 workdir, package, viable, target=target,
                 discharged_issues=open_issues,
             )
+            # Attach exploration-coverage telemetry once, before the branch
+            # handling — every downstream path returns this same `result`, so
+            # the fields ride along regardless of the verdict, and the run's
+            # JSON output carries them for later analysis.
+            if selection is not None:
+                if "selection_coverage" in selection:
+                    result["selection_coverage"] = selection["selection_coverage"]
+                if "selection_context_efficiency" in selection:
+                    result["selection_context_efficiency"] = (
+                        selection["selection_context_efficiency"]
+                    )
             if selection is not None and selection.get("chosen_index") == -1:
                 # Agentic selection rejected every candidate after verification.
                 # The honest signal is "skip this run" — not "fall back to the
                 # top-ranked candidate," because that's precisely what
-                # verification just rejected.
-                result["status"] = "skipped_by_selection_verification"
+                # verification just rejected. When the coverage gate (enforce
+                # mode) is what forced the -1, distinguish it as
+                # skipped_under_explored so the telemetry separates "verified
+                # and rejected" from "didn't read enough to decide."
+                if selection.get("under_explored"):
+                    result["status"] = "skipped_under_explored"
+                    log.info("  ✗ skipped_under_explored: coverage gate "
+                             "downgraded an under-explored verdict")
+                else:
+                    result["status"] = "skipped_by_selection_verification"
+                    log.info("  ✗ skipped_by_selection_verification: every "
+                             "candidate failed verification")
                 result["selection_reasoning"] = selection.get("reasoning", "")
                 result["selection_rejected"] = _enrich_selection_rejected(
                     selection.get("rejected") or [], viable
                 )
-                log.info("  ✗ skipped_by_selection_verification: every "
-                         "candidate failed verification")
                 return result
             if selection is not None and selection.get("chosen_index") == -2:
                 # External pick — selection surfaced an out-of-pool candidate
@@ -7467,6 +7792,7 @@ def _write_step_summary(result: dict) -> None:
         "skipped_issue_exists":    "⏭️",
         "skipped_external_issue_exists": "⏭️",
         "skipped_by_selection_verification": "⏭️",
+        "skipped_under_explored":            "⏭️",
         "issue_opened_substitution": "🔁",
         "skipped_test_failure":    "⏭️",
         "claude_failed":           "❌",

--- a/tests/test_extension_shape.py
+++ b/tests/test_extension_shape.py
@@ -104,9 +104,9 @@ def test_prompt_schema_documents_extension_specific_fields():
 def _run_selection(monkeypatch, tmp_path, candidates, claude_response):
     """Invoke select_recommendation with a mocked Claude response."""
     def fake_oneshot(workdir, prompt, timeout_s, max_turns=None):
-        return True, json.dumps(claude_response)
+        return True, json.dumps(claude_response), []
 
-    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", fake_oneshot)
     monkeypatch.setattr(run, "_repo_layout_manifest", lambda wd, pkg: "(layout)")
 
     return run.select_recommendation(

--- a/tests/test_gh_graph.py
+++ b/tests/test_gh_graph.py
@@ -1,0 +1,94 @@
+"""Unit tests for the gh-graph dependency-navigation tool.
+
+Covers forward imports (ast), reverse imports (grep over a temp repo), and
+graceful degradation on non-Python / missing files.
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import gh_graph  # noqa: E402
+
+
+def _write(p: Path, text: str) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+    return p
+
+
+def test_forward_imports_plain_and_from(tmp_path):
+    f = _write(tmp_path / "mod.py",
+               "import os\nfrom pkg.depth import estimate\nimport pkg.localize\n")
+    fwd = gh_graph.forward_imports(str(f))
+    mods = {m for m, _ in fwd}
+    assert "os" in mods
+    assert "pkg.depth" in mods
+    assert "pkg.localize" in mods
+    # line numbers are carried through, sorted ascending
+    lines = [ln for _, ln in fwd]
+    assert lines == sorted(lines)
+
+
+def test_forward_imports_relative(tmp_path):
+    f = _write(tmp_path / "pkg" / "a.py", "from . import depth\nfrom .util import x\n")
+    mods = {m for m, _ in gh_graph.forward_imports(str(f))}
+    assert "." in mods           # `from . import depth`
+    assert ".util" in mods
+
+
+def test_forward_imports_syntax_error_is_empty(tmp_path):
+    f = _write(tmp_path / "bad.py", "def (:\n")
+    assert gh_graph.forward_imports(str(f)) == []
+
+
+def test_reverse_imports_finds_callers(tmp_path):
+    _write(tmp_path / "pkg" / "depth.py", "VALUE = 1\n")
+    _write(tmp_path / "caller.py",
+           "from pkg.depth import VALUE\nimport pkg.depth\n")
+    _write(tmp_path / "pkg" / "sibling.py", "from pkg import depth\n")
+    _write(tmp_path / "unrelated.py", "import os\n")
+    rev = gh_graph.reverse_imports("pkg/depth.py", str(tmp_path))
+    files = {f for f, _ in rev}
+    assert "caller.py" in files
+    assert "pkg/sibling.py" in files
+    assert "unrelated.py" not in files
+
+
+def test_reverse_imports_excludes_self(tmp_path):
+    # A file that imports a sibling shouldn't list itself as an importer.
+    _write(tmp_path / "pkg" / "depth.py", "import pkg.depth\n")
+    rev = gh_graph.reverse_imports("pkg/depth.py", str(tmp_path))
+    assert all(f != "pkg/depth.py" for f, _ in rev)
+
+
+def test_render_block_shape(tmp_path):
+    _write(tmp_path / "pkg" / "depth.py", "import os\n")
+    _write(tmp_path / "caller.py", "from pkg.depth import x\n")
+    out = gh_graph.render(str(tmp_path / "pkg" / "depth.py"), root=str(tmp_path))
+    assert "Imports (this file uses):" in out
+    assert "Imported-by (files that use this file):" in out
+    assert "os" in out
+    assert "caller.py" in out
+
+
+def test_render_non_python_graceful(tmp_path):
+    f = _write(tmp_path / "notes.md", "# hi\n")
+    out = gh_graph.render(str(f), root=str(tmp_path))
+    assert "not a Python file" in out
+
+
+def test_render_missing_file_graceful(tmp_path):
+    out = gh_graph.render(str(tmp_path / "nope.py"), root=str(tmp_path))
+    assert "not found" in out
+
+
+def test_main_selftest_exits_zero(capsys):
+    assert gh_graph.main(["--selftest"]) == 0
+    assert "ok" in capsys.readouterr().out
+
+
+def test_main_no_args_usage(capsys):
+    assert gh_graph.main([]) == 2

--- a/tests/test_gh_graph.py
+++ b/tests/test_gh_graph.py
@@ -45,6 +45,7 @@ def test_forward_imports_syntax_error_is_empty(tmp_path):
 
 
 def test_reverse_imports_finds_callers(tmp_path):
+    _write(tmp_path / "pkg" / "__init__.py", "")
     _write(tmp_path / "pkg" / "depth.py", "VALUE = 1\n")
     _write(tmp_path / "caller.py",
            "from pkg.depth import VALUE\nimport pkg.depth\n")
@@ -57,14 +58,40 @@ def test_reverse_imports_finds_callers(tmp_path):
     assert "unrelated.py" not in files
 
 
+def test_reverse_imports_relative_sibling(tmp_path):
+    # Intra-package relative imports must be found (both `from .a` spellings).
+    _write(tmp_path / "pkg" / "__init__.py", "")
+    _write(tmp_path / "pkg" / "a.py", "X = 1\n")
+    _write(tmp_path / "pkg" / "b.py", "from .a import X\n")
+    _write(tmp_path / "pkg" / "c.py", "from . import a\n")
+    files = {f for f, _ in gh_graph.reverse_imports("pkg/a.py", str(tmp_path))}
+    assert "pkg/b.py" in files
+    assert "pkg/c.py" in files
+
+
+def test_reverse_imports_src_layout(tmp_path):
+    # src-layout: the module is `pkg.agent`, not `src.pkg.agent`. Both an
+    # absolute import (from outside) and a relative one (a sibling) resolve.
+    _write(tmp_path / "src" / "pkg" / "__init__.py", "")
+    _write(tmp_path / "src" / "pkg" / "agent.py", "class Agent: ...\n")
+    _write(tmp_path / "src" / "pkg" / "run.py", "from .agent import Agent\n")
+    _write(tmp_path / "tests" / "test_it.py", "from pkg.agent import Agent\n")
+    files = {f for f, _ in
+             gh_graph.reverse_imports("src/pkg/agent.py", str(tmp_path))}
+    assert "src/pkg/run.py" in files          # relative sibling
+    assert "tests/test_it.py" in files        # absolute, dotted name has no `src.`
+
+
 def test_reverse_imports_excludes_self(tmp_path):
     # A file that imports a sibling shouldn't list itself as an importer.
+    _write(tmp_path / "pkg" / "__init__.py", "")
     _write(tmp_path / "pkg" / "depth.py", "import pkg.depth\n")
     rev = gh_graph.reverse_imports("pkg/depth.py", str(tmp_path))
     assert all(f != "pkg/depth.py" for f, _ in rev)
 
 
 def test_render_block_shape(tmp_path):
+    _write(tmp_path / "pkg" / "__init__.py", "")
     _write(tmp_path / "pkg" / "depth.py", "import os\n")
     _write(tmp_path / "caller.py", "from pkg.depth import x\n")
     out = gh_graph.render(str(tmp_path / "pkg" / "depth.py"), root=str(tmp_path))

--- a/tests/test_maintainer_arxiv_dedup.py
+++ b/tests/test_maintainer_arxiv_dedup.py
@@ -275,9 +275,9 @@ def test_end_to_end_maintainer_rfc_discharges_pool_candidate(monkeypatch, tmp_pa
 
     def fake_oneshot(workdir, prompt, timeout_s, max_turns=None):
         captured_prompts.append(prompt)
-        return True, '{"chosen_index": 0, "reasoning": "test"}'
+        return True, '{"chosen_index": 0, "reasoning": "test"}', []
 
-    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", fake_oneshot)
     monkeypatch.setattr(run, "_repo_layout_manifest", lambda wd, pkg: "(layout)")
 
     # Pool has the paper at index 0; maintainer RFC has it discharged

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -82,11 +82,14 @@ def test_select_single_candidate_short_circuits(tmp_path):
 
 def test_select_parses_chosen_index(tmp_path, monkeypatch):
     geo, count = _make_candidates()
+    # The selection pass runs in streaming mode so it can parse the tool
+    # transcript into coverage; the runner returns `(ok, text, events)`.
+    # Empty events here.
     monkeypatch.setattr(
-        run, "_run_claude_oneshot",
+        run, "_run_claude_oneshot_streaming",
         lambda wd, p, t, **kw: (True, '{"chosen_index": 1, "reasoning": "clear call '
                                       'site in prompts.py", "rejected": [{"index": 0, '
-                                      '"why": "model architecture, no call site"}]}'),
+                                      '"why": "model architecture, no call site"}]}', []),
     )
     sel = run.select_recommendation(tmp_path, "pkg", [geo, count])
     assert sel is not None
@@ -95,25 +98,62 @@ def test_select_parses_chosen_index(tmp_path, monkeypatch):
     assert sel["rejected"][0]["index"] == 0
 
 
+def test_select_attaches_coverage_telemetry(tmp_path, monkeypatch):
+    """Every parseable verdict carries selection_coverage +
+    selection_context_efficiency, computed from the transcript."""
+    geo, count = _make_candidates()
+    events = [
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Bash",
+             "input": {"command": 'gh search code "load_dataset" --repo o/r'}},
+        ]}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t2", "name": "Bash",
+             "input": {"command": "gh api repos/o/r/contents/src/x.py"}},
+        ]}},
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "t2",
+             "content": "\n".join(f"line{i}" for i in range(200))},
+        ]}},
+    ]
+    monkeypatch.setattr(
+        run, "_run_claude_oneshot_streaming",
+        lambda wd, p, t, **kw: (
+            True,
+            '{"chosen_index": 1, "reasoning": "verified at src/x.py:10", '
+            '"rejected": []}',
+            events,
+        ),
+    )
+    sel = run.select_recommendation(tmp_path, "pkg", [geo, count])
+    assert sel is not None
+    cov = sel["selection_coverage"]
+    assert cov["searches"] == 1
+    assert cov["file_reads"] == 1
+    assert cov["visible_lines"] == 200
+    assert cov["under_explored"] is False           # 200 ≥ 150 in-pool floor
+    assert sel["selection_context_efficiency"] == round(1 / 200, 4)
+
+
 def test_select_out_of_range_falls_back(tmp_path, monkeypatch):
     geo, count = _make_candidates()
-    monkeypatch.setattr(run, "_run_claude_oneshot",
-                        lambda wd, p, t, **kw: (True, '{"chosen_index": 9}'))
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming",
+                        lambda wd, p, t, **kw: (True, '{"chosen_index": 9}', []))
     # Out-of-range → None → caller falls back to candidates[0].
     assert run.select_recommendation(tmp_path, "pkg", [geo, count]) is None
 
 
 def test_select_non_int_index_falls_back(tmp_path, monkeypatch):
     geo, count = _make_candidates()
-    monkeypatch.setattr(run, "_run_claude_oneshot",
-                        lambda wd, p, t, **kw: (True, '{"chosen_index": "two"}'))
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming",
+                        lambda wd, p, t, **kw: (True, '{"chosen_index": "two"}', []))
     assert run.select_recommendation(tmp_path, "pkg", [geo, count]) is None
 
 
 def test_select_claude_failure_falls_back(tmp_path, monkeypatch):
     geo, count = _make_candidates()
-    monkeypatch.setattr(run, "_run_claude_oneshot",
-                        lambda wd, p, t, **kw: (False, "claude CLI timed out"))
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming",
+                        lambda wd, p, t, **kw: (False, "claude CLI timed out", []))
     assert run.select_recommendation(tmp_path, "pkg", [geo, count]) is None
 
 
@@ -121,8 +161,8 @@ def test_select_unparseable_output_falls_back(tmp_path, monkeypatch):
     """Prose on both the initial call AND the format-only retry → fall
     through to None. Caller's job to substitute a fallback candidate."""
     geo, count = _make_candidates()
-    monkeypatch.setattr(run, "_run_claude_oneshot",
-                        lambda wd, p, t, **kw: (True, "I think candidate 1 is best"))
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming",
+                        lambda wd, p, t, **kw: (True, "I think candidate 1 is best", []))
     assert run.select_recommendation(tmp_path, "pkg", [geo, count]) is None
 
 
@@ -138,13 +178,13 @@ def test_select_unparseable_initial_then_clean_retry(tmp_path, monkeypatch):
         if calls["n"] == 1:
             return True, ("I now have enough evidence to decide. Let me "
                           "consolidate the maintainer's stated preferences "
-                          "with the candidate pool ...")
+                          "with the candidate pool ..."), []
         # Second call gets the format reminder appended → returns clean JSON.
         assert "OUTPUT FORMAT REMINDER" in p
         return True, ('{"chosen_index": 1, "reasoning": "matches an open RFC", '
-                      '"rejected": []}')
+                      '"rejected": []}'), []
 
-    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", fake_oneshot)
     sel = run.select_recommendation(tmp_path, "pkg", [geo, count])
     assert calls["n"] == 2, "retry should have fired exactly once"
     assert sel is not None
@@ -160,9 +200,9 @@ def test_select_retry_fires_only_once(tmp_path, monkeypatch):
 
     def fake_oneshot(wd, p, t, **kw):
         calls["n"] += 1
-        return True, "still just prose, no JSON here"
+        return True, "still just prose, no JSON here", []
 
-    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", fake_oneshot)
     assert run.select_recommendation(tmp_path, "pkg", [geo, count]) is None
     assert calls["n"] == 2, "should call exactly twice (initial + 1 retry)"
 
@@ -176,9 +216,9 @@ def test_select_retry_skipped_when_first_call_fails(tmp_path, monkeypatch):
 
     def fake_oneshot(wd, p, t, **kw):
         calls["n"] += 1
-        return False, "claude CLI timed out"
+        return False, "claude CLI timed out", []
 
-    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", fake_oneshot)
     assert run.select_recommendation(tmp_path, "pkg", [geo, count]) is None
     assert calls["n"] == 1, "no retry on ok=False — that's not a parse problem"
 
@@ -192,10 +232,10 @@ def test_select_retry_handles_second_call_infra_failure(tmp_path, monkeypatch):
     def fake_oneshot(wd, p, t, **kw):
         calls["n"] += 1
         if calls["n"] == 1:
-            return True, "first attempt prose, no JSON"
-        return False, "claude CLI crashed on retry"
+            return True, "first attempt prose, no JSON", []
+        return False, "claude CLI crashed on retry", []
 
-    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", fake_oneshot)
     assert run.select_recommendation(tmp_path, "pkg", [geo, count]) is None
     assert calls["n"] == 2
 

--- a/tests/test_selection_coverage.py
+++ b/tests/test_selection_coverage.py
@@ -1,0 +1,190 @@
+"""Unit tests for selection-pass exploration telemetry.
+
+Covers the segment-aware shell classifier, the transcript→coverage parser,
+the context-efficiency proxy, and the coverage gate (observe / enforce / off).
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# ── segment-aware shell classifier ─────────────────────────────────────────
+
+def test_classify_piped_search_excludes_pager():
+    # `gh search code … | head` — search counts, the stdin pager doesn't.
+    assert run._classify_shell_command('gh search code "x" --repo o/r | head') \
+        == ["search"]
+
+
+def test_classify_compound_command_each_stage():
+    # grep over a path → search; sed/cat over a file → file_read.
+    cmd = "grep -rn pat src; sed -n '1,40p' src/run.py; cat README.md"
+    assert run._classify_shell_command(cmd) == ["search", "file_read", "file_read"]
+
+
+def test_classify_stdin_filter_is_neither():
+    # `cat file | grep foo`: the cat is a real read, the piped grep is stdin.
+    assert run._classify_shell_command("cat foo.py | grep foo") == ["file_read"]
+
+
+def test_classify_gh_api_contents_is_read():
+    assert run._classify_shell_command(
+        "gh api repos/o/r/contents/src/x.py") == ["file_read"]
+
+
+def test_classify_gh_issue_is_neither():
+    assert run._classify_shell_command("gh issue list --repo o/r") == []
+
+
+def test_classify_gh_graph_is_neither():
+    # gh-graph is structural navigation, not a content read.
+    assert run._classify_shell_command("gh-graph src/x.py") == []
+
+
+def test_classify_head_with_file_vs_stdin():
+    assert run._classify_shell_command("head -n 50 src/x.py") == ["file_read"]
+    assert run._classify_shell_command("head -n 50") == []   # reads stdin
+
+
+# ── tool_use classification (native tools) ──────────────────────────────────
+
+def test_classify_native_read_and_grep():
+    assert run._classify_tool_use("Read", {"file_path": "x.py"}) == ["file_read"]
+    assert run._classify_tool_use("Grep", {"pattern": "x"}) == ["search"]
+    assert run._classify_tool_use("WebFetch", {"url": "http://x"}) == ["file_read"]
+
+
+# ── transcript → coverage ───────────────────────────────────────────────────
+
+def _events():
+    return [
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "s1", "name": "Bash",
+             "input": {"command": 'gh search code "foo" --repo o/r'}},
+        ]}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "r1", "name": "Bash",
+             "input": {"command": "gh api repos/o/r/contents/a.py"}},
+        ]}},
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "r1",
+             "content": "l1\nl2\nl3\nl4\nl5"},
+        ]}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "r2", "name": "Read",
+             "input": {"file_path": "b.py"}},
+        ]}},
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "r2",
+             "content": [{"type": "text", "text": "x\ny\nz"}]},
+        ]}},
+    ]
+
+
+def test_coverage_counts_and_ratio():
+    cov = run._selection_coverage_from_events(_events())
+    assert cov["searches"] == 1
+    assert cov["file_reads"] == 2
+    assert cov["visible_lines"] == 8                 # 5 + 3
+    assert cov["search_to_read_ratio"] == round(1 / 2, 2)
+
+
+def test_coverage_empty_transcript():
+    cov = run._selection_coverage_from_events([])
+    assert cov == {"searches": 0, "file_reads": 0, "visible_lines": 0,
+                   "search_to_read_ratio": 0.0}
+
+
+def test_coverage_result_lines_only_for_reads():
+    # A search's tool_result must not contribute to visible_lines.
+    events = [
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "s1", "name": "Grep",
+             "input": {"pattern": "x"}},
+        ]}},
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "s1",
+             "content": "hit1\nhit2\nhit3"},
+        ]}},
+    ]
+    cov = run._selection_coverage_from_events(events)
+    assert cov["searches"] == 1
+    assert cov["visible_lines"] == 0
+
+
+# ── context-efficiency proxy ────────────────────────────────────────────────
+
+def test_context_efficiency_distinct_citations():
+    text = "verified src/run.py:120 and src/run.py:120 and pkg/a.py:9"
+    # distinct pairs = {(src/run.py,120),(pkg/a.py,9)} = 2
+    assert run._selection_context_efficiency(text, 100) == round(2 / 100, 4)
+
+
+def test_context_efficiency_zero_visible_guard():
+    assert run._selection_context_efficiency("src/x.py:1", 0) == 1.0
+
+
+def test_context_efficiency_no_citations():
+    assert run._selection_context_efficiency("no file refs here", 50) == 0.0
+
+
+# ── coverage gate ───────────────────────────────────────────────────────────
+
+def test_gate_observe_flags_without_blocking(monkeypatch):
+    monkeypatch.delenv("REMYX_SELECTION_COVERAGE_GATE", raising=False)  # default observe
+    data = {"chosen_index": 1}
+    cov = {"visible_lines": 50}
+    run._apply_coverage_gate(data, cov, higher_floor=False)
+    assert cov["under_explored"] is True             # 50 < 150 floor
+    assert data["chosen_index"] == 1                 # observe never blocks
+    assert "under_explored" not in data
+
+
+def test_gate_observe_above_floor(monkeypatch):
+    monkeypatch.delenv("REMYX_SELECTION_COVERAGE_GATE", raising=False)
+    cov = {"visible_lines": 200}
+    run._apply_coverage_gate({"chosen_index": 1}, cov, higher_floor=False)
+    assert cov["under_explored"] is False
+
+
+def test_gate_enforce_downgrades(monkeypatch):
+    monkeypatch.setenv("REMYX_SELECTION_COVERAGE_GATE", "enforce")
+    data = {"chosen_index": 1}
+    cov = {"visible_lines": 50}
+    run._apply_coverage_gate(data, cov, higher_floor=False)
+    assert data["chosen_index"] == -1
+    assert data["under_explored"] is True
+
+
+def test_gate_off_is_noop(monkeypatch):
+    monkeypatch.setenv("REMYX_SELECTION_COVERAGE_GATE", "off")
+    data = {"chosen_index": 1}
+    cov = {"visible_lines": 1}
+    run._apply_coverage_gate(data, cov, higher_floor=False)
+    assert "under_explored" not in cov
+    assert data["chosen_index"] == 1
+
+
+def test_gate_higher_floor_for_extension(monkeypatch):
+    monkeypatch.setenv("REMYX_SELECTION_COVERAGE_GATE", "enforce")
+    # 200 lines clears the in-pool floor (150) but not the extension floor (300).
+    data = {"chosen_index": 2}
+    cov = {"visible_lines": 200}
+    run._apply_coverage_gate(data, cov, higher_floor=True)
+    assert cov["under_explored"] is True
+    assert data["chosen_index"] == -1
+
+
+def test_gate_env_override_floor(monkeypatch):
+    monkeypatch.setenv("REMYX_SELECTION_COVERAGE_GATE", "enforce")
+    monkeypatch.setenv("REMYX_SELECTION_MIN_VISIBLE_LINES", "10")
+    data = {"chosen_index": 1}
+    cov = {"visible_lines": 50}
+    run._apply_coverage_gate(data, cov, higher_floor=False)
+    assert cov["under_explored"] is False            # 50 ≥ overridden floor 10
+    assert data["chosen_index"] == 1

--- a/tests/test_selection_dedup_aware.py
+++ b/tests/test_selection_dedup_aware.py
@@ -257,9 +257,9 @@ def test_selection_prompt_renders_byte_stable_when_no_issues(monkeypatch, tmp_pa
 
     def fake_oneshot(workdir, prompt, timeout_s, max_turns=None):
         captured_prompts.append(prompt)
-        return True, '{"chosen_index": 0, "reasoning": "test"}'
+        return True, '{"chosen_index": 0, "reasoning": "test"}', []
 
-    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", fake_oneshot)
     monkeypatch.setattr(run, "_repo_layout_manifest", lambda wd, pkg: "(layout)")
 
     candidates = [_rec("2605.26102", "A"), _rec("2412.18404", "B")]
@@ -288,9 +288,9 @@ def test_selection_prompt_renders_discharge_section_when_issues_present(
 
     def fake_oneshot(workdir, prompt, timeout_s, max_turns=None):
         captured_prompts.append(prompt)
-        return True, '{"chosen_index": 1, "reasoning": "test"}'
+        return True, '{"chosen_index": 1, "reasoning": "test"}', []
 
-    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", fake_oneshot)
     monkeypatch.setattr(run, "_repo_layout_manifest", lambda wd, pkg: "(layout)")
 
     candidates = [


### PR DESCRIPTION
## Selection-pass exploration telemetry + `gh-graph`

The selection pass explores a repo (searches, file reads) before picking a recommendation, but we couldn't see *how much* it explored or catch a verdict made on too little reading. This adds that visibility, a navigation tool, and an optional gate. All new fields are additive.

### What's new

  - **Coverage telemetry** : `selection_coverage` records `searches`, `file_reads`, `visible_lines`, and `search_to_read_ratio` per run, parsed from the agent's tool transcript (selection now runs in streaming mode; token/cost accounting unchanged). Classification is segment-aware: a command is split on `; && || |` and each stage counted on its own, so a batched call is scored right and pipe-fed pagers (`… | head`) don't count as reads.

  - **Context efficiency** : `selection_context_efficiency`: distinct `path:line` citations in the verdict's reasoning ÷ visible lines. A proxy for how much of what was read got used.

  - **`gh-graph <file>`** (`src/gh_graph.py`) : lists a Python file's imports *and* the files that import it (forward + reverse, via stdlib `ast` + a source walk). The reverse edge lets the agent walk outward to real call sites and check the I/O contract. Installed on `PATH`; non-Python/missing files degrade gracefully.

  - **Coverage gate** : flags picks made on too few `visible_lines`. `REMYX_SELECTION_COVERAGE_GATE`: `observe` (default is flag, don't block) / `enforce` (downgrade to `skipped_under_explored`) / `off`. Floors overridable via `REMYX_SELECTION_MIN_VISIBLE_LINES` (`150`, or `300` for extension picks).

  ### Testing

  Unit tests for the classifier, transcript parser, efficiency proxy, gate modes, and `gh-graph`; existing selection tests updated for the streaming runner. Full suite green.
  
  Ships gated in **observe** mode so the floors can be calibrated on real runs before enabling `enforce`. No change to existing output contracts.