### PR TITLE
Exploration-structure dimension on selection_coverage (arXiv:2606.11976)

### DIFF
--- a/src/exploration_structure.py
+++ b/src/exploration_structure.py
@@ -1,0 +1,210 @@
+"""Exploration-structure dimension for the selection pass transcript.
+
+Adapted from *Exploration Structure in LLM Agents for Multi-File Change
+Localization* (arXiv:2606.11976). That paper contrasts **linear** agentic
+exploration — visiting one directory or file per step, sequentially within
+a single region — against **non-linear, domain-scoped** exploration that
+branches across several subsystems in parallel. Its central finding is that
+linear traversal is a *structural mismatch* for changes spanning multiple
+subsystems: domain-scoped parallel spawning lifts all-gold recall on
+multi-file localization, while a single sequential agent under-covers the
+subsystems a change actually touches.
+
+This module ports the paper's *analytical result*, not its multi-agent
+orchestration: it does not spawn domain-agents or change how Outrider's
+selection pass explores. Instead it reads the same ordered event stream the
+selection pass already records and classifies how that exploration was
+*structured* — how many distinct repo domains (top-level subsystems) the
+agent touched, how often it switched between them, and whether it issued its
+file reads one-per-step (linear) or batched several per turn (branching).
+The output rides along as one more telemetry dimension on the existing
+selection-coverage dict, so an under-covered, single-subsystem traversal is
+visible alongside the count/ratio dimensions already gated.
+
+Everything here is computed from the existing transcript — no new
+instrumentation hooks, matching the selection-coverage constraint.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+# Tokens in a Bash command that look like a repo path: either they contain a
+# directory separator, or they carry a source/doc/config extension. Quoting
+# and trailing punctuation are stripped by the caller.
+_PATHISH_RE = re.compile(
+    r"""[\w./-]+/[\w./-]+|[\w-]+\.(?:py|md|rst|txt|toml|cfg|ini|ya?ml|json|sh)""",
+)
+
+# Path-bearing native tools and the input key holding their target path.
+_PATH_INPUT_KEYS = {
+    "Read": "file_path",
+    "Edit": "file_path",
+    "Write": "file_path",
+    "NotebookEdit": "notebook_path",
+    "Grep": "path",
+    "Glob": "path",
+}
+
+
+def _domain_of(path: str) -> str:
+    """Top-level subsystem a path belongs to.
+
+    ``src/run.py`` → ``src``; ``tests/x.py`` → ``tests``; a bare ``README.md``
+    → ``<root>``. Leading ``./`` and absolute prefixes are normalised away so
+    the same subsystem is not double-counted.
+    """
+    p = path.strip().lstrip("./")
+    if not p:
+        return "<root>"
+    head = p.split("/", 1)[0]
+    return head if "/" in p else "<root>"
+
+
+def _paths_in_tool_use(name: str, inp: dict) -> list[str]:
+    """Repo paths referenced by one ``tool_use`` block.
+
+    Native path tools expose their target directly; Bash commands are scanned
+    for path-ish tokens. Returns ``[]`` for non-exploration tool calls.
+    """
+    inp = inp or {}
+    key = _PATH_INPUT_KEYS.get(name)
+    if key is not None:
+        val = inp.get(key)
+        return [val] if isinstance(val, str) and val.strip() else []
+    if name == "Bash":
+        cmd = inp.get("command")
+        if not isinstance(cmd, str) or not cmd:
+            return []
+        out: list[str] = []
+        for tok in _PATHISH_RE.findall(cmd):
+            tok = tok.strip("'\"`,;:()")
+            # Skip URLs and flag-looking tokens.
+            if tok and "://" not in tok and not tok.startswith("-"):
+                out.append(tok)
+        return out
+    return []
+
+
+def _structure_label(
+    domains: int, parallel_turns: int, domain_switches: int
+) -> str:
+    """Collapse the raw signals into one of the paper's exploration shapes.
+
+    - ``none`` — no file exploration in the transcript.
+    - ``domain-scoped`` — touched ≥2 subsystems *and* branched (batched a
+      turn or repeatedly crossed domains): the paper's non-linear shape.
+    - ``branching`` — batched reads but stayed within one subsystem, or
+      crossed domains only sequentially: partially non-linear.
+    - ``linear`` — one read per step inside a single subsystem: the paper's
+      structural-mismatch shape for multi-file changes.
+    """
+    if domains == 0:
+        return "none"
+    branched = parallel_turns >= 1 or domain_switches >= 2
+    if domains >= 2 and branched:
+        return "domain-scoped"
+    if branched:
+        return "branching"
+    return "linear"
+
+
+def exploration_structure_from_events(events: list[dict]) -> dict:
+    """Classify selection-pass exploration as linear vs domain-scoped.
+
+    Walks the ordered transcript, extracts the repo paths each ``tool_use``
+    touched, and derives the structure dimension the paper studies:
+
+    - ``domains`` / ``domain_list`` — distinct subsystems the agent reached.
+    - ``domain_switches`` — transitions between subsystems in read order.
+    - ``parallel_turns`` / ``max_turn_width`` — turns issuing >1 path read
+      (branching) and the widest such turn.
+    - ``linearity`` — share of path-bearing turns that read exactly one path
+      (1.0 = strictly one-per-step; lower = more batched).
+    - ``structure`` — the collapsed label (see :func:`_structure_label`).
+
+    Pure over ``events``; safe on a malformed or empty stream.
+    """
+    ordered_domains: list[str] = []
+    domain_set: set[str] = set()
+    single_turns = 0
+    parallel_turns = 0
+    max_turn_width = 0
+    path_turns = 0
+
+    for ev in events:
+        msg = ev.get("message") if isinstance(ev, dict) else None
+        content = (msg or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        turn_width = 0
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            paths = _paths_in_tool_use(
+                block.get("name") or "", block.get("input") or {}
+            )
+            if not paths:
+                continue
+            turn_width += 1
+            for p in paths:
+                dom = _domain_of(p)
+                ordered_domains.append(dom)
+                domain_set.add(dom)
+        if turn_width:
+            path_turns += 1
+            max_turn_width = max(max_turn_width, turn_width)
+            if turn_width >= 2:
+                parallel_turns += 1
+            else:
+                single_turns += 1
+
+    domain_switches = sum(
+        1 for a, b in zip(ordered_domains, ordered_domains[1:]) if a != b
+    )
+    linearity = round(single_turns / path_turns, 2) if path_turns else 0.0
+    domains = len(domain_set)
+
+    return {
+        "domains": domains,
+        "domain_list": sorted(domain_set),
+        "domain_switches": domain_switches,
+        "parallel_turns": parallel_turns,
+        "max_turn_width": max_turn_width,
+        "linearity": linearity,
+        "structure": _structure_label(
+            domains, parallel_turns, domain_switches
+        ),
+    }
+
+
+def is_single_subsystem(structure: dict) -> bool:
+    """True when exploration stayed linear within one subsystem.
+
+    The paper's structural-mismatch case: a multi-subsystem change localized
+    by a one-file-per-step traversal that never branched out. Callers use
+    this as a soft under-coverage signal alongside the line-count floor.
+    """
+    return (
+        structure.get("structure") == "linear"
+        and structure.get("domains", 0) <= 1
+    )
+
+
+def structure_summary(structure: dict) -> str:
+    """One-line human-readable summary for logs / step summary."""
+    return (
+        f"{structure.get('structure', 'none')} "
+        f"({structure.get('domains', 0)} domains, "
+        f"linearity {structure.get('linearity', 0.0)}, "
+        f"{structure.get('parallel_turns', 0)} parallel turns)"
+    )
+
+
+# Whether the structure dimension is computed and merged into selection
+# coverage. Defaults on; set REMYX_SELECTION_EXPLORATION_STRUCTURE=off to
+# skip it (keeps the coverage dict to its original four keys).
+def structure_enabled() -> bool:
+    return os.environ.get(
+        "REMYX_SELECTION_EXPLORATION_STRUCTURE", "on"
+    ).lower().strip() != "off"

--- a/src/run.py
+++ b/src/run.py
@@ -70,6 +70,10 @@ from diff_risk_score import (
     render_risk_detail,
     score_diff_risk,
 )
+from exploration_structure import (
+    exploration_structure_from_events,
+    structure_enabled,
+)
 
 # ─── Configuration ─────────────────────────────────────────────────────────
 
@@ -4032,12 +4036,22 @@ def _selection_coverage_from_events(events: list[dict]) -> dict:
             elif btype == "tool_result":
                 if block.get("tool_use_id") in read_ids:
                     visible_lines += _count_result_lines(block.get("content"))
-    return {
+    coverage = {
         "searches": searches,
         "file_reads": file_reads,
         "visible_lines": visible_lines,
         "search_to_read_ratio": round(searches / max(file_reads, 1), 2),
     }
+    # Exploration-structure dimension (arXiv:2606.11976): classify the same
+    # ordered stream as linear (one read per step, single subsystem) vs
+    # non-linear/domain-scoped (branching across subsystems). Rides along as
+    # telemetry beside the count/ratio dimensions; gating still keys off
+    # visible_lines.
+    if structure_enabled():
+        coverage["exploration_structure"] = exploration_structure_from_events(
+            events
+        )
+    return coverage
 
 
 def _selection_context_efficiency(text: str, visible_lines: int) -> float:
@@ -4231,12 +4245,15 @@ def select_recommendation(
     _apply_coverage_gate(data, coverage, higher_floor=_higher_floor)
     data["selection_coverage"] = coverage
     data["selection_context_efficiency"] = context_efficiency
+    _struct = coverage.get("exploration_structure") or {}
     log.info(
         f"  selection coverage: {coverage['searches']} searches, "
         f"{coverage['file_reads']} file reads, "
         f"{coverage['visible_lines']} lines visible, "
         f"context-efficiency {context_efficiency} "
-        f"(under_explored={coverage.get('under_explored')})"
+        f"(under_explored={coverage.get('under_explored')}, "
+        f"structure={_struct.get('structure', 'n/a')}, "
+        f"domains={_struct.get('domains', 0)})"
     )
     try:
         idx = int(data.get("chosen_index"))

--- a/tests/test_exploration_structure.py
+++ b/tests/test_exploration_structure.py
@@ -1,0 +1,143 @@
+"""Tests for the exploration-structure dimension (arXiv:2606.11976).
+
+The paper distinguishes *linear* sequential exploration (one file per step,
+single subsystem) from *non-linear, domain-scoped* exploration (branching
+across subsystems). These tests exercise the standalone classifier and,
+crucially, the wiring into the existing selection-coverage call site in
+``run._selection_coverage_from_events`` — confirming the new dimension
+rides along on the same coverage dict that already flows through the gate
+and run telemetry.
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402  (existing, non-new call-site module)
+import exploration_structure as es  # noqa: E402
+
+
+def _read(turn_paths):
+    """An assistant turn issuing one Read tool_use per path in ``turn_paths``."""
+    return {"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "id": f"r{i}", "name": "Read",
+         "input": {"file_path": p}}
+        for i, p in enumerate(turn_paths)
+    ]}}
+
+
+# ── path / domain extraction ────────────────────────────────────────────────
+
+def test_domain_of_top_level_and_root():
+    assert es._domain_of("src/run.py") == "src"
+    assert es._domain_of("./tests/x.py") == "tests"
+    assert es._domain_of("README.md") == "<root>"
+
+
+def test_paths_from_native_and_bash_tools():
+    assert es._paths_in_tool_use("Read", {"file_path": "src/run.py"}) == \
+        ["src/run.py"]
+    assert es._paths_in_tool_use("Grep", {"pattern": "x"}) == []  # no path key
+    bash = es._paths_in_tool_use(
+        "Bash", {"command": "sed -n '1,40p' src/run.py; cat tests/a.py"})
+    assert "src/run.py" in bash and "tests/a.py" in bash
+
+
+def test_bash_skips_urls_and_flags():
+    paths = es._paths_in_tool_use(
+        "Bash", {"command": "gh api https://x/contents/src/run.py --json name"})
+    assert all("://" not in p for p in paths)
+
+
+# ── structure classification ────────────────────────────────────────────────
+
+def test_linear_single_subsystem():
+    # One read per step, all under src/ → the paper's structural-mismatch shape.
+    events = [_read(["src/a.py"]), _read(["src/b.py"]), _read(["src/c.py"])]
+    out = es.exploration_structure_from_events(events)
+    assert out["structure"] == "linear"
+    assert out["domains"] == 1
+    assert out["linearity"] == 1.0
+    assert out["parallel_turns"] == 0
+    assert es.is_single_subsystem(out) is True
+
+
+def test_domain_scoped_parallel_branching():
+    # Batched reads spanning several subsystems → non-linear domain-scoped.
+    events = [
+        _read(["src/run.py", "tests/test_run.py", "docs/guide.md"]),
+        _read(["src/gh_graph.py", "tests/test_axis.py"]),
+    ]
+    out = es.exploration_structure_from_events(events)
+    assert out["structure"] == "domain-scoped"
+    assert out["domains"] == 3
+    assert out["parallel_turns"] == 2
+    assert out["max_turn_width"] == 3
+    assert out["linearity"] == 0.0
+    assert es.is_single_subsystem(out) is False
+
+
+def test_branching_within_one_subsystem():
+    # Batched, but every read stays in src/ → branching, not domain-scoped.
+    events = [_read(["src/a.py", "src/b.py"])]
+    out = es.exploration_structure_from_events(events)
+    assert out["structure"] == "branching"
+    assert out["domains"] == 1
+
+
+def test_domain_switches_counted_in_order():
+    events = [_read(["src/a.py"]), _read(["tests/b.py"]), _read(["src/c.py"])]
+    out = es.exploration_structure_from_events(events)
+    # src → tests → src = 2 switches; sequential single steps over 2 domains
+    # with ≥2 switches still reads as domain-scoped.
+    assert out["domain_switches"] == 2
+    assert out["structure"] == "domain-scoped"
+
+
+def test_empty_and_no_path_events():
+    assert es.exploration_structure_from_events([])["structure"] == "none"
+    no_path = [{"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "id": "s1", "name": "Grep",
+         "input": {"pattern": "x"}}]}}]
+    assert es.exploration_structure_from_events(no_path)["structure"] == "none"
+
+
+def test_summary_string_is_human_readable():
+    out = es.exploration_structure_from_events([_read(["src/a.py"])])
+    s = es.structure_summary(out)
+    assert "linear" in s and "domains" in s
+
+
+# ── integration: rides along on the existing coverage call site ─────────────
+
+def test_coverage_merges_structure_dimension():
+    events = [
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "r1", "name": "Read",
+             "input": {"file_path": "src/run.py"}},
+            {"type": "tool_use", "id": "r2", "name": "Read",
+             "input": {"file_path": "tests/test_run.py"}},
+        ]}},
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "r1", "content": "a\nb"},
+        ]}},
+    ]
+    cov = run._selection_coverage_from_events(events)
+    # Original dimensions still present and unchanged in shape.
+    assert cov["file_reads"] == 2
+    assert "search_to_read_ratio" in cov
+    # New dimension merged in by the call-site edit.
+    struct = cov["exploration_structure"]
+    assert struct["domains"] == 2                 # src + tests
+    assert struct["parallel_turns"] == 1
+    assert struct["structure"] == "domain-scoped"
+
+
+def test_structure_disabled_via_env(monkeypatch):
+    monkeypatch.setenv("REMYX_SELECTION_EXPLORATION_STRUCTURE", "off")
+    cov = run._selection_coverage_from_events([_read(["src/a.py"])])
+    assert "exploration_structure" not in cov
+    # Core coverage dimensions remain intact when the dimension is disabled.
+    assert cov["file_reads"] == 1

