### PR TITLE
Diff Risk Score: recalibrate weights for v1.7.0

### DIFF
--- a/docs/diff_risk_calibration_runs.md
+++ b/docs/diff_risk_calibration_runs.md
@@ -2,13 +2,47 @@
 
 Each row is a `remyx-recommendation/*` branch scored against its merge-base with `origin/main`. Sorted by score descending so disputed-band candidates surface first.
 
+## v1.7.0 weights (current)
+
+Recalibrated 2026-06-16 after a cross-portfolio re-scoring exercise across ~20 fork targets showed v1.6.0 over-routing to the high band. The gate triages "draft PR for review vs RFC Issue for discussion" — not "is this diff risky" — so the bar for downgrade-to-Issue is now much higher. The size of an Outrider scaffold (9-12 files, 500-1000 lines, module + tests + wiring + docs) is the expected output shape, not a risk signal; categorical signals (`critical_file_touched`, `untested_new_surface`) carry the routing decisions.
+
 | Branch | Date | Score | Band | Files | +Lines | -Lines | New cb | Crit | Untested | Top factor |
 |---|---|---:|---|---:|---:|---:|---:|---|---|---|
-| `pr-28` | 2026-06-15 | 0.99 | high | 6 | +927 | -0 | 11 | Y | N | `lines_changed` (+2.43) |
-| `smellslikeml/openai-agents-python-outrider-demo#4` † | 2026-06-15 | 0.94 | high | 9 | +1013 | -1 | 6 | N | N | `lines_changed` (+2.51) |
-| `smellslikeml/openai-agents-python-outrider-demo#2` † | 2026-06-11 | 0.64 | elevated | 3 | +360 | -1 | 6 | N | N | `lines_changed` (+1.44) |
-| `smellslikeml/Arbor#2` | 2026-06-12 | 0.60 | elevated | 4 | +367 | -1 | 2 | N | N | `lines_changed` (+1.47) |
-| `smellslikeml/openai-agents-python-outrider-demo#3` | 2026-06-12 | 0.58 | elevated | 4 | +296 | -4 | 4 | N | N | `lines_changed` (+1.2) |
-| `smellslikeml/pytorch_geometric-outrider-demo#3` | 2026-06-11 | 0.46 | low | 4 | +252 | -3 | 1 | N | N | `lines_changed` (+1.02) |
+| `pr-28` | 2026-06-15 | 0.53 | elevated | 6 | +927 | -0 | 11 | Y | N | `critical_file_touched` (+1.50) |
+| `recuse-recommendation-A` † | 2026-06-15 | 0.18 | low | 9 | +1013 | -1 | 6 | N | N | `lines_changed` (+0.51) |
+| `recuse-recommendation-B` † | 2026-06-11 | 0.12 | low | 3 | +360 | -1 | 6 | N | N | `new_callables` (+0.30) |
+| `projectmem-recommendation` | 2026-06-12 | 0.11 | low | 4 | +367 | -1 | 2 | N | N | `lines_changed` (+0.18) |
+| `prompt-injection-recommendation` | 2026-06-12 | 0.11 | low | 4 | +296 | -4 | 4 | N | N | `new_callables` (+0.20) |
+| `graph-rec` | 2026-06-11 | 0.10 | low | 4 | +252 | -3 | 1 | N | N | `lines_changed` (+0.13) |
 
