### PR TITLE
Handle Issues-disabled-on-forks gracefully + README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Scouts the arXiv frontier for your repo and picks the next paper most implementa
 - **RFC-shape Issues** when the team has signaled openness to a new capability (a README roadmap section, an open `[RFC]` Issue, a CONTEXT.md investment pattern) and a candidate fits as an extension — a clear proposal instead of speculation
 - **No duplicate work** — the same paper isn't re-recommended once any Outrider or maintainer Issue references it; reopen the Issue to re-engage
 - **A selection narrative** in the run's GitHub Actions step summary explaining why this paper (or why nothing actionable this run) — visible at a glance, not buried in logs
+- **Actionable failure guidance**, not opaque errors — when the agent fails on a recognizable cause (Anthropic credit-balance exhausted, invalid API key, rate-limit), the step-summary panel renders the specific remediation (top-up link, key-setup hint, retry note) instead of a buried log line
 - **No stacking unresolved work** by default — a new run skips while a prior Remyx PR or Issue is still open; engagement (merge or close) releases the gate
 
 ## Setup
@@ -129,8 +130,10 @@ With the default cadence guard (gate enabled), expect ~$2–4/mo Claude at typic
 | `issue_opened_no_test_integration` | New tests don't import from any pre-existing module |
 | `issue_opened_self_review` | Self-review judged the new code an orphan, unreachable from production. Body preserves Claude's implementation diff so the maintainer can review or apply it manually |
 | `issue_opened_substitution` | Selection identified a replacement / pipeline-simplification / extension candidate (vs. additive drop-in); routed to Issue because the swap needs dep changes the PR guardrails block, or there's no existing call site to anchor against |
+| `issue_opened_high_risk` | Diff Risk Score gate routed to a human-review Issue instead of a PR (implementation diff preserved in the Issue body). See [Diff Risk Score](#diff-risk-score--adapted-from-automating-low-risk-code-review-at-meta-radar-risk-calibration-and-review-efficiency) |
 | `skipped_low_confidence` | Recommendation below `min-confidence` |
 | `skipped_open_artifact` | An open Remyx PR or Issue from a prior run still exists on the target — engagement (merge or close) releases the gate |
+| `skipped_issues_disabled` | The target repo has its Issues tab disabled (default on forks) and the scoped App token can't re-enable it. Enable with `gh repo edit <repo> --enable-issues` and the next run proceeds |
 | `skipped_pr_exists` | Every candidate already has an open PR |
 | `skipped_issue_exists` | Every candidate already has a prior Issue referencing the arxiv id — Outrider-opened OR maintainer-opened, open OR closed. Step summary differentiates "Already in flight" (open) vs "Already addressed" (closed). Reopen the Issue to re-engage |
 | `skipped_external_issue_exists` | Selection pass surfaced an out-of-pool candidate but it's already in the team's attention — same Outrider/Maintainer × open/closed differentiation as above |
@@ -252,7 +255,11 @@ Setup:
 
 1. **Enable Discussions** on your repo if it isn't already on:
    *Settings → General → Features → ☑ Discussions*. (Repos — forks
-   especially — have Discussions off by default.)
+   especially — have Discussions off by default; the same is true for
+   the Issues tab, which Outrider needs for Issue-route recommendations.
+   When Issues are disabled the run exits cleanly with
+   `skipped_issues_disabled` and a hint to run `gh repo edit <repo>
+   --enable-issues`.)
 2. **Create (or pick) a Discussion** on your repo to host the digests, and
    note its number from the URL.
 3. **Add a second scheduled job** (weekly cron) that calls the action in

--- a/action.yml
+++ b/action.yml
@@ -138,7 +138,8 @@ outputs:
   status:
     description: |
       Run outcome: "pr_opened" | "pr_opened_draft" | "issue_opened" |
-      "skipped_low_confidence" | "skipped_open_artifact" | "skipped_pr_exists" |
+      "skipped_low_confidence" | "skipped_open_artifact" |
+      "skipped_issues_disabled" | "skipped_pr_exists" |
       "skipped_issue_exists" | "skipped_test_failure" | "claude_failed" |
       "rejected_path_violations" | "error". In weekly-summary mode:
       "weekly_summary_posted" | "weekly_summary_skipped_no_discussion_id" |

