### PR TITLE
Include CONTEXT.md in the orientation-block instruction-file list

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -3013,9 +3013,18 @@ def detect_package_name(workdir: Path) -> str:
 
 
 def _orient_contributor_guides(workdir: Path, cap: int = 3000) -> str:
-    """Read contributor-guide files; concatenate and truncate to ``cap``."""
+    """Read contributor-guide files; concatenate and truncate to ``cap``.
+
+    Includes ``CONTEXT.md`` for repos that ship it: it carries
+    team-direction signal (active investigation areas, stable
+    architecture, out-of-scope boundaries) that the implementation
+    pass can use alongside style-shaped guides like ``CLAUDE.md`` and
+    ``AGENTS.md``. Order is precedence-from-most-specific: per-agent
+    files first, then generic agentic conventions, then human
+    contributor docs, then team-direction context.
+    """
     chunks: list[str] = []
-    for name in ("CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md"):
+    for name in ("CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md", "CONTEXT.md"):
         path = workdir / name
         if not path.is_file():
             continue

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -27,10 +27,11 @@ from run import Target  # noqa: E402
 # ─── _orient_contributor_guides ───────────────────────────────────────────
 
 
-def test_contributor_guides_reads_all_three(tmp_path: Path) -> None:
+def test_contributor_guides_reads_all_four(tmp_path: Path) -> None:
     (tmp_path / "CLAUDE.md").write_text("# Claude Guide\nUse the verification stack.\n")
     (tmp_path / "AGENTS.md").write_text("# Agents Guide\nFollow these rules.\n")
     (tmp_path / "CONTRIBUTING.md").write_text("# Contributing\nWelcome contributors.\n")
+    (tmp_path / "CONTEXT.md").write_text("# Context\nActive investigation areas.\n")
 
     body = run._orient_contributor_guides(tmp_path)
 
@@ -40,6 +41,46 @@ def test_contributor_guides_reads_all_three(tmp_path: Path) -> None:
     assert "Follow these rules." in body
     assert "`CONTRIBUTING.md`" in body
     assert "Welcome contributors." in body
+    assert "`CONTEXT.md`" in body
+    assert "Active investigation areas." in body
+
+
+def test_contributor_guides_reads_context_md_alone(tmp_path: Path) -> None:
+    """A repo that ships only CONTEXT.md (no CLAUDE.md / AGENTS.md /
+    CONTRIBUTING.md) still gets its team-direction signal into the
+    orientation block. Targets the lessons-from-CONTEXT.md case: the
+    file types the orientation pass surfaces shouldn't gate each other."""
+    (tmp_path / "CONTEXT.md").write_text(
+        "# Outrider CONTEXT.md\nActive investigation areas: …\n"
+    )
+
+    body = run._orient_contributor_guides(tmp_path)
+
+    assert "`CONTEXT.md`" in body
+    assert "Active investigation areas" in body
+    # No other files present → only the CONTEXT.md block.
+    assert "`CLAUDE.md`" not in body
+    assert "`AGENTS.md`" not in body
+    assert "`CONTRIBUTING.md`" not in body
+
+
+def test_contributor_guides_precedence_order(tmp_path: Path) -> None:
+    """When all four files exist, output order is the precedence order:
+    CLAUDE.md → AGENTS.md → CONTRIBUTING.md → CONTEXT.md. Stable order
+    matters so the agent's context-window position for the most-specific
+    guide is consistent across runs."""
+    (tmp_path / "CLAUDE.md").write_text("claude")
+    (tmp_path / "AGENTS.md").write_text("agents")
+    (tmp_path / "CONTRIBUTING.md").write_text("contributing")
+    (tmp_path / "CONTEXT.md").write_text("context")
+
+    body = run._orient_contributor_guides(tmp_path)
+
+    pos_claude = body.index("`CLAUDE.md`")
+    pos_agents = body.index("`AGENTS.md`")
+    pos_contrib = body.index("`CONTRIBUTING.md`")
+    pos_context = body.index("`CONTEXT.md`")
+    assert pos_claude < pos_agents < pos_contrib < pos_context
 
 
 def test_contributor_guides_returns_empty_when_none_present(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`_orient_contributor_guides` currently reads `CLAUDE.md`, `AGENTS.md`, and `CONTRIBUTING.md` from the target repo and threads them into the implementation pass's orientation block. This PR adds `CONTEXT.md` to the same list.

CONTEXT.md is a slightly different shape than the other three — it carries team-direction signal (active investigation areas, stable architecture, out-of-scope boundaries) rather than style/contribution guidance. Both are useful to the implementation agent, and they don't gate each other: a repo that ships only CONTEXT.md still gets that signal surfaced; a repo with all four files gets them all in a defined order.

Outrider's own repo recently demonstrated this empirically — the selection-pass agent on a self-dogfood run explicitly cited `CONTEXT.md` in its rejection reasoning, indicating that team-direction markdown does change agent behavior. Generalizing the surface to target repos that ship one is the natural extension.

## Precedence order

`CLAUDE.md → AGENTS.md → CONTRIBUTING.md → CONTEXT.md` — per-agent first, generic agentic conventions next, human contributor docs after, team-direction context last. Stable ordering matters so the agent's context-window position for the most-specific guide is consistent across runs.

## Test plan

- [x] Existing test extended (was `_reads_all_three`, now `_reads_all_four`)
- [x] New: `test_contributor_guides_reads_context_md_alone` — a repo with only CONTEXT.md still gets it surfaced
- [x] New: `test_contributor_guides_precedence_order` — asserts the four-way order explicitly so future additions don't quietly reorder it
- [x] Full suite: 506 pass (was 504, +2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)