--- a/tests/test_selection_coverage.py
+++ b/tests/test_selection_coverage.py
@@ -96,8 +96,13 @@ def test_coverage_counts_and_ratio():
 
 def test_coverage_empty_transcript():
     cov = run._selection_coverage_from_events([])
-    assert cov == {"searches": 0, "file_reads": 0, "visible_lines": 0,
-                   "search_to_read_ratio": 0.0}
+    # The exploration-structure dimension rides along; assert the count/ratio
+    # core directly and the structure shape separately.
+    assert cov["searches"] == 0
+    assert cov["file_reads"] == 0
+    assert cov["visible_lines"] == 0
+    assert cov["search_to_read_ratio"] == 0.0
+    assert cov["exploration_structure"]["structure"] == "none"
 
 
 def test_coverage_result_lines_only_for_reads():


### PR DESCRIPTION
## Summary

Adds an `exploration_structure` dimension to `selection_coverage`, capturing *how* the selection-pass agent moved through the target repo rather than just *how much* it read. Adapted from *Exploration Structure in LLM Agents for Multi-File Change Localization* (arXiv:2606.11976) — ports the paper's analytical classification, not its multi-agent orchestration.

Today's `selection_coverage` reports 4 scalars (`searches`, `file_reads`, `visible_lines`, `search_to_read_ratio`). A run that hits the `visible_lines` floor by deep-diving one subsystem can still under-cover what a multi-file change actually touches. This PR adds the structural dimension the paper identifies as the missing signal.

