### PR TITLE
Post run telemetry 

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -746,8 +746,8 @@ Recovery strategies for missing/broken links (apply BEFORE concluding
          absent from the abstract.
     Treat "no code found" as a verdict you reach AFTER exhausting these,
     not a default. Many engine `github_url: (none)` cases have code
-    reachable via one of these paths (REMYX-100 will fix this at ingest;
-    until then, agent-side recovery is the defense).
+    reachable via one of these paths (ingest-side fixes may improve this
+    over time; until then, agent-side recovery is the defense).
   - **Login-wall detection.** Pages from Colab, Drive, JSTOR, OpenReview
     can return HTTP 200 with sign-in content that LOOKS like real
     content. If a fetched page is < 500 chars of non-nav body AND
@@ -1018,7 +1018,7 @@ class Recommendation:
                                       # on engine.remyx.ai (research focus,
                                       # current goals, what they care about)
     experiment_history: str = ""      # LLM-ready bullets from
-                                      # ExperimentHistory (REMYX-58 format),
+                                      # ExperimentHistory format,
                                       # fetched from the research-interests
                                       # endpoint. Empty when the interest
                                       # has no linked history.
@@ -1768,8 +1768,8 @@ def _fetch_interest_context(interest_id: str) -> tuple[str, str, str]:
     Returns (interest_name, interest_context, experiment_history). The
     context body is the rich text the customer wrote on engine.remyx.ai
     about their research focus / goals. The experiment_history is the
-    LLM-ready bullet summary of the team's shipping trajectory (REMYX-58
-    format) — empty string when the interest has no linked
+    LLM-ready bullet summary of the team's shipping trajectory — empty
+    string when the interest has no linked
     ExperimentHistory or when the engine hasn't deployed the field yet.
 
     Best-effort: on any failure we return empty strings and fall back to
@@ -3283,7 +3283,7 @@ def write_spec_bundle(
         paper_abstract=rec.paper_abstract,
     ))
 
-    # CONTEXT.md — team's shipping history bullets (REMYX-58 format),
+    # CONTEXT.md — team's shipping history bullets,
     # fetched from the research-interests endpoint. Skipped entirely
     # when no history is linked, so INVOCATION.md's "if Remyx returned
     # any" caveat continues to hold.