-† `oai-agents-python-outrider-demo#2` and `#4` are two Outrider runs of the **same** recommendation (arxiv 2606.06460v1, "Will the Agent Recuse Itself?") on the same target. The scaffold in `#4` added 1013 LOC across 9 files vs. `#2`'s 360 LOC across 3 files — the gate routed `#4` to Issue and `#2` to PR, validating that the band routing tracks variance in scaffold blast-radius rather than just paper choice. Run-to-run variance is the gate's blind spot today; tightening it is REMYX-121's job.
+Distribution: **1 elevated / 5 low / 0 high**.
+
+† Two Outrider runs of the **same** recommendation (arxiv 2606.06460v1, "Will the Agent Recuse Itself?") on the same target. Under v1.6.0 weights they routed to different bands (one high, one elevated) because the scaffolds differed in size (1013 LOC across 9 files vs 360 LOC across 3 files); under v1.7.0 they both land in `low`. The size variance no longer changes the routing — both are draft PRs for human review, which matches the gate's actual job. Run-to-run variance is the gate's blind spot today; tightening it is future work.
+
+## v1.6.0 weights (historical — pre-recalibration)
+
+The original v1.6.0 scores are preserved here for reference. The recalibration was driven by the cross-portfolio re-scoring exercise confirming the "over-routing to high" failure mode: of the runs that produced an artifact, 82% landed in high band, and zero produced a PR.
+
+| Branch | v1.6.0 Score | v1.6.0 Band |
+|---|---:|---|
+| `pr-28` | 0.99 | high |
+| `recuse-recommendation-A` | 0.94 | high |
+| `recuse-recommendation-B` | 0.64 | elevated |
+| `projectmem-recommendation` | 0.60 | elevated |
+| `prompt-injection-recommendation` | 0.58 | elevated |
+| `graph-rec` | 0.46 | low |
+
+v1.6.0 distribution: **2 high / 3 elevated / 1 low**.
+
+## Weight changes (v1.6.0 → v1.7.0)
+
+| Weight | v1.6.0 | v1.7.0 | Change |
+|---|---:|---:|---|
+| `_W_INTERCEPT` | -2.0 | -2.5 | Lower baseline |
+| `_W_FILES` | 0.18 | 0.02 | 9× less |
+| `_W_LINES` | 0.004 (capped at 500 + 0.001/line overflow) | 0.0005 (linear, no cap) | 8× less, cap removed |
+| `_W_NEW_CALLABLES` | 0.10 | 0.05 | Half |
+| `_W_CRITICAL` | 1.6 | 1.5 | Slight reduction |
+| `_W_UNTESTED` | 1.1 | 1.7 | Raised (Outrider almost always adds tests, so missing tests IS a real signal) |
+| `DIFF_RISK_ELEVATED_THRESHOLD` | 0.50 | 0.50 | Hold |
+| `DIFF_RISK_ISSUE_THRESHOLD` | 0.80 | 0.80 | Hold |

