### PR TITLE
Rate-limit gate: switch from time window to open-artifact check

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Scouts the arXiv frontier for your repo and picks the next paper most implementa
 - **RFC-shape Issues** when the team has signaled openness to a new capability (a README roadmap section, an open `[RFC]` Issue, a CONTEXT.md investment pattern) and a candidate fits as an extension — a clear proposal instead of speculation
 - **No duplicate work** — the same paper isn't re-recommended once any Outrider or maintainer Issue references it; reopen the Issue to re-engage
 - **A selection narrative** in the run's GitHub Actions step summary explaining why this paper (or why nothing actionable this run) — visible at a glance, not buried in logs
-- **One artifact per `rate-limit-days`** by default — no Issue spam
+- **No stacking unresolved work** by default — a new run skips while a prior Remyx PR or Issue is still open; engagement (merge or close) releases the gate
 
 ## Setup
 
@@ -84,7 +84,7 @@ Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Sett
 | `github-token` | `${{ github.token }}` | Override only for cross-repo controller patterns |
 | `min-confidence` | `moderate` | Tier gate: `high` / `moderate` / `low` |
 | `draft-mode` | `always` | `always` / `on_test_failure` / `never` |
-| `rate-limit-days` | `7` | Cadence guard. Skip the run if any Remyx artifact (PR **or** Issue) was opened within this window. Set `0` to disable. |
+| `rate-limit-days` | `7` | Cadence guard. Any value > 0 enables: skip the run if any **open** Remyx PR or Issue exists on the target. Engagement (merge or close) releases the gate. Set `0` to disable. The numeric value is otherwise ignored — kept as an on/off bit for compatibility with workflow files written for the prior sliding-window semantics. |
 | `guardrails-allowlist` | `''` | Extra path globs Claude Code may modify, **added on top of** the defaults (`*.py`, `.remyx-recommendation/**`, `**/*.md`). Most repos won't need this. |
 | `test-integration-policy` | `strict` | `strict` (demote to Issue if new tests don't import an existing module) / `soft` (open draft PR with warning) / `off` (skip the gate). Use `soft` for layer/component repos where standalone modules are the contribution. |
 | `lookback` | `week` | Candidate pool window: `today` / `week` / `month` |
@@ -113,7 +113,7 @@ Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Sett
 - **Remyx API**: included in your engine.remyx.ai subscription.
 - **GitHub Actions**: ~6–8 min on `ubuntu-latest` per run.
 
-At weekly cadence (default `rate-limit-days: 7`), expect ~$2–4/mo Claude.
+With the default cadence guard (gate enabled), expect ~$2–4/mo Claude at typical engagement patterns.
 
 <details>
 <summary><b>Status codes</b></summary>
@@ -130,7 +130,7 @@ At weekly cadence (default `rate-limit-days: 7`), expect ~$2–4/mo Claude.
 | `issue_opened_self_review` | Self-review judged the new code an orphan, unreachable from production. Body preserves Claude's implementation diff so the maintainer can review or apply it manually |
 | `issue_opened_substitution` | Selection identified a replacement / pipeline-simplification / extension candidate (vs. additive drop-in); routed to Issue because the swap needs dep changes the PR guardrails block, or there's no existing call site to anchor against |
 | `skipped_low_confidence` | Recommendation below `min-confidence` |
-| `skipped_rate_limit` | A Remyx PR or Issue was opened within `rate-limit-days` |
+| `skipped_open_artifact` | An open Remyx PR or Issue from a prior run still exists on the target — engagement (merge or close) releases the gate |
 | `skipped_pr_exists` | Every candidate already has an open PR |
 | `skipped_issue_exists` | Every candidate already has a prior Issue referencing the arxiv id — Outrider-opened OR maintainer-opened, open OR closed. Step summary differentiates "Already in flight" (open) vs "Already addressed" (closed). Reopen the Issue to re-engage |
 | `skipped_external_issue_exists` | Selection pass surfaced an out-of-pool candidate but it's already in the team's attention — same Outrider/Maintainer × open/closed differentiation as above |

--- a/action.yml
+++ b/action.yml
@@ -60,12 +60,16 @@ inputs:
     default: 'always'
   rate-limit-days:
     description: |
-      Cadence guard: skip the run if any Remyx Recommendation artifact
-      (PR or Issue) was opened on the target repo within this many
-      days. Counts both routes so customers see at most one Remyx
-      artifact per `rate-limit-days` regardless of whether it lands as
-      a PR or as a discussion Issue. Default 7 (weekly cadence). Set
-      to 0 to disable and rely only on per-paper dedup.
+      Cadence guard: skip the run if an *open* Remyx Recommendation
+      artifact (PR or Issue) from a prior run still exists on the
+      target repo. Engagement (merge or close) signals the channel is
+      clear and the next run can proceed. Per-paper dedup (a separate
+      gate) handles same-recommendation retries — this guard is purely
+      about not stacking unresolved work. Any value > 0 enables the
+      guard; 0 disables it. The numeric value is otherwise ignored
+      (retained as an on/off bit so existing workflow files continue
+      to work unchanged; pre-2026-06 versions interpreted it as a
+      sliding "opened within N days" window).
     required: false
     default: '7'
   guardrails-allowlist:
@@ -134,7 +138,7 @@ outputs:
   status:
     description: |
       Run outcome: "pr_opened" | "pr_opened_draft" | "issue_opened" |
-      "skipped_low_confidence" | "skipped_rate_limit" | "skipped_pr_exists" |
+      "skipped_low_confidence" | "skipped_open_artifact" | "skipped_pr_exists" |
       "skipped_issue_exists" | "skipped_test_failure" | "claude_failed" |
       "rejected_path_violations" | "error". In weekly-summary mode:
       "weekly_summary_posted" | "weekly_summary_skipped_no_discussion_id" |

--- a/src/run.py
+++ b/src/run.py
@@ -2790,42 +2790,40 @@ def issue_for_paper(open_issues: list[dict], rec: Recommendation) -> dict | None
     return None
 
 
-def recent_remyx_activity_within_rate_limit(target: Target) -> bool:
-    """Return True if any Remyx Recommendation PR OR Issue was opened on
-    the target repo within `rate_limit_days`.
+def open_remyx_artifact_exists(target: Target) -> bool:
+    """Return True if any **open** Remyx Recommendation PR or Issue exists
+    on the target repo.
 
-    Counts both states (open and closed) — a recently-closed artifact
-    still represents a recent customer interruption that the rate-limit
-    is designed to throttle. Counts both PRs (identified by branch
-    prefix) and Issues (identified by title prefix or body marker), so
-    a cadence guard set to e.g. 7 days produces at most one Remyx
-    artifact per week, regardless of whether it lands as a PR or an
-    Issue."""
+    The cadence guard's job is to avoid stacking unresolved work on a
+    maintainer who hasn't engaged with the prior recommendation. Once
+    they merge or close it, the channel is clear and the next run can
+    proceed — engagement IS the signal. Per-paper dedup (a separate
+    gate) already prevents the same recommendation from re-surfacing,
+    so the cadence guard doesn't need its own time window.
+
+    `target.rate_limit_days > 0` enables this gate; `<= 0` disables it.
+    The numeric value is otherwise ignored — preserved as an on/off bit
+    so existing `outrider.yml` workflows continue to work unchanged.
+    """
     if target.rate_limit_days <= 0:
         return False
-    cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=target.rate_limit_days)
 
