### PR TITLE
Diff Risk Score: align version references with v1.6.1 release

### DIFF
--- a/docs/diff_risk_calibration_runs.md
+++ b/docs/diff_risk_calibration_runs.md
@@ -2,7 +2,7 @@
 
 Each row is a `remyx-recommendation/*` branch scored against its merge-base with `origin/main`. Sorted by score descending so disputed-band candidates surface first.
 
-## v1.7.0 weights (current)
+## v1.6.1 weights (current)
 
 Recalibrated 2026-06-16 after a cross-portfolio re-scoring exercise across ~20 fork targets showed v1.6.0 over-routing to the high band. The gate triages "draft PR for review vs RFC Issue for discussion" — not "is this diff risky" — so the bar for downgrade-to-Issue is now much higher. The size of an Outrider scaffold (9-12 files, 500-1000 lines, module + tests + wiring + docs) is the expected output shape, not a risk signal; categorical signals (`critical_file_touched`, `untested_new_surface`) carry the routing decisions.
 
@@ -17,7 +17,7 @@ Recalibrated 2026-06-16 after a cross-portfolio re-scoring exercise across ~20 f
 
 Distribution: **1 elevated / 5 low / 0 high**.
 
-† Two Outrider runs of the **same** recommendation (arxiv 2606.06460v1, "Will the Agent Recuse Itself?") on the same target. Under v1.6.0 weights they routed to different bands (one high, one elevated) because the scaffolds differed in size (1013 LOC across 9 files vs 360 LOC across 3 files); under v1.7.0 they both land in `low`. The size variance no longer changes the routing — both are draft PRs for human review, which matches the gate's actual job. Run-to-run variance is the gate's blind spot today; tightening it is future work.
+† Two Outrider runs of the **same** recommendation (arxiv 2606.06460v1, "Will the Agent Recuse Itself?") on the same target. Under v1.6.0 weights they routed to different bands (one high, one elevated) because the scaffolds differed in size (1013 LOC across 9 files vs 360 LOC across 3 files); under v1.6.1 they both land in `low`. The size variance no longer changes the routing — both are draft PRs for human review, which matches the gate's actual job. Run-to-run variance is the gate's blind spot today; tightening it is future work.
 
 ## v1.6.0 weights (historical — pre-recalibration)
 
@@ -34,9 +34,9 @@ The original v1.6.0 scores are preserved here for reference. The recalibration w
 
 v1.6.0 distribution: **2 high / 3 elevated / 1 low**.
 
-## Weight changes (v1.6.0 → v1.7.0)
+## Weight changes (v1.6.0 → v1.6.1)
 
-| Weight | v1.6.0 | v1.7.0 | Change |
+| Weight | v1.6.0 | v1.6.1 | Change |
 |---|---:|---:|---|
 | `_W_INTERCEPT` | -2.0 | -2.5 | Lower baseline |
 | `_W_FILES` | 0.18 | 0.02 | 9× less |

--- a/src/diff_risk_score.py
+++ b/src/diff_risk_score.py
@@ -62,19 +62,22 @@ CRITICAL_PATH_HINTS = (
 
 # ── Logistic feature weights ───────────────────────────────────────────────
 #
-# Recalibrated 2026-06-16 from REMYX-101 sprint-1 data: 9 of 11 artifact-
-# producing runs (82%) routed to high-band Issue under the original weights,
-# net zero PRs. The gate triages "draft PR for review vs RFC Issue for
-# discussion", NOT "is this diff risky" — Outrider never auto-merges, so
-# downgrade-to-Issue is reserved for cases the maintainer needs to discuss
-# before reviewing a diff, not "the diff is big." Size of an Outrider
-# scaffold (9-12 files, 500-1000 lines) IS the expected output shape, not
-# a risk signal.
+# Recalibrated 2026-06-16 from a cross-portfolio re-scoring exercise that
+# showed the prior weights mechanically over-routed to high band: every
+# typical Outrider scaffold (9-12 files, 500-1000 lines for module + tests
+# + wiring + docs) crossed the high threshold by feature accumulation
+# alone, before the categorical risk signals weighed in.
+#
+# The gate triages "draft PR for review vs RFC Issue for discussion",
+# NOT "is this diff risky" — Outrider never auto-merges, so downgrade-
+# to-Issue is reserved for cases the maintainer needs to discuss before
+# reviewing a diff, not "the diff is big." The size of an Outrider
+# scaffold IS its expected output shape, not a risk signal.
 #
 # Categorical signals (critical-path edit, untested new surface) remain
 # the dominant risk drivers. The previous _LINES_CAP / _W_LINES_OVERFLOW
-# pair is removed since the linear weight is now small enough not to need
-# cap behaviour.
+# pair is removed since the linear weight is now small enough not to
+# need cap behaviour.
 _W_INTERCEPT = -2.5
 _W_FILES = 0.02          # per file touched
 _W_LINES = 0.0005        # per added+deleted line (linear, no cap)

--- a/tests/test_diff_risk_score.py
+++ b/tests/test_diff_risk_score.py
@@ -196,7 +196,7 @@ def test_test_functions_excluded_from_new_callables():
 
 def test_lines_changed_contribution_scales_modestly():
     """A typical Outrider scaffold (~1000 lines) shouldn't have a lines
-    contribution that dominates the categorical risk signals. The v1.7.0
+    contribution that dominates the categorical risk signals. The v1.6.1
     recalibration cut `_W_LINES` 8× (from 0.004 to 0.0005) precisely so
     size-of-diff stays well below the categorical weights for the diff
     sizes Outrider actually produces."""


### PR DESCRIPTION
## Summary

The recalibration in #40 was authored as v1.7.0 but is shipping as **v1.6.1** since the public API surface and band-routing semantics are unchanged — only the calibration weight values move. Rename `v1.7.0` → `v1.6.1` in source comments, the calibration doc heading, and a test docstring.

Also scrubs a remaining internal-tracker reference and specific eval percentages from the `src/diff_risk_score.py` weights docstring that shouldn't have shipped on a public-OSS PR.

## Test plan

- [x] `python3 -m pytest tests/test_diff_risk_score.py -q` — 9 passed
- [x] `grep -rn 'v1\.7\.0' src/ docs/ tests/` returns no matches