### PR TITLE
step_summary: surface Anthropic credit/auth/rate-limit failures with action guidance

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -145,6 +145,13 @@ BUNDLE_DIR_NAME = ".remyx-recommendation"
 BRANCH_PREFIX = "remyx-recommendation/"
 PR_TITLE_PREFIX = "[Remyx Recommendation]"
 
+# Vendor-console URLs surfaced in step_summary when the agent fails with a
+# recognizable cause. Currently Anthropic-only; when alternative agent CLIs
+# land, these become a per-agent lookup (`_AGENT_URLS = {"claude": ...,
+# "aider": ...}`) keyed by the agent type recorded in the result dict.
+_ANTHROPIC_BILLING_URL = "https://console.anthropic.com/settings/billing"
+_ANTHROPIC_KEYS_URL = "https://console.anthropic.com/settings/keys"
+
 # Files that are NEVER allowed to be touched. Blocked by ROLE (filename /
 # type), not by directory, so the policy doesn't encode any one repo's
 # layout: a Dockerfile is off-limits whether it sits at the root, under
@@ -7775,6 +7782,62 @@ def run_weekly_summary(target: Target) -> dict:
     return result
 
 
+def _agent_failure_blocks(agent: str, log_tail: str, claude_calls: int) -> list[str]:
+    """Render a list of step_summary markdown lines for a ``claude_failed``
+    status, dispatching on the agent's log tail.
+
+    Currently agent-specific to Claude Code (Anthropic). When alternative
+    agent CLIs land (Aider, Goose, Copilot, Codex), this helper grows a
+    per-agent patterns + URLs lookup keyed on ``agent`` — the call site
+    in ``_write_step_summary`` doesn't change.
+    """
+    tail = (log_tail or "").lower()
+    lines: list[str] = []
+    if "credit balance is too low" in tail:
+        lines.append("\n> ### 🪙 Action required: Anthropic credit balance exhausted\n>")
+        lines.append(
+            f"> All {claude_calls} Claude calls this run failed with "
+            "\"Credit balance is too low\"."
+        )
+        lines.append(
+            "> The `ANTHROPIC_API_KEY` secret authenticated — the account "
+            "just has no remaining credits."
+        )
+        lines.append(">")
+        lines.append(f"> **Top up at:** {_ANTHROPIC_BILLING_URL}")
+        lines.append(">")
+        lines.append(
+            "> The next scheduled run will retry automatically once "
+            "credits are available.\n"
+        )
+    elif "401" in tail and (
+        "authentication" in tail
+        or "invalid api key" in tail
+        or "invalid x-api-key" in tail
+    ):
+        lines.append("\n> ### 🔑 Action required: ANTHROPIC_API_KEY secret invalid\n>")
+        lines.append(
+            "> The key configured as the `ANTHROPIC_API_KEY` repo secret "
+            "didn't authenticate."
+        )
+        lines.append(
+            f"> Check the key at {_ANTHROPIC_KEYS_URL} and update the "
+            "secret via"
+        )
+        lines.append("> `gh secret set ANTHROPIC_API_KEY --repo <this-repo>`.\n")
+    elif "429" in tail or "rate_limit" in tail or "too many requests" in tail:
+        lines.append("\n> ### ⏱️ Rate limited — no action needed\n>")
+        lines.append(
+            "> The Anthropic API rate-limited this run. The next "
+            "scheduled run will retry.\n"
+        )
+    elif tail:
+        lines.append("\n<details><summary>Claude agent failure tail</summary>\n")
+        lines.append(f"\n```\n{log_tail[:1500]}\n```\n")
+        lines.append("\n</details>\n")
+    return lines
+
+
 def _write_step_summary(result: dict) -> None:
     """Render the run outcome as Markdown into $GITHUB_STEP_SUMMARY.
 
@@ -7985,6 +8048,13 @@ def _write_step_summary(result: dict) -> None:
         if len(rejected) > 10:
             lines.append(f"- _…and {len(rejected) - 10} more_")
         lines.append("\n</details>\n")
+
+    if status == "claude_failed":
+        lines.extend(_agent_failure_blocks(
+            agent="claude",
+            log_tail=result.get("claude_log_tail") or "",
+            claude_calls=claude_calls,
+        ))
 
     if err:
         lines.append("\n**Error**\n")

--- a/tests/test_step_summary_selection_reasoning.py
+++ b/tests/test_step_summary_selection_reasoning.py
@@ -146,3 +146,64 @@ def test_renders_above_cost_line(tmp_path, monkeypatch):
         "cost_usd": 1.23,
     }, tmp_path, monkeypatch)
     assert out.index("Why this selection") < out.index("Cost & tokens")
+
+
+# ── claude_failed rendering (REMYX-106) ────────────────────────────────────
+
+
+def test_step_summary_credit_balance_renders_topup_section(tmp_path, monkeypatch):
+    out = _capture({
+        "status": "claude_failed",
+        "claude_log_tail": "ERROR: Credit balance is too low to make request",
+        "claude_calls": 4,
+    }, tmp_path, monkeypatch)
+    assert "Anthropic credit balance exhausted" in out
+    assert "console.anthropic.com/settings/billing" in out
+    assert "4 Claude calls" in out
+
+
+def test_step_summary_invalid_key_renders_secret_section(tmp_path, monkeypatch):
+    out = _capture({
+        "status": "claude_failed",
+        "claude_log_tail": "401 Authentication error: invalid x-api-key",
+    }, tmp_path, monkeypatch)
+    assert "ANTHROPIC_API_KEY secret invalid" in out
+    assert "console.anthropic.com/settings/keys" in out
+    assert "gh secret set ANTHROPIC_API_KEY" in out
+
+
+def test_step_summary_rate_limit_renders_no_action_section(tmp_path, monkeypatch):
+    out = _capture({
+        "status": "claude_failed",
+        "claude_log_tail": "HTTP 429 Too Many Requests rate_limit_error",
+    }, tmp_path, monkeypatch)
+    assert "Rate limited" in out
+    assert "no action needed" in out
+    assert "next scheduled run will retry" in out
+
+
+def test_step_summary_unknown_failure_renders_tail(tmp_path, monkeypatch):
+    out = _capture({
+        "status": "claude_failed",
+        "claude_log_tail": "Unexpected error: model returned malformed json",
+    }, tmp_path, monkeypatch)
+    # Generic failures fall through to a collapsed details block with the tail.
+    assert "Claude agent failure tail" in out
+    assert "malformed json" in out
+    # Specific-action sections should NOT fire.
+    assert "Anthropic credit balance" not in out
+    assert "ANTHROPIC_API_KEY secret invalid" not in out
+
+
+def test_step_summary_succeeds_when_claude_log_tail_missing(tmp_path, monkeypatch):
+    # claude_failed without a log tail shouldn't crash; just no extra block.
+    out = _capture({
+        "status": "claude_failed",
+        "claude_calls": 0,
+    }, tmp_path, monkeypatch)
+    # Headline still renders even without the tail-derived action block.
+    assert "claude_failed" in out
+    # No specific-action section fires when there's no tail content.
+    assert "Anthropic credit balance" not in out
+    assert "ANTHROPIC_API_KEY secret invalid" not in out
+    assert "Claude agent failure tail" not in out


### PR DESCRIPTION
## Summary

When the agent fails due to an Anthropic API issue (credit-balance exhausted, invalid key, rate-limit), the step_summary previously rendered an opaque `claude_failed` headline. The cause was captured in `result["claude_log_tail"]` but never read — operators had to dig through Actions logs.

This patch reads `claude_log_tail` and renders a structured action-required block matching the detected failure mode:

| Pattern | Rendered block |
|---|---|
| `Credit balance is too low` | Anthropic top-up link + auto-retry note |
| `401` + auth-related substring | `ANTHROPIC_API_KEY secret invalid` + `gh secret set` guidance |
| `429` / `rate_limit` / `too many requests` | "rate limited — no action needed" + retry note |
| (anything else with a tail) | Collapsed `<details>` block with the tail snippet |

## Agent-aware design

Rendering lives behind an `_agent_failure_blocks(agent, log_tail, claude_calls)` helper that currently hardcodes `agent="claude"`. The call site in `_write_step_summary` passes the agent explicitly, so when alternative agent CLIs land later, the helper grows a per-agent patterns + URLs lookup instead of needing a rewrite. Anthropic console URLs live as module-level constants positioned to expand into a per-agent URL table.

## Surface

- **Additive only** — no public API change, status codes unchanged, no behavior change on non-`claude_failed` runs
- ~70 LOC src (helper + constants + call-site wiring)
- ~80 LOC tests (5 new cases)

## Test plan

- [x] `python3 -m pytest tests/test_step_summary_selection_reasoning.py -v` — 14 passed (9 existing + 5 new)
- [x] `python3 -m pytest tests/ -q` — 464 passed (was 459)
- [ ] After merge: trigger an Outrider run with an exhausted-credit key on a test repo and verify the step_summary panel shows the top-up link

Ships as v1.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)