-    # PRs — identified by branch prefix.
+    # PRs — identified by branch prefix. Only open PRs block.
     prs = gh_api(
-        "GET", f"/repos/{target.repo}/pulls?state=all&per_page=20"
-    )
+        "GET", f"/repos/{target.repo}/pulls?state=open&per_page=50"
+    ) or []
     for pr in prs:
         ref = pr.get("head", {}).get("ref", "")
         if not ref.startswith(BRANCH_PREFIX):
             continue
-        created = dt.datetime.fromisoformat(pr["created_at"].replace("Z", "+00:00"))
-        if created > cutoff:
-            log.info(
-                f"  rate-limit hit (PR): {pr['html_url']} opened "
-                f"{(dt.datetime.now(dt.timezone.utc) - created).days}d ago"
-            )
-            return True
+        log.info(f"  open Remyx PR exists: {pr['html_url']}")
+        return True
 
     # Issues — identified by title prefix or body attribution marker.
     # GitHub's /issues endpoint also returns PRs (they carry a
     # 'pull_request' key); filter those out so we don't double-count.
     issues = gh_api(
-        "GET", f"/repos/{target.repo}/issues?state=all&per_page=50"
+        "GET", f"/repos/{target.repo}/issues?state=open&per_page=50"
     ) or []
     for it in issues:
         if it.get("pull_request"):
@@ -2834,13 +2832,8 @@ def recent_remyx_activity_within_rate_limit(target: Target) -> bool:
         body = it.get("body") or ""
         if not (title.startswith(PR_TITLE_PREFIX) or "Remyx Recommendation" in body):
             continue
-        created = dt.datetime.fromisoformat(it["created_at"].replace("Z", "+00:00"))
-        if created > cutoff:
-            log.info(
-                f"  rate-limit hit (Issue): {it['html_url']} opened "
-                f"{(dt.datetime.now(dt.timezone.utc) - created).days}d ago"
-            )
-            return True
+        log.info(f"  open Remyx Issue exists: {it['html_url']}")
+        return True
 
     return False
 