--- a/src/run.py
+++ b/src/run.py
@@ -5036,9 +5036,24 @@ def open_issue(
         # disabled". Enable it and retry once rather than failing the run.
         msg = str(e)
         if "Issues has been disabled" in msg or "HTTP 410" in msg:
-            log.warning("  Issues disabled on repo; enabling and retrying")
-            gh_api("PATCH", f"/repos/{target.repo}", {"has_issues": True})
-            issue = gh_api("POST", f"/repos/{target.repo}/issues", payload)
+            log.warning("  Issues disabled on repo; attempting to enable")
+            try:
+                gh_api("PATCH", f"/repos/{target.repo}", {"has_issues": True})
+                issue = gh_api("POST", f"/repos/{target.repo}/issues", payload)
+            except RuntimeError as patch_err:
+                # PATCH /repos requires `administration: write`, which the
+                # scoped App installation token doesn't carry. Raise the
+                # documented graceful-skip exception so process_target can
+                # convert it to a `skipped_issues_disabled` status instead
+                # of a generic error.
+                if "403" in str(patch_err) or "Resource not accessible" in str(patch_err):
+                    raise IssuesDisabledError(
+                        f"Issues tab disabled on {target.repo} and the bot's "
+                        f"installation token lacks admin scope to enable it. "
+                        f"Enable Issues manually: "
+                        f"`gh repo edit {target.repo} --enable-issues`."
+                    ) from patch_err
+                raise
         else:
             raise
     return issue["html_url"]
@@ -5605,6 +5620,27 @@ def process_target(target: Target) -> dict:
     #    dedup (further down) handles same-recommendation retries.
     if open_remyx_artifact_exists(target):
         result["status"] = "skipped_open_artifact"
+        return result
+
+    # 1b. Issues-disabled pre-flight — GitHub disables the Issues tab on
+    #     forks (and some repos) by default; without it, every Issue-route
+    #     artifact this run might emit (high-risk downgrade, no-integration,
+    #     stub-density, self-review, substitution, preflight, OPEN_AS_ISSUE)
+    #     fails at the POST /issues step. The scoped App token can't
+    #     re-enable Issues (PATCH /repos requires `administration: write`,
+    #     not granted), so a single GET here saves a full selection +
+    #     scaffold pass that would be wasted at the Issue step. The race
+    #     where Issues get disabled mid-run is caught by IssuesDisabledError
+    #     below (see open_issue + the except handler before the finally).
+    try:
+        repo_meta = gh_api("GET", f"/repos/{target.repo}")
+    except RuntimeError as e:
+        log.warning(f"  repo metadata fetch failed ({e}); assuming Issues enabled")
+        repo_meta = {"has_issues": True}
+    if not repo_meta.get("has_issues", True):
+        log.info(f"  Issues disabled on {target.repo}; skipping. "
+                 f"Enable: gh repo edit {target.repo} --enable-issues")
+        result["status"] = "skipped_issues_disabled"
         return result
 
     # 2. Query the candidate pool over the lookback window (default: the
@@ -6373,6 +6409,18 @@ def process_target(target: Target) -> dict:
         result["status"] = "pr_opened_draft" if draft else "pr_opened"
         result["pr_url"] = pr_url
         log.info(f"  ✓ {result['status']}: {pr_url}")
+        return result
+
+    except IssuesDisabledError as e:
+        # Race: Issues were enabled at the pre-flight check but got disabled
+        # mid-run, so open_issue's PATCH-to-enable hit 403. Catch here so
+        # the run ends with a graceful skipped_issues_disabled status
+        # instead of a generic error — selection-pass + scaffold work is
+        # already done; surfacing the actionable hint is the best we can
+        # do for this rare path.
+        log.warning(f"  ↪ Issues became disabled mid-run: {e}")
+        result["status"] = "skipped_issues_disabled"
+        result["error"] = str(e)
         return result
 
     finally:
@@ -7890,6 +7938,7 @@ def _write_step_summary(result: dict) -> None:
         "issue_opened_self_review":        "🟡",
         "skipped_low_confidence":  "⏭️",
         "skipped_open_artifact":   "⏭️",
+        "skipped_issues_disabled": "⏭️",
         "skipped_pr_exists":       "⏭️",
         "skipped_issue_exists":    "⏭️",
         "skipped_external_issue_exists": "⏭️",

--- a/tests/test_issues_disabled.py
+++ b/tests/test_issues_disabled.py
@@ -1,0 +1,178 @@
+"""Tests for the IssuesDisabledError graceful-skip path.
+
+GitHub disables the Issues tab on forks (and some repos) by default.
+Outrider's ``open_issue`` tries to auto-enable it via PATCH /repos, but
+the scoped App installation token deliberately lacks
+``administration: write`` — the PATCH returns 403, and the run errored
+out generically before this change.
+
+The fix:
+
+* ``open_issue`` catches the PATCH 403 and raises ``IssuesDisabledError``
+  (the class was defined at ``src/run.py:947`` for this case but never
+  raised or caught).
+* ``process_target`` pre-flights ``has_issues`` before doing any LLM
+  work, so the common case (forks with Issues disabled from creation)
+  short-circuits with status ``skipped_issues_disabled`` before any
+  selection or scaffold cost is incurred.
+* ``process_target`` also catches ``IssuesDisabledError`` defensively in
+  case Issues get disabled mid-run after the pre-flight passed.
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import pytest  # noqa: E402
+
+import run  # noqa: E402
+from run import IssuesDisabledError, Target  # noqa: E402
+
+
+def _target() -> Target:
+    return Target(
+        repo="owner/repo",
+        interest_id="iid",
+        min_confidence="moderate",
+        draft_mode="always",
+        rate_limit_days=7,
+    )
+
+
+# ─── open_issue: happy path + 410-recovery + 403-graceful ──────────────────
+
+
+def test_open_issue_succeeds_when_post_works(monkeypatch):
+    """Normal case: POST /issues returns a usable issue dict; no retry."""
+    calls = []
+
+    def fake_gh_api(method, path, body=None):
+        calls.append((method, path))
+        if method == "POST" and "/issues" in path:
+            return {"html_url": "https://github.com/owner/repo/issues/42"}
+        raise AssertionError(f"unexpected call: {method} {path}")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    url = run.open_issue(_target(), "title", "body")
+    assert url == "https://github.com/owner/repo/issues/42"
+    assert calls == [("POST", "/repos/owner/repo/issues")]
+
+
+def test_open_issue_retries_after_410_when_patch_succeeds(monkeypatch):
+    """410 on POST → PATCH to enable → retry POST. The pre-existing
+    recovery path; assertion is that the PATCH-then-retry still works
+    when the bot's token DOES have admin scope (e.g. customer ran with
+    a PAT instead of the default App token)."""
+    call_log = []
+
+    def fake_gh_api(method, path, body=None):
+        call_log.append((method, path))
+        if method == "POST" and "/issues" in path and len(call_log) == 1:
+            raise RuntimeError("HTTP 410: Issues has been disabled in this repository")
+        if method == "PATCH" and path == "/repos/owner/repo":
+            return {"has_issues": True}
+        if method == "POST" and "/issues" in path and len(call_log) >= 3:
+            return {"html_url": "https://github.com/owner/repo/issues/7"}
+        raise AssertionError(f"unexpected call sequence: {call_log}")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    url = run.open_issue(_target(), "title", "body")
+    assert url == "https://github.com/owner/repo/issues/7"
+    # Three calls: POST (410) → PATCH (success) → POST (success)
+    assert len(call_log) == 3
+    assert call_log[1] == ("PATCH", "/repos/owner/repo")
+
+
+def test_open_issue_raises_issues_disabled_error_on_patch_403(monkeypatch):
+    """The fork-default case: POST 410 → PATCH 403 → IssuesDisabledError.
+    Replaces the previous generic-RuntimeError path that produced
+    status=error and a wasted selection + scaffold run."""
+
+    def fake_gh_api(method, path, body=None):
+        if method == "POST" and "/issues" in path:
+            raise RuntimeError("HTTP 410: Issues has been disabled in this repository")
+        if method == "PATCH" and path == "/repos/owner/repo":
+            raise RuntimeError(
+                "HTTP 403: Resource not accessible by integration"
+            )
+        raise AssertionError(f"unexpected call: {method} {path}")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    with pytest.raises(IssuesDisabledError) as excinfo:
+        run.open_issue(_target(), "title", "body")
+    # Surface the actionable hint so the operator can self-resolve.
+    msg = str(excinfo.value)
+    assert "owner/repo" in msg
+    assert "gh repo edit owner/repo --enable-issues" in msg
+
+
+def test_open_issue_propagates_non_403_patch_errors(monkeypatch):
+    """If the PATCH fails for a NON-403 reason (e.g. 500), the generic
+    RuntimeError still propagates — we only graceful-skip the 403
+    permission case, not arbitrary API failures."""
+
+    def fake_gh_api(method, path, body=None):
+        if method == "POST" and "/issues" in path:
+            raise RuntimeError("HTTP 410: Issues has been disabled")
+        if method == "PATCH":
+            raise RuntimeError("HTTP 500: Internal Server Error")
+        raise AssertionError(f"unexpected call: {method} {path}")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    # NOT IssuesDisabledError — should propagate as plain RuntimeError.
+    with pytest.raises(RuntimeError) as excinfo:
+        run.open_issue(_target(), "title", "body")
+    assert not isinstance(excinfo.value, IssuesDisabledError)
+    assert "HTTP 500" in str(excinfo.value)
+
+
+def test_open_issue_propagates_non_410_post_errors(monkeypatch):
+    """If the initial POST fails for a NON-410 reason (e.g. 422
+    validation), the generic RuntimeError propagates without attempting
+    the PATCH-and-retry recovery path."""
+
+    def fake_gh_api(method, path, body=None):
+        if method == "POST":
+            raise RuntimeError("HTTP 422: Validation failed")
+        raise AssertionError("PATCH shouldn't fire on non-410 errors")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    with pytest.raises(RuntimeError) as excinfo:
+        run.open_issue(_target(), "title", "body")
+    assert "HTTP 422" in str(excinfo.value)
+
+
+# ─── IssuesDisabledError type contract ─────────────────────────────────────
+
+
+def test_issues_disabled_error_inherits_from_runtime_error():
+    """Callers that broadly catch RuntimeError still see the exception
+    (back-compat for any catch-all error handler), but the new typed
+    name lets process_target route it to skipped_issues_disabled
+    specifically."""
+    err = IssuesDisabledError("test")
+    assert isinstance(err, RuntimeError)
+    assert isinstance(err, IssuesDisabledError)
+
+
+def test_issues_disabled_error_carries_chained_patch_error(monkeypatch):
+    """`raise ... from patch_err` preserves the underlying PATCH error
+    for debugging; the __cause__ chain shouldn't be lost."""
+
+    def fake_gh_api(method, path, body=None):
+        if method == "POST":
+            raise RuntimeError("HTTP 410: Issues has been disabled")
+        if method == "PATCH":
+            raise RuntimeError("HTTP 403: Resource not accessible by integration")
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    try:
+        run.open_issue(_target(), "title", "body")
+    except IssuesDisabledError as e:
+        assert e.__cause__ is not None
+        assert "HTTP 403" in str(e.__cause__)
+        return
+    raise AssertionError("expected IssuesDisabledError")