@@ -7041,8 +7041,8 @@ def _compose_weekly_markdown(
         lines += ["", "### 📈 In the research stream", ""]
         lines += [f"- {t}" for t in trends]
 
-    # Lifecycle events on Outrider Issues/PRs in the past 7 days
-    # (REMYX-114). Section omitted entirely when no events occurred.
+    # Lifecycle events on Outrider Issues/PRs in the past 7 days.
+    # Section omitted entirely when no events occurred.
     if lifecycle_events:
         lines += _render_lifecycle_events_section(lifecycle_events, window_end)
 
@@ -7137,7 +7137,7 @@ def _compose_weekly_markdown(
     return "\n".join(lines)
 
 
-# ─── Lifecycle events for Outrider-authored artifacts (REMYX-114) ─────────
+# ─── Lifecycle events for Outrider-authored artifacts ─────────────────────
 
 
 def _is_bot_actor(user: dict | None) -> bool:
@@ -7321,8 +7321,7 @@ def _render_lifecycle_events_section(
     """Render the Outrider-artifact lifecycle events as markdown lines.
 
     Returns ``[]`` when no events were detected — caller skips the
-    section header entirely (no "nothing happened" noise per the
-    REMYX-114 acceptance criteria).
+    section header entirely (no "nothing happened" noise).
     """
     if not events:
         return []
@@ -7705,15 +7704,15 @@ def run_weekly_summary(target: Target) -> dict:
         reverse=True,
     )
     # Lifecycle events on Outrider-authored Issues/PRs in the window —
-    # state transitions + maintainer comments since the prior digest
-    # (REMYX-114). Empty list when nothing changed; the render code
+    # state transitions + maintainer comments since the prior digest.
+    # Empty list when nothing changed; the render code
     # then omits the section header entirely.
     lifecycle_events = _lifecycle_events_for_outrider_artifacts(
         target, window_start, window_end,
     )
     # License-watch: re-check upstream license for open Outrider Issues
     # that were originally blocked at the license/code-availability gate;
-    # surface ones that transitioned to viable (REMYX-115). Sibling
+    # surface ones that transitioned to viable. Sibling
     # category to the lifecycle events above — shares the same surface.
     newly_viable = _newly_viable_outrider_artifacts(target)
     agg = _aggregate_week(entries)
@@ -7960,10 +7959,10 @@ def _write_step_summary(result: dict) -> None:
 
 
 def _post_run_telemetry(result: dict, target: "Target") -> None:
-    """Best-effort POST of this run's telemetry to the engine (REMYX-68).
+    """Best-effort POST of this run's telemetry to the engine.
 
     Captures the per-run output into the engine's ``recommendation_runs`` table
-    for internal portfolio diagnostics. Never raises and never blocks: any
+    for later analysis. Never raises and never blocks: any
     failure (no API key, endpoint unreachable, non-2xx) is logged and
     swallowed so a telemetry outage can't break a customer's run. Skipped
     outside GitHub Actions, where there's no ``GITHUB_RUN_ID`` to dedup on.
@@ -7992,9 +7991,9 @@ def _post_run_telemetry(result: dict, target: "Target") -> None:
         "recommendation_id": result.get("recommendation_id"),
         "target_repo": target.repo,
         "status": result.get("status"),
-        # Distinguishes real customer runs from the internal eval portfolio
-        # (REMYX-101 sets REMYX_RUN_SOURCE=eval_portfolio in its fork workflows).
-        "source": os.environ.get("REMYX_RUN_SOURCE", "customer"),
+        # The run's origin, so downstream analysis can separate standard
+        # Outrider runs from other run sources. Override via REMYX_RUN_SOURCE.
+        "source": os.environ.get("REMYX_RUN_SOURCE", "outrider"),
         "artifact_url": (
             result.get("pr_url")
             or result.get("issue_url")
@@ -8110,9 +8109,9 @@ def main():
     # customers see cost telemetry without wiring downstream steps.
     _write_step_summary(result)
 
-    # Best-effort: capture this run's telemetry to the engine for internal
-    # portfolio diagnostics (REMYX-68). Only recommend-mode runs map onto the
-    # recommendation_runs schema; weekly-summary runs are skipped. Never blocks.
+    # Best-effort: capture this run's telemetry to the engine for analysis.
+    # Only recommend-mode runs map onto the run schema; weekly-summary runs
+    # are skipped. Never blocks the run.
     if mode == "recommend":
         _post_run_telemetry(result, target)
 

--- a/src/run.py
+++ b/src/run.py
@@ -5887,6 +5887,7 @@ def process_target(target: Target) -> dict:
                     "paper": rec.paper_title,
                     "arxiv": rec.arxiv_id,
                     "tier": rec.tier,
+                    "recommendation_id": rec.recommendation_id or None,
                     "candidates_considered": len(viable),
                     "status": "issue_opened_substitution",
                     "issue_url": issue_url,
@@ -5958,6 +5959,7 @@ def process_target(target: Target) -> dict:
                         "paper": rec.paper_title,
                         "arxiv": rec.arxiv_id,
                         "tier": rec.tier,
+                        "recommendation_id": rec.recommendation_id or None,
                         "candidates_considered": len(viable),
                         "status": "issue_opened_substitution",
                         "issue_url": issue_url,
@@ -5981,6 +5983,7 @@ def process_target(target: Target) -> dict:
             "paper": rec.paper_title,
             "arxiv": rec.arxiv_id,
             "tier": rec.tier,
+            "recommendation_id": rec.recommendation_id or None,
             "candidates_considered": len(viable),
         })
         _record_verdict_fields(result, rec)
@@ -7956,6 +7959,70 @@ def _write_step_summary(result: dict) -> None:
         log.warning(f"Could not write to $GITHUB_STEP_SUMMARY: {e}")
 
 
+def _post_run_telemetry(result: dict, target: "Target") -> None:
+    """Best-effort POST of this run's telemetry to the engine (REMYX-68).
+
+    Captures the per-run output into the engine's ``recommendation_runs`` table
+    for internal portfolio diagnostics. Never raises and never blocks: any
+    failure (no API key, endpoint unreachable, non-2xx) is logged and
+    swallowed so a telemetry outage can't break a customer's run. Skipped
+    outside GitHub Actions, where there's no ``GITHUB_RUN_ID`` to dedup on.
+
+    The fields are read defensively with ``.get`` — a skipped run that never
+    reached the selection pass simply sends nulls for the pool / selection /
+    coverage fields.
+    """
+    run_id_raw = os.environ.get("GITHUB_RUN_ID")
+    if not run_id_raw:
+        log.debug("  run telemetry: no GITHUB_RUN_ID (local run?); skipping POST")
+        return
+    try:
+        run_id = int(run_id_raw)
+    except (TypeError, ValueError):
+        log.debug(f"  run telemetry: GITHUB_RUN_ID {run_id_raw!r} not an int; "
+                  f"skipping POST")
+        return
+
+    reasoning = result.get("selection_reasoning") or ""
+    payload = {
+        "run_id": run_id,
+        # The chosen candidate's engine paper_recommendation UUID, threaded
+        # onto `result` when an in-pool candidate is picked; null for skips and
+        # out-of-pool (search-surfaced) picks, which have no pool row.
+        "recommendation_id": result.get("recommendation_id"),
+        "target_repo": target.repo,
+        "status": result.get("status"),
+        # Distinguishes real customer runs from the internal eval portfolio
+        # (REMYX-101 sets REMYX_RUN_SOURCE=eval_portfolio in its fork workflows).
+        "source": os.environ.get("REMYX_RUN_SOURCE", "customer"),
+        "artifact_url": (
+            result.get("pr_url")
+            or result.get("issue_url")
+            or result.get("discussion_comment_url")
+        ),
+        "broad_pool_size": result.get("broad_pool_size"),
+        "refine_pool_size": result.get("refine_pool_size"),
+        "candidates_considered": result.get("candidates_considered"),
+        "refine_queries": result.get("refine_queries"),
+        "license_class_counts": result.get("license_class_counts"),
+        "selection_reasoning_excerpt": reasoning[:2048] or None,
+        "selection_integration_shape": result.get("selection_integration_shape"),
+        "selection_coverage": result.get("selection_coverage"),
+        "selection_context_efficiency": result.get("selection_context_efficiency"),
+        "cost_usd": result.get("cost_usd"),
+        "input_tokens": result.get("input_tokens"),
+        "output_tokens": result.get("output_tokens"),
+        "claude_calls": result.get("claude_calls"),
+        "error": result.get("error"),
+    }
+    try:
+        _remyx_post("/api/v1.0/outrider/runs", payload)
+        log.info(f"  run telemetry posted (run_id={run_id}, "
+                 f"status={payload['status']})")
+    except Exception as e:
+        log.warning(f"  run telemetry POST failed (non-fatal): {str(e)[:200]}")
+
+
 def main():
     # Mode dispatch: "recommend" is the classic
     # scout-and-implement run; "weekly-summary" aggregates the past week
@@ -8042,6 +8109,12 @@ def main():
     # page — by far the most visible surface, and the one place
     # customers see cost telemetry without wiring downstream steps.
     _write_step_summary(result)
+
+    # Best-effort: capture this run's telemetry to the engine for internal
+    # portfolio diagnostics (REMYX-68). Only recommend-mode runs map onto the
+    # recommendation_runs schema; weekly-summary runs are skipped. Never blocks.
+    if mode == "recommend":
+        _post_run_telemetry(result, target)
 
     # Non-zero exit on genuine failures so the workflow step fails visibly
     # (a green run with no PR/Issue previously masked claude_failed). Issues,

--- a/tests/test_direct_arxiv_lookup.py
+++ b/tests/test_direct_arxiv_lookup.py
@@ -26,7 +26,7 @@ import run  # noqa: E402
 
 def test_get_asset_returns_dict_on_success(monkeypatch):
     """Direct lookup returns the asset envelope as-is when the engine
-    has the asset (the InstructSAM-shaped case from REMYX-91 + REMYX-90).
+    has the asset (the InstructSAM-shaped case).
     """
     asset = {
         "arxiv_id": "2605.26102",

--- a/tests/test_downgrade_diff.py
+++ b/tests/test_downgrade_diff.py
@@ -108,8 +108,8 @@ def test_capture_diff_excludes_remyx_recommendation_scratchpad(tmp_path):
     """The orchestrator writes internal agent-facing prompts under
     `.remyx-recommendation/` (CONTEXT.md, GUARDRAILS.md, etc.). These
     must NOT appear in the diff embedded in downgrade-Issue bodies —
-    they leak orchestrator phrasing into a maintainer-facing artifact
-    (REMYX-112). The actual code contribution alongside them MUST still
+    they leak orchestrator phrasing into a maintainer-facing artifact.
+    The actual code contribution alongside them MUST still
     appear."""
     _init_git_repo(tmp_path)
     # Real code contribution the agent wrote

--- a/tests/test_lifecycle_events.py
+++ b/tests/test_lifecycle_events.py
@@ -1,4 +1,4 @@
-"""Tests for the weekly-summary lifecycle-events helpers (REMYX-114).
+"""Tests for the weekly-summary lifecycle-events helpers.
 
 Covers:
   - `_is_bot_actor` — bot detection across the GitHub user-dict shapes

--- a/tests/test_link_robustness.py
+++ b/tests/test_link_robustness.py
@@ -1,5 +1,5 @@
 """Tests for v1.5.1 missing-link recovery strategies in the selection
-prompt (REMYX-104).
+prompt.
 
 These tests lock in the *presence* of the recovery-strategy guidance —
 the selection-pass agent (Claude Code) reads the prompt and applies the
@@ -10,7 +10,7 @@ edits.
 
 A follow-up release will add CLI helpers (`arxiv-fetch`,
 `web-fetch-resilient`) and instrument `failed_lookups` in the result
-dict per the full REMYX-104 ticket; tests for those land then.
+dict per the full link-robustness work; tests for those land then.
 
 Run with: pytest tests/ -q
 """
@@ -77,7 +77,7 @@ def test_prompt_documents_missing_github_url_recovery_chain():
 
     This is the load-bearing protection against rejecting viable
     candidates that the engine mis-labeled as code-less — the failure
-    mode that surfaced REMYX-104 in the first place."""
+    mode that surfaced this in the first place."""
     prompt = _unwrap(run._SELECTION_PROMPT_TEMPLATE)
     assert "Engine reports `github_url: (none)`" in prompt
     # Tells the agent explicitly not to trust the null

--- a/tests/test_run_telemetry.py
+++ b/tests/test_run_telemetry.py
@@ -1,0 +1,141 @@
+"""Unit tests for the best-effort run-telemetry POST (REMYX-68 Outrider half).
+
+Covers payload mapping from the `result` dict, the source/env handling,
+artifact-url fallback, reasoning truncation, the local-run skip (no
+GITHUB_RUN_ID), and the best-effort guarantee (a POST failure never raises).
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Target  # noqa: E402
+
+
+def _result(**over):
+    base = {
+        "status": "pr_opened",
+        "pr_url": "https://github.com/remyxai/example/pull/1",
+        "broad_pool_size": 30,
+        "refine_pool_size": 12,
+        "candidates_considered": 24,
+        "refine_queries": ["q1", "q2"],
+        "license_class_counts": {"permissive": 3},
+        "selection_reasoning": "clear call site at src/foo.py:12",
+        "selection_integration_shape": "addition",
+        "selection_coverage": {"searches": 1, "file_reads": 6, "visible_lines": 318},
+        "selection_context_efficiency": 0.0063,
+        "cost_usd": 0.45,
+        "input_tokens": 4188,
+        "output_tokens": 4635,
+        "claude_calls": 1,
+    }
+    base.update(over)
+    return base
+
+
+def _capture(monkeypatch):
+    calls = []
+    monkeypatch.setattr(run, "_remyx_post", lambda path, body: calls.append((path, body)) or {})
+    return calls
+
+
+def _target():
+    return Target(repo="remyxai/example", interest_id="iid")
+
+
+def test_posts_full_payload(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    monkeypatch.delenv("REMYX_RUN_SOURCE", raising=False)
+    calls = _capture(monkeypatch)
+
+    run._post_run_telemetry(_result(), _target())
+
+    assert len(calls) == 1
+    path, body = calls[0]
+    assert path == "/api/v1.0/outrider/runs"
+    assert body["run_id"] == 12345 and isinstance(body["run_id"], int)
+    assert body["target_repo"] == "remyxai/example"
+    assert body["status"] == "pr_opened"
+    assert body["source"] == "customer"                      # default
+    assert body["recommendation_id"] is None
+    assert body["artifact_url"].endswith("/pull/1")
+    assert body["refine_queries"] == ["q1", "q2"]
+    assert body["license_class_counts"] == {"permissive": 3}
+    assert body["selection_coverage"]["visible_lines"] == 318
+    assert body["selection_context_efficiency"] == 0.0063
+    assert body["cost_usd"] == 0.45 and body["claude_calls"] == 1
+
+
+def test_recommendation_id_threaded_from_result(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    calls = _capture(monkeypatch)
+    rid = "11111111-2222-3333-4444-555555555555"
+    run._post_run_telemetry(_result(recommendation_id=rid), _target())
+    assert calls[0][1]["recommendation_id"] == rid
+
+
+def test_recommendation_id_null_when_absent(monkeypatch):
+    # Skip / out-of-pool runs never set result["recommendation_id"].
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    calls = _capture(monkeypatch)
+    run._post_run_telemetry(_result(), _target())   # no recommendation_id key
+    assert calls[0][1]["recommendation_id"] is None
+
+
+def test_skips_without_run_id(monkeypatch):
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+    calls = _capture(monkeypatch)
+    run._post_run_telemetry(_result(), _target())
+    assert calls == []           # local run → no POST attempted
+
+
+def test_best_effort_swallows_post_failure(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+
+    def boom(path, body):
+        raise RuntimeError("Remyx API POST → HTTP 503")
+
+    monkeypatch.setattr(run, "_remyx_post", boom)
+    # Must NOT raise — telemetry is best-effort.
+    run._post_run_telemetry(_result(), _target())
+
+
+def test_source_env_override(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    monkeypatch.setenv("REMYX_RUN_SOURCE", "eval_portfolio")
+    calls = _capture(monkeypatch)
+    run._post_run_telemetry(_result(), _target())
+    assert calls[0][1]["source"] == "eval_portfolio"
+
+
+def test_artifact_url_falls_back_to_issue(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    calls = _capture(monkeypatch)
+    res = _result(status="issue_opened_preflight")
+    res.pop("pr_url")
+    res["issue_url"] = "https://github.com/remyxai/example/issues/6"
+    run._post_run_telemetry(res, _target())
+    assert calls[0][1]["artifact_url"].endswith("/issues/6")
+
+
+def test_reasoning_truncated_to_2kb(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    calls = _capture(monkeypatch)
+    run._post_run_telemetry(_result(selection_reasoning="x" * 5000), _target())
+    assert len(calls[0][1]["selection_reasoning_excerpt"]) == 2048
+
+
+def test_skipped_run_sends_nulls(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    calls = _capture(monkeypatch)
+    # A skip that never reached the selection pass — only status present.
+    run._post_run_telemetry({"status": "skipped_rate_limit"}, _target())
+    body = calls[0][1]
+    assert body["status"] == "skipped_rate_limit"
+    assert body["selection_coverage"] is None
+    assert body["artifact_url"] is None
+    assert body["selection_reasoning_excerpt"] is None

--- a/tests/test_run_telemetry.py
+++ b/tests/test_run_telemetry.py
@@ -1,4 +1,4 @@
-"""Unit tests for the best-effort run-telemetry POST (REMYX-68 Outrider half).
+"""Unit tests for the best-effort run-telemetry POST.
 
 Covers payload mapping from the `result` dict, the source/env handling,
 artifact-url fallback, reasoning truncation, the local-run skip (no
@@ -60,7 +60,7 @@ def test_posts_full_payload(monkeypatch):
     assert body["run_id"] == 12345 and isinstance(body["run_id"], int)
     assert body["target_repo"] == "remyxai/example"
     assert body["status"] == "pr_opened"
-    assert body["source"] == "customer"                      # default
+    assert body["source"] == "outrider"                      # default
     assert body["recommendation_id"] is None
     assert body["artifact_url"].endswith("/pull/1")
     assert body["refine_queries"] == ["q1", "q2"]
@@ -106,10 +106,10 @@ def test_best_effort_swallows_post_failure(monkeypatch):
 
 def test_source_env_override(monkeypatch):
     monkeypatch.setenv("GITHUB_RUN_ID", "12345")
-    monkeypatch.setenv("REMYX_RUN_SOURCE", "eval_portfolio")
+    monkeypatch.setenv("REMYX_RUN_SOURCE", "outrider_eval")
     calls = _capture(monkeypatch)
     run._post_run_telemetry(_result(), _target())
-    assert calls[0][1]["source"] == "eval_portfolio"
+    assert calls[0][1]["source"] == "outrider_eval"
 
 
 def test_artifact_url_falls_back_to_issue(monkeypatch):


### PR DESCRIPTION
## Post per-run telemetry to the engine (best-effort)

After each recommend run, POST the run summary to the engine. Additive; no behavior change.

  - New `_post_run_telemetry(result, target)` → `POST /api/v1.0/outrider/runs` via `_remyx_post`. **Best-effort** — swallows failures, never
  blocks a run; skipped outside GitHub Actions.
  - Called from `main()` for `recommend`-mode runs only.
  - Threads the chosen candidate's recommendation id through `result` (null for skips / out-of-pool picks).
  - Tests: `tests/test_run_telemetry.py`.

Config: `REMYX_RUN_SOURCE` (default `outrider`) tags the run origin. 