### PR TITLE
Add outbound-body secret scanner at the gh_api boundary

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -1178,8 +1178,104 @@ def _github_token() -> str:
     return os.environ.get("GITHUB_TOKEN", "").strip()
 
 
+# Defense-in-depth: refuse to send any GitHub API body whose string
+# fields contain content matching known credential shapes (Anthropic
+# API keys, GitHub PAT/App/OAuth tokens, Remyx API keys, JWTs, Bearer
+# headers, env-var-style leaks). Outbound PR/Issue/Discussion bodies
+# get assembled from many upstream paths — agent self-review, test
+# stdout, pre-flight reasoning, file-fallback content — and a
+# regression in any of them could otherwise leak a secret into a
+# public repo via the GitHub API. Catching it at the API boundary is
+# the one place that covers every upstream variant.
+#
+# Fails closed: raises ``OutboundSecretError`` rather than scrubbing
+# in-place, because partial redaction risks letting variant token
+# shapes through. The exception message reports the JSON path and a
+# pattern identifier — never the matched secret itself.
+_OUTBOUND_SECRET_PATTERNS: tuple[tuple[str, re.Pattern], ...] = (
+    ("anthropic_api_key", re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}")),
+    ("github_token", re.compile(r"\bgh[psoaru]_[A-Za-z0-9]{20,}\b")),
+    ("github_pat", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b")),
+    ("remyx_api_key", re.compile(r"\brmxu_[A-Za-z0-9_-]{20,}\b")),
+    (
+        "jwt",
+        re.compile(
+            r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"
+        ),
+    ),
+    (
+        "authorization_header",
+        re.compile(r"(?i)Authorization\s*:\s*Bearer\s+[A-Za-z0-9_.-]{16,}"),
+    ),
+    ("bearer_token", re.compile(r"(?i)\bBearer\s+[A-Za-z0-9_.-]{32,}")),
+    (
+        "env_var_leak",
+        re.compile(
+            r"\b(?:ANTHROPIC_API_KEY|REMYX_API_KEY|GITHUB_TOKEN|"
+            r"INPUT_GITHUB_TOKEN)\s*=\s*[A-Za-z0-9_.-]{16,}"
+        ),
+    ),
+)
+
+
+class OutboundSecretError(RuntimeError):
+    """A GitHub API call was refused because the request payload
+    matched credential patterns. Investigate the body-assembly path
+    (PR template, Issue body, GraphQL variables, comment text) before
+    retrying. The exception message includes only the JSON path and a
+    pattern identifier — never the actual matched secret."""
+
+
+def _scan_for_secrets(text: str) -> list[str]:
+    """Return pattern identifiers for any credential shapes found in
+    ``text``. Empty when clean. The actual matched secret is never
+    included in the return value, so a log message built from this
+    can't propagate the leaked credential further."""
+    if not text:
+        return []
+    hits: list[str] = []
+    for name, pat in _OUTBOUND_SECRET_PATTERNS:
+        if pat.search(text):
+            hits.append(name)
+    return hits
+
+
+def _scrub_outbound_payload(payload: Any, _path: str = "") -> None:
+    """Recursively scan ``payload`` for secret-shape strings and raise
+    ``OutboundSecretError`` if any are found. No-op for ``None``.
+
+    Used by ``gh_api`` and ``gh_graphql`` to refuse outbound requests
+    whose bodies contain content matching credential patterns. Fails
+    closed: the exception aborts the API call entirely rather than
+    silently redacting, so the operator must investigate the upstream
+    leak before the next request goes out."""
+    if payload is None:
+        return
+    if isinstance(payload, str):
+        hits = _scan_for_secrets(payload)
+        if hits:
+            raise OutboundSecretError(
+                f"Outbound payload field {_path!r} matched credential "
+                f"pattern(s) {hits}; refusing to send the API request. "
+                f"Investigate the body-assembly path before retrying — "
+                f"this is a leak-prevention abort, not a content issue."
+            )
+        return
+    if isinstance(payload, dict):
+        for k, v in payload.items():
+            child = f"{_path}.{k}" if _path else str(k)
+            _scrub_outbound_payload(v, child)
+        return
+    if isinstance(payload, list):
+        for i, v in enumerate(payload):
+            _scrub_outbound_payload(v, f"{_path}[{i}]")
+        return
+    # Numbers, bools, etc. pass through silently.
+
+
 def gh_api(method: str, path: str, body: dict | None = None) -> Any:
     """Minimal GitHub API wrapper."""
+    _scrub_outbound_payload(body)
     token = _github_token()
     if not token:
         raise RuntimeError(
@@ -1223,6 +1319,7 @@ def gh_graphql(
     token — used by the Discussion-post permission fallback. Returns the
     ``data`` object.
     """
+    _scrub_outbound_payload(variables)
     token = token or _github_token()
     if not token:
         raise RuntimeError(

--- a/tests/test_outbound_secret_scrubber.py
+++ b/tests/test_outbound_secret_scrubber.py
@@ -1,0 +1,224 @@
+"""Tests for the outbound secret-scrubber at the GitHub API boundary.
+
+The scrubber refuses to send any GitHub API body whose string fields
+match known credential shapes (Anthropic, GitHub, Remyx, JWTs, Bearer
+headers, env-var-style leaks). It's the one-place catch-all that
+covers leaks from every upstream body-assembly path — agent
+self-review, test stdout, pre-flight reasoning, file-fallback content
+— since each of those can in principle propagate untrusted content
+into a public-repo PR/Issue/Discussion body.
+
+The fix exists because PR bodies are assembled from many sources, and
+any individual upstream getting a regression could leak a credential
+into a public repo. Defense in depth at the boundary catches it
+regardless of which upstream path leaks.
+
+The exception message includes only the JSON path and a pattern
+identifier — never the actual matched secret, so log lines built from
+the exception don't propagate the credential further.
+
+Run with: pytest tests/test_outbound_secret_scrubber.py -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import pytest  # noqa: E402
+
+from run import (  # noqa: E402
+    OutboundSecretError,
+    _scan_for_secrets,
+    _scrub_outbound_payload,
+)
+
+
+# ─── Synthetic, non-credential strings shaped like real tokens ─────
+# Each value below matches the production token format precisely
+# enough for the regex to fire, but the payload bytes are uniform
+# letters so the strings themselves are obviously not real secrets
+# and never grant access anywhere.
+_SYNTH_SK_ANT = "sk-ant-api03-" + ("A" * 95)
+_SYNTH_GHP = "ghp_" + ("A" * 36)
+_SYNTH_GHS = "ghs_" + ("A" * 36)
+_SYNTH_GITHUB_PAT = "github_pat_" + ("A" * 30) + "_" + ("B" * 30)
+_SYNTH_RMXU = "rmxu_" + ("A" * 32)
+_SYNTH_JWT = "eyJ" + ("A" * 20) + "." + ("B" * 20) + "." + ("C" * 20)
+_SYNTH_BEARER = "Authorization: Bearer " + ("A" * 64)
+_SYNTH_GENERIC_BEARER = "Bearer " + ("A" * 64)
+_SYNTH_ENV_LEAK = "ANTHROPIC_API_KEY=" + ("X" * 64)
+
+
+# ─── _scan_for_secrets: per-pattern detection ─────────────────────
+
+
+def test_scan_detects_anthropic_key():
+    assert "anthropic_api_key" in _scan_for_secrets(f"key={_SYNTH_SK_ANT}")
+
+
+def test_scan_detects_github_personal_token():
+    assert "github_token" in _scan_for_secrets(_SYNTH_GHP)
+
+
+def test_scan_detects_github_app_token():
+    assert "github_token" in _scan_for_secrets(_SYNTH_GHS)
+
+
+def test_scan_detects_github_fine_grained_pat():
+    assert "github_pat" in _scan_for_secrets(_SYNTH_GITHUB_PAT)
+
+
+def test_scan_detects_remyx_api_key():
+    assert "remyx_api_key" in _scan_for_secrets(_SYNTH_RMXU)
+
+
+def test_scan_detects_jwt():
+    assert "jwt" in _scan_for_secrets(_SYNTH_JWT)
+
+
+def test_scan_detects_authorization_header():
+    assert "authorization_header" in _scan_for_secrets(_SYNTH_BEARER)
+
+
+def test_scan_detects_generic_bearer_token():
+    assert "bearer_token" in _scan_for_secrets(_SYNTH_GENERIC_BEARER)
+
+
+def test_scan_detects_env_var_leak():
+    assert "env_var_leak" in _scan_for_secrets(_SYNTH_ENV_LEAK)
+
+
+# ─── _scan_for_secrets: clean text + false-positive guards ────────
+
+
+def test_scan_clean_text_returns_empty():
+    assert _scan_for_secrets(
+        "This is a normal PR body about exploration structure in agents."
+    ) == []
+
+
+def test_scan_commit_sha_no_false_positive():
+    # Short hex SHAs in commit messages shouldn't trip the patterns.
+    assert _scan_for_secrets("commit abc1234def567890") == []
+
+
+def test_scan_arxiv_id_no_false_positive():
+    assert _scan_for_secrets("see arxiv 2606.11976v1") == []
+
+
+def test_scan_empty_string_returns_empty():
+    assert _scan_for_secrets("") == []
+
+
+# ─── Return value never propagates the actual secret ──────────────
+
+
+def test_scan_return_value_does_not_include_actual_secret():
+    """If a caller logs the result of _scan_for_secrets, the log line
+    must not contain the matched secret — only the pattern name."""
+    hits = _scan_for_secrets(_SYNTH_SK_ANT)
+    for h in hits:
+        # The synthetic payload was all 'A's; no hit identifier should
+        # contain that payload signature.
+        assert "AAAA" not in h
+        # The hit identifier should be a short pattern name, not the
+        # matched substring.
+        assert len(h) < 40
+
+
+# ─── _scrub_outbound_payload: refuses payloads with secrets ───────
+
+
+def test_scrub_clean_payload_no_raise():
+    _scrub_outbound_payload({"title": "Fix typo", "body": "Clean."})
+
+
+def test_scrub_raises_on_top_level_body_secret():
+    body = {"title": "PR", "body": f"see {_SYNTH_GHS} for context"}
+    with pytest.raises(OutboundSecretError) as excinfo:
+        _scrub_outbound_payload(body)
+    msg = str(excinfo.value)
+    # Path identifies which field tripped the gate.
+    assert "body" in msg
+    # The actual secret value must NOT appear in the exception message.
+    assert "AAA" not in msg
+    # The pattern name SHOULD appear so the operator can find the leak.
+    assert "github_token" in msg
+
+
+def test_scrub_raises_on_nested_list_secret():
+    body = {
+        "title": "Recommended paper",
+        "body": "Clean prose.",
+        "labels": ["docs", _SYNTH_RMXU],
+    }
+    with pytest.raises(OutboundSecretError) as excinfo:
+        _scrub_outbound_payload(body)
+    # Nested-path notation pinpoints the offending element.
+    assert "labels[1]" in str(excinfo.value)
+
+
+def test_scrub_raises_on_deeply_nested_secret():
+    body = {
+        "input": {
+            "discussion": {
+                "comment": {
+                    "body": f"context: {_SYNTH_BEARER}",
+                },
+            },
+        },
+    }
+    with pytest.raises(OutboundSecretError) as excinfo:
+        _scrub_outbound_payload(body)
+    assert "input.discussion.comment.body" in str(excinfo.value)
+
+
+def test_scrub_handles_none_payload():
+    # GET requests pass body=None; the scrubber must be a no-op.
+    _scrub_outbound_payload(None)
+
+
+def test_scrub_handles_non_string_leaf_values():
+    # bool / int / None values should pass through silently.
+    _scrub_outbound_payload(
+        {"draft": True, "number": 42, "labels": None, "body": "ok"}
+    )
+
+
+def test_outbound_secret_error_inherits_from_runtime_error():
+    """Callers that broadly catch RuntimeError still see the error
+    (back-compat for any catch-all handler), but the typed name lets
+    higher-level handlers route it to a security-incident pathway
+    specifically."""
+    err = OutboundSecretError("test")
+    assert isinstance(err, RuntimeError)
+    assert isinstance(err, OutboundSecretError)
+
+
+# ─── End-to-end: gh_api refuses to send a body containing a token ─
+
+
+def test_gh_api_refuses_to_send_payload_with_anthropic_key(monkeypatch):
+    """If a body with a leaked token reaches gh_api, the request must
+    be aborted before any network call. urlopen would have to NOT be
+    invoked — we monkeypatch it to a sentinel-raising stub so any
+    accidental network call surfaces as a different exception."""
+    import run
+
+    def _should_not_be_called(*args, **kwargs):
+        raise AssertionError(
+            "urlopen was reached despite OutboundSecretError being raised "
+            "upstream — defense bypassed"
+        )
+
+    monkeypatch.setattr(run.urllib.request, "urlopen", _should_not_be_called)
+    # Make _github_token return a valid-looking value so we know the
+    # rejection is due to the scrubber, not the missing-token guard.
+    monkeypatch.setattr(run, "_github_token", lambda: "test-token-value")
+
+    body_with_leak = {
+        "title": "Recommended paper",
+        "body": f"agent output: {_SYNTH_SK_ANT}",
+    }
+    with pytest.raises(OutboundSecretError):
+        run.gh_api("POST", "/repos/owner/repo/pulls", body_with_leak)


### PR DESCRIPTION
## Summary

PR/Issue/Discussion bodies are assembled from many upstream paths — agent self-review JSON, test stdout tail, pre-flight reasoning, the Claude-written file-fallback, raw recommendation envelope fields. A regression in any of those could in principle propagate untrusted content (including a credential) into a public-repo body via the GitHub API.

This adds a one-place catch at the API boundary: `gh_api` and `gh_graphql` now call `_scrub_outbound_payload` on the request payload before serialization. If any string field matches a known credential pattern, the request is aborted with `OutboundSecretError`. Fails closed — partial redaction risks letting variant shapes through.

## Patterns covered

- Anthropic API keys (`sk-ant-…`)
- GitHub PAT / App / OAuth tokens (`gh[psoaru]_…`) and fine-grained PATs (`github_pat_…`)
- Remyx API keys (`rmxu_…`)
- JWTs (3-segment `eyJ…`)
- `Authorization: Bearer …` headers and generic `Bearer …` tokens
- Env-var-style leaks (`ANTHROPIC_API_KEY=…`, etc.)

## Failure mode

The exception message reports the JSON path of the offending field and a short pattern identifier (e.g. `anthropic_api_key`, `github_token`). The matched secret value is never propagated into the error or any log line built from it.

## Test plan

- [x] 22 new tests in `tests/test_outbound_secret_scrubber.py` cover per-pattern detection, false-positive guards (commit SHAs, arxiv ids), nested-payload traversal, the no-leak property of the exception message, and an end-to-end check that `urlopen` is never reached when a secret-shaped body reaches `gh_api`
- [x] Full suite: 493 pass (was 471, +22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)