## What's reported

`coverage["exploration_structure"]` becomes a dict with:

| Field | Meaning |
| -- | -- |
| `domains` / `domain_list` | Distinct top-level subsystems touched (`src`, `tests`, `docs`, ...) |
| `domain_switches` | Transitions between subsystems in read order |
| `parallel_turns` / `max_turn_width` | Turns issuing >1 path read (branching shape) |
| `linearity` | Share of path-bearing turns reading exactly one path (1.0 = strictly one-per-step) |
| `structure` | Collapsed label: `linear` / `branching` / `domain-scoped` / `none` |

The paper's *linear* shape (one read per step, single subsystem) is the structural-mismatch case for multi-file changes — visible alongside count/ratio metrics now.

## Constraints honored

- **Pure function over the existing event stream** — no new instrumentation hooks in the agent's loop. Satisfies the design constraint that coverage metrics must be derivable from the transcript Outrider already records.
- **Backwards-compatible** — downstream consumers that read the existing 4 scalars are unaffected; the new dimension rides along as an additional key.
- **Feature-flagged** — `REMYX_SELECTION_EXPLORATION_STRUCTURE=off` disables computation and reverts the dict to its original 4 keys.
- **No gate changes** — `visible_lines` remains the keying signal. This PR is observability-additive; behavior changes (e.g. soft-warning on `linear` + single subsystem) would land in a follow-up.

## Helper

`is_single_subsystem(structure: dict) -> bool` exposes the paper's structural-mismatch case as a callable. Future predictor or soft-gate work can consume it without re-deriving from the dict.

## Test plan

- [x] 143-line `tests/test_exploration_structure.py` covers per-shape classification, path extraction across native tools + Bash, URL/flag false-positive guards, empty-stream tolerance, and the feature-flag off path
- [x] `tests/test_selection_coverage.py` extended (+7/−2) for the new dimension on the integration boundary
- [x] Full suite: 504 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)