--- a/src/diff_risk_score.py
+++ b/src/diff_risk_score.py
@@ -62,23 +62,25 @@ CRITICAL_PATH_HINTS = (
 
 # ── Logistic feature weights ───────────────────────────────────────────────
 #
-# Signs and magnitudes are calibrated (not trained) so that a small,
-# tested, non-critical wiring PR lands in "low", a moderate or untested
-# change lands in "elevated", and a sprawling multi-file rewrite or an
-# untested critical-path edit crosses into "high". The two categorical
-# signals (critical-path edit, new surface shipped without any test change)
-# are the dominant risk drivers, mirroring RADAR's finding that test
-# coverage and blast radius matter more than raw line count.
-_W_INTERCEPT = -2.0
-_W_FILES = 0.18          # per file touched
-_W_LINES = 0.004         # per added+deleted line UP TO _LINES_CAP
-_LINES_CAP = 500         # contribution saturates here; bigger diffs don't
-                          # linearly dominate the score (diminishing returns)
-_W_LINES_OVERFLOW = 0.001  # per line beyond _LINES_CAP — keeps the signal
-                            # monotonically increasing but flattened
-_W_NEW_CALLABLES = 0.10  # per newly-added public callable
-_W_CRITICAL = 1.6        # any pre-existing critical-path file edited
-_W_UNTESTED = 1.1        # new public surface added with no test-file change
+# Recalibrated 2026-06-16 from REMYX-101 sprint-1 data: 9 of 11 artifact-
+# producing runs (82%) routed to high-band Issue under the original weights,
+# net zero PRs. The gate triages "draft PR for review vs RFC Issue for
+# discussion", NOT "is this diff risky" — Outrider never auto-merges, so
+# downgrade-to-Issue is reserved for cases the maintainer needs to discuss
+# before reviewing a diff, not "the diff is big." Size of an Outrider
+# scaffold (9-12 files, 500-1000 lines) IS the expected output shape, not
+# a risk signal.
+#
+# Categorical signals (critical-path edit, untested new surface) remain
+# the dominant risk drivers. The previous _LINES_CAP / _W_LINES_OVERFLOW
+# pair is removed since the linear weight is now small enough not to need
+# cap behaviour.
+_W_INTERCEPT = -2.5
+_W_FILES = 0.02          # per file touched
+_W_LINES = 0.0005        # per added+deleted line (linear, no cap)
+_W_NEW_CALLABLES = 0.05  # per newly-added public callable
+_W_CRITICAL = 1.5        # any pre-existing critical-path file edited
+_W_UNTESTED = 1.7        # new public surface added with no test-file change
 
 
 @dataclass
@@ -298,11 +300,9 @@ def score_diff_risk(
     no sampling, deterministic for a given tree.
     """
     f = extract_features(workdir, package, base_ref=base_ref)
-    capped = min(f["lines_changed"], _LINES_CAP)
-    overflow = max(f["lines_changed"] - _LINES_CAP, 0)
     contributions = {
         "files_touched": _W_FILES * f["files_touched"],
-        "lines_changed": _W_LINES * capped + _W_LINES_OVERFLOW * overflow,
+        "lines_changed": _W_LINES * f["lines_changed"],
         "new_callables": _W_NEW_CALLABLES * f["new_callables"],
         "critical_file_touched": _W_CRITICAL if f["critical_file_touched"] else 0.0,
         "untested_new_surface": _W_UNTESTED if f["untested_new_surface"] else 0.0,

--- a/tests/test_diff_risk_score.py
+++ b/tests/test_diff_risk_score.py
@@ -194,36 +194,43 @@ def test_test_functions_excluded_from_new_callables():
     assert risk.features["new_callables"] == 1
 
 
-def test_lines_changed_contribution_is_capped():
-    """A 5000-line PR shouldn't get a linearly-unbounded lines contribution
-    that dominates every other signal. The cap + overflow weight makes the
-    relationship monotonically increasing but flattened above the cap."""
+def test_lines_changed_contribution_scales_modestly():
+    """A typical Outrider scaffold (~1000 lines) shouldn't have a lines
+    contribution that dominates the categorical risk signals. The v1.7.0
+    recalibration cut `_W_LINES` 8× (from 0.004 to 0.0005) precisely so
+    size-of-diff stays well below the categorical weights for the diff
+    sizes Outrider actually produces."""
     # Score-by-direct-call against synthetic features so we can probe the
     # math without building a 5000-line tree.
-    f_huge = {
-        "files_touched": 1, "lines_added": 5000, "lines_deleted": 0,
-        "lines_changed": 5000, "new_callables": 0,
-        "critical_file_touched": False, "untested_new_surface": False,
-    }
-    f_at_cap = dict(f_huge, lines_added=500, lines_changed=500)
-    # Monkey-patch extract_features to return our synthetic features.
     import diff_risk_score as drs
     real_extract = drs.extract_features
     try:
-        drs.extract_features = lambda *a, **kw: f_huge
+        # Typical Outrider scaffold: ~1000 lines
+        drs.extract_features = lambda *a, **kw: {
+            "files_touched": 10, "lines_added": 1000, "lines_deleted": 0,
+            "lines_changed": 1000, "new_callables": 8,
+            "critical_file_touched": False, "untested_new_surface": False,
+        }
+        typical = drs.score_diff_risk(Path("/tmp"), "x")
+        # Outlier 5000-line refactor
+        drs.extract_features = lambda *a, **kw: {
+            "files_touched": 10, "lines_added": 5000, "lines_deleted": 0,
+            "lines_changed": 5000, "new_callables": 8,
+            "critical_file_touched": False, "untested_new_surface": False,
+        }
         huge = drs.score_diff_risk(Path("/tmp"), "x")
-        drs.extract_features = lambda *a, **kw: f_at_cap
-        at_cap = drs.score_diff_risk(Path("/tmp"), "x")
     finally:
         drs.extract_features = real_extract
-    # The 5000-line diff is riskier than a 500-line diff but not 10x as
-    # contributing — the lines contribution is capped + overflow-weighted.
-    huge_contrib = huge.factors["lines_changed"]
-    cap_contrib = at_cap.factors["lines_changed"]
-    assert huge_contrib > cap_contrib
-    # Without the cap, 5000 lines × 0.004 = 20.0. With cap=500 + overflow:
-    # 500 × 0.004 + 4500 × 0.001 = 2.0 + 4.5 = 6.5.
-    assert huge_contrib < 10.0
+    # Monotonic: more lines → higher contribution
+    assert huge.factors["lines_changed"] > typical.factors["lines_changed"]
+    # Bounded for typical scaffolds: 1000 lines × 0.0005 = 0.5 — well below
+    # the categorical weights (_W_CRITICAL=1.5, _W_UNTESTED=1.7) which
+    # should dominate when they fire.
+    assert typical.factors["lines_changed"] < drs._W_CRITICAL
+    assert typical.factors["lines_changed"] < drs._W_UNTESTED
+    # The 5000-line outlier IS allowed to weigh in heavily — but only after
+    # the linear scaling carries it there (not via a discontinuous cap+overflow).
+    assert huge.factors["lines_changed"] == 5 * typical.factors["lines_changed"]
 
 
 def test_branch_vs_base_mode_detects_untested_surface():


### PR DESCRIPTION
## Summary

The v1.6.0 Diff Risk Score weights over-routed Outrider scaffolds to the high band. Cross-portfolio re-scoring showed every typical scaffold (9-12 files, 500-1000 lines for module + tests + wiring + docs) crossed the high threshold by feature accumulation alone — before the categorical risk signals even weighed in. The gate's actual job is "draft PR for review vs RFC Issue for discussion," not "is this diff risky" — Outrider never auto-merges, so the bar for downgrade-to-Issue should be high.

## Changes

- `_W_FILES` 0.18 → 0.02 (9× less)
- `_W_LINES` 0.004 → 0.0005 (8× less); `_LINES_CAP` and `_W_LINES_OVERFLOW` removed
- `_W_NEW_CALLABLES` 0.10 → 0.05 (half)
- `_W_INTERCEPT` -2.0 → -2.5; `_W_CRITICAL` 1.6 → 1.5; `_W_UNTESTED` 1.1 → 1.7 (raised since Outrider almost always adds tests)
- Thresholds (`DIFF_RISK_ELEVATED_THRESHOLD = 0.50`, `DIFF_RISK_ISSUE_THRESHOLD = 0.80`) unchanged

The size of an Outrider scaffold IS its expected output shape; the categorical signals (`critical_file_touched`, `untested_new_surface`) now carry the routing decisions.

## Re-scored calibration baseline

`docs/diff_risk_calibration_runs.md` shows the existing 6-row baseline under both weight sets. Distribution shifts from **2 high / 3 elevated / 1 low** (v1.6.0) to **0 high / 1 elevated / 5 low** (v1.7.0).

## Test plan

- [x] `python3 -m pytest tests/ -q` — 459 passed
- [x] `test_lines_changed_contribution_scales_modestly` (renamed from `test_lines_changed_contribution_is_capped`) asserts linear bounded scaling without dominating categorical weights
- [x] `test_large_untested_critical_change_is_high_risk` still produces a high band under new weights
- [x] `test_small_tested_wiring_pr_is_low_risk` still produces a low band
- [ ] After merge: validate band distribution against fresh runs across a portfolio of fork targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)