### PR DESCRIPTION
## Summary

Forks inherit `has_issues=false` by default. Outrider's `open_issue` tried to auto-enable Issues via `PATCH /repos`, but the scoped App installation token deliberately lacks `administration: write` — the PATCH 403'd and the run errored generically. The `IssuesDisabledError` class was already defined at `src/run.py:947` for exactly this case but never raised or caught.

This PR wires the graceful-skip path + bundles three small README touches.

## Changes

**Code (src/run.py)**

- `process_target` gains an Issues-enabled pre-flight right after the cadence guard. When `has_issues` is `false`, the run exits cleanly with status `skipped_issues_disabled` — no selection or scaffold cost incurred. Hint message points at `gh repo edit <repo> --enable-issues`.
- `open_issue` catches the PATCH 403 inside the existing 410-recovery block and raises `IssuesDisabledError`. The error message carries the actionable hint and `raise ... from` preserves the underlying PATCH error.
- `process_target` adds an `except IssuesDisabledError` before the existing `finally` block, routing the race condition (Issues disabled between pre-flight and the in-flight Issue emit) to the same `skipped_issues_disabled` status. Pre-flight catches the common case; this catch is defense-in-depth.

**Plumbing**

- `action.yml` outputs enum includes `skipped_issues_disabled`
- `_write_step_summary` emoji map: `skipped_issues_disabled` → `⏭️`