@@ -5552,10 +5545,11 @@ def process_target(target: Target) -> dict:
     skip:
 
         skipped_low_confidence            — tier below min_confidence
-        skipped_rate_limit                — any Remyx artifact (PR or
-                                            Issue) opened within
-                                            rate-limit-days; the gate is
-                                            a global cadence guard
+        skipped_open_artifact             — an open Remyx PR or Issue
+                                            from a prior run still
+                                            exists on the target; the
+                                            cadence guard avoids
+                                            stacking unresolved work
         skipped_pr_exists                 — every candidate already has an
                                             open PR (or a mix of open PRs/Issues)
         skipped_issue_exists              — every candidate already has an
@@ -5596,16 +5590,14 @@ def process_target(target: Target) -> dict:
     """
     result: dict = {"repo": target.repo, "status": "unknown"}
 
-    # 1. Rate-limit (cadence guard) — cheapest gate, before any
-    #    candidate work or checkout. Counts BOTH Remyx PRs and Issues
-    #    opened within rate-limit-days; if any exists, skip the run.
-    #    This makes the rate-limit a true global cadence guard:
-    #    customers see at most one Remyx artifact per N days regardless
-    #    of which route (PR or Issue) it takes. The earlier version
-    #    counted only PRs, which let Issues open daily during PR
-    #    throttle — that was high-noise on daily crons.
-    if recent_remyx_activity_within_rate_limit(target):
-        result["status"] = "skipped_rate_limit"
+    # 1. Cadence guard — cheapest gate, before any candidate work or
+    #    checkout. Skip if any *open* Remyx artifact exists on the
+    #    target. Engagement (merge/close) IS the signal that the
+    #    channel is clear; the guard exists to avoid stacking
+    #    unresolved work, not to enforce a time window. Per-paper
+    #    dedup (further down) handles same-recommendation retries.
+    if open_remyx_artifact_exists(target):
+        result["status"] = "skipped_open_artifact"
         return result
 
     # 2. Query the candidate pool over the lookback window (default: the
@@ -7832,7 +7824,7 @@ def _write_step_summary(result: dict) -> None:
         "issue_opened_no_test_integration": "🟡",
         "issue_opened_self_review":        "🟡",
         "skipped_low_confidence":  "⏭️",
-        "skipped_rate_limit":      "⏭️",
+        "skipped_open_artifact":   "⏭️",
         "skipped_pr_exists":       "⏭️",
         "skipped_issue_exists":    "⏭️",
         "skipped_external_issue_exists": "⏭️",

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,148 @@
+"""Tests for the cadence guard `open_remyx_artifact_exists`.
+
+The guard's new semantic (2026-06-15): skip a run iff an *open* Remyx
+PR or Issue from a prior run still exists on the target. Engagement
+(merge or close) releases the gate. The prior sliding-window
+("opened within N days") behavior is gone; the `rate_limit_days`
+field on Target is reinterpreted as an on/off bit (>0 enables, <=0
+disables) so existing workflow files continue to work.
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Target  # noqa: E402
+
+
+def _pr(ref: str, html_url: str = "https://github.com/r/x/pull/1") -> dict:
+    return {"head": {"ref": ref}, "html_url": html_url}
+
+
+def _issue(title: str = "", body: str = "",
+           html_url: str = "https://github.com/r/x/issues/1",
+           is_pr: bool = False) -> dict:
+    out = {"title": title, "body": body, "html_url": html_url}
+    if is_pr:
+        out["pull_request"] = {"url": "..."}
+    return out
+
+
+def _target(rate_limit_days: int = 7) -> Target:
+    return Target(
+        repo="r/x",
+        interest_id="iid",
+        min_confidence="moderate",
+        draft_mode="always",
+        rate_limit_days=rate_limit_days,
+    )
+
+
+# ─── happy path: gate fires when an open Remyx artifact exists ─────────────
+
+
+def test_open_remyx_pr_fires_the_gate(monkeypatch):
+    """A Remyx PR (`remyx-recommendation/*` branch) that's open blocks
+    the next run — that's the whole point of the guard."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return [_pr(ref="remyx-recommendation/2606.06460v1")]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target()) is True
+
+
+def test_open_remyx_issue_fires_the_gate(monkeypatch):
+    """A Remyx Issue (identified by title prefix or body marker) that's
+    open blocks the next run."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return []
+        if "/issues?" in path:
+            return [_issue(title="[Remyx Recommendation] foo")]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target()) is True
+
+
+# ─── engagement releases the gate ──────────────────────────────────────────
+
+
+def test_only_merged_or_closed_prs_do_not_fire(monkeypatch):
+    """Once a Remyx PR is merged or closed, the gate releases — the
+    GitHub API's `state=open` filter never surfaces them, so this is
+    the simplest test: only open PRs come back, and if there are
+    none, the gate is clear."""
+    state_param: list[str] = []
+
+    def fake_gh_api(method, path, body=None):
+        # Capture the query so we can prove we ask only for state=open.
+        if "/pulls?" in path:
+            state_param.append(path)
+            return []  # merged/closed don't satisfy state=open
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target()) is False
+    assert any("state=open" in p for p in state_param), \
+        "gate must query only open PRs, not state=all"
+
+
+# ─── on/off bit ────────────────────────────────────────────────────────────
+
+
+def test_rate_limit_days_zero_disables_the_gate(monkeypatch):
+    """`rate-limit-days: 0` in the workflow input disables the gate
+    entirely — the guard returns False even if a Remyx PR is open."""
+    def fake_gh_api(method, path, body=None):
+        # Should never be reached when the gate is disabled.
+        raise AssertionError("gate must not call gh_api when disabled")
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target(rate_limit_days=0)) is False
+
+
+# ─── non-Remyx artifacts don't fire the gate ───────────────────────────────
+
+
+def test_non_remyx_open_pr_does_not_fire(monkeypatch):
+    """A maintainer's own open PR (not on a `remyx-recommendation/*`
+    branch) is irrelevant to the cadence guard."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return [_pr(ref="feat/some-maintainer-work")]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target()) is False
+
+
+def test_open_issue_without_remyx_marker_does_not_fire(monkeypatch):
+    """A random open Issue with no Remyx title prefix or body marker
+    is irrelevant — the guard counts only Remyx-authored Issues."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return []
+        if "/issues?" in path:
+            return [_issue(title="Bug: foo broken", body="unrelated")]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target()) is False
+
+
+def test_issues_endpoint_returns_prs_which_are_filtered(monkeypatch):
+    """GitHub's /issues endpoint returns PRs too (they carry a
+    'pull_request' key). The guard's Issue scan must ignore those so
+    PRs aren't double-counted — they're already handled by the
+    /pulls scan."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return []
+        if "/issues?" in path:
+            # Looks like a Remyx Issue by title, but it's actually a PR.
+            return [_issue(title="[Remyx Recommendation] X",
+                           body="...", is_pr=True)]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    # The PR-like Issue is filtered; no Remyx artifact reported.
+    assert run.open_remyx_artifact_exists(_target()) is False


### PR DESCRIPTION
## Summary

The cadence guard (`rate-limit-days`) used to skip a run if **any Remyx artifact was opened within N days** — regardless of whether that artifact was still open, merged, or closed. After a maintainer engaged with a Remyx PR (merge or close), the gate kept blocking for the remainder of the window, dead-cadencing the daily cron for days at a time.

This PR switches the gate to fire iff an **open** Remyx PR or Issue still exists on the target. Engagement releases the gate. Per-paper dedup (a separate gate) already handles same-recommendation retries, so the time window did no work the open-artifact check doesn't already do.

## Concrete trigger

A scheduled run on this repo at 2026-06-15 15:56 UTC ([run 27558869776](https://github.com/remyxai/outrider/actions/runs/27558869776)) skipped because PR #28 (then open for 5 days) was inside the 7-day window. PR #28 merged ~1h later, but the gate would have kept blocking the daily cron through 2026-06-22 — six days of dead cadence after the maintainer had already engaged.

## Changes

- `src/run.py`: function `recent_remyx_activity_within_rate_limit` → `open_remyx_artifact_exists`; queries `state=open` instead of `state=all` + cutoff. Status code on the routing path: `skipped_rate_limit` → `skipped_open_artifact`.
- `Target.rate_limit_days` kept as an on/off bit (`> 0` enables, `<= 0` disables) so existing `outrider.yml` files continue to work unchanged. The numeric value is otherwise ignored.
- `action.yml`: input description rewritten to explain the new semantic and the compatibility behavior.
- `README.md`: top-feature bullet, inputs table, and status-code table updated.
- `tests/test_rate_limit.py` (new): 7 cases — gate fires on open PR/Issue, releases on engagement, ignores non-Remyx artifacts, filters PRs from the `/issues` endpoint, honors the on/off bit.

## Backward compatibility

- Customer workflows pinning `rate-limit-days: '0'` or `'7'` continue to behave correctly (off vs. on).
- The numeric value loses its sliding-window meaning; an integer other than 0 just enables the gate.
- The `skipped_rate_limit` status code no longer appears on new runs. Historical telemetry rows with that code remain valid; the action's documented outputs add `skipped_open_artifact`.

## Test plan

- [x] `python3 -m pytest tests/test_rate_limit.py -q` — 7 passed
- [x] `python3 -m pytest tests/ -q` — 450 passed
- [ ] After merge: verify the next scheduled run on `remyxai/outrider` (with the rate-limit-days input still pinned to 7) proceeds once any open Remyx PR/Issue is engaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)