**README (3 small touches, bundled to ship with the fix)**

- Status codes table adds `issue_opened_high_risk` (the row was missing despite the Diff Risk Score section referencing the status by name) and `skipped_issues_disabled`.
- *What you get* list mentions the v1.6.2 step_summary failure-mode surfacing (credit-balance / auth / rate-limit blocks).
- Weekly Discussion section's "forks have Discussions off by default" parenthetical extended to call out the same default for Issues + the new graceful skip behavior.

## Test plan

- [x] `python3 -m pytest tests/test_issues_disabled.py -v` — 7 new tests pass:
  - happy path
  - existing 410-recovery still works when PATCH succeeds
  - new graceful path: 410 → 403 → `IssuesDisabledError` with hint
  - non-403 PATCH errors still propagate as `RuntimeError`
  - non-410 POST errors propagate without attempting recovery
  - type contract: `IssuesDisabledError` is a `RuntimeError` subclass
  - `__cause__` chain preserved via `raise ... from`
- [x] `python3 -m pytest tests/ -q` — 471 passed (was 464 prior, +7 new)
- [ ] After merge: trigger Outrider on a fresh fork with Issues disabled; verify the run exits with `skipped_issues_disabled` status and the step_summary panel shows the actionable hint instead of a traceback

Ships as v1.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)