### PR TITLE
Selection-pass code-override carve-out for self-contained no-code papers

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -777,6 +777,42 @@ Recovery strategies for missing/broken links (apply BEFORE concluding
     document the failed lookups in `reasoning` and reject the
     candidate rather than burning the turn budget guessing.
 
+**Overriding the no-code penalty.** When a candidate has no code link
+(license class `no-code-link`, compat 0.30) you MAY still pick it if
+ALL THREE conditions hold:
+
+  1. **Method is conceptually self-contained.** The abstract and any
+     method-section text in the candidate brief contain enough detail
+     that a competent implementer could reproduce the contribution
+     without reference code. Empirical / analytical papers proposing a
+     classification scheme, signal, or measurement typically qualify;
+     complex algorithmic methods (novel attention variants, kernel
+     tricks, training recipes with non-obvious hyperparameters)
+     typically do not.
+
+  2. **Verified existing call site with a clear contract match.** Same
+     bar as a code-bearing addition — locate the existing function /
+     module the new code would integrate into and confirm the I/O
+     contract aligns.
+
+  3. **Integration shape is `addition` or `simplification`, NOT
+     `replacement` or `extension`.** Replacement touches code already
+     in production, where the bar for borrowing from a no-code paper
+     is much higher. Extension lacks a call site at all — combining
+     "no code" + "no anchoring call site" is speculation, not a
+     contract-anchored override.
+
+When all three hold, set `chosen_index` to the candidate, classify the
+shape, AND populate the new `code_override_justification` field with a
+1-2 sentence audit trail explaining WHY this specific paper's method
+is self-contained enough to implement from its description. The
+override fires only when justification is explicit — lazy
+justifications ("method is clear enough" without specifics about
+which scheme/signal/measurement is being ported) are not durable and
+will be reviewed downstream. When the no-code candidate does NOT meet
+all three conditions, reject it in `rejected[]` with the standard
+reason; the override is a narrow carve-out, not a general permission.
+
 Stop iterating once you have enough evidence to pick (verified one
 candidate fits one of the three shapes) OR to reject all (every
 candidate has a structural mismatch). Don't burn turns on diminishing
@@ -835,6 +871,19 @@ fences, no prose before or after. Schema:
                             torchtune/training/quantization/_quantize.py
                             hosts the bit-allocation step the paper
                             extends'>",
+  "code_override_justification": "<OPTIONAL: REQUIRED when the chosen
+                                   candidate has license_class=`no-code-link`
+                                   (compat 0.30) AND you are picking it as
+                                   `addition` or `simplification` per the
+                                   override carve-out documented above.
+                                   1-2 sentences naming the specific
+                                   self-contained signal/scheme/measurement
+                                   being ported and why it does not need
+                                   reference code to disambiguate. Omit
+                                   when the chosen candidate has a code
+                                   link, when chosen_index < 0, or when
+                                   the integration_shape is `replacement`
+                                   or `extension`.>",
   "reasoning": "<2-3 sentences: why this candidate's contribution maps
                  cleanly onto the verified call site (addition) or why
                  the contract match is clean (replacement /
@@ -4313,6 +4362,50 @@ def select_recommendation(
             f"  selection: extension pick — direction signal: {tds[:100]!r}, "
             f"adjacent call site: {pcs[:80]!r}"
         )
+    # Code-override audit (Path B from REMYX-130): when the chosen
+    # candidate has no code link (compat <= 0.30) AND the agent
+    # populated code_override_justification, validate the override is
+    # restricted to the eligible archetypes (addition / simplification)
+    # per the prompt contract. If the agent overrode for replacement
+    # or extension, the override is invalid — fall back to skip rather
+    # than silently allowing a no-code pick in an archetype where the
+    # bar should be higher.
+    #
+    # When the override is empty AND the candidate is no-code, the
+    # current behavior holds — the agent is expected to either justify
+    # explicitly via this field or reject in `rejected[]`. We don't
+    # auto-fail no-code picks without an explicit justification field;
+    # this is the carve-out path, not a hard requirement.
+    override_just = (data.get("code_override_justification") or "").strip()
+    # Normalize: drop empty / whitespace-only justification so downstream
+    # consumers don't have to treat "field present but blank" as a special
+    # case. Same effect as the field being absent.
+    if "code_override_justification" in data and not override_just:
+        data.pop("code_override_justification", None)
+    if idx >= 0 and 0 <= idx < len(candidates) and override_just:
+        cand_compat = getattr(candidates[idx], "license_compat", 1.0)
+        if cand_compat > 0.3:
+            log.warning(
+                f"  selection: code_override_justification set on a "
+                f"candidate with code link (compat={cand_compat:.2f}); "
+                f"justification ignored — override only applies to "
+                f"no-code-link candidates"
+            )
+            data.pop("code_override_justification", None)
+        elif shape not in ("addition", "simplification"):
+            log.warning(
+                f"  selection: code_override_justification set but "
+                f"integration_shape={shape!r} (must be addition or "
+                f"simplification); rejecting override"
+            )
+            data["chosen_index"] = -1
+            return data
+        else:
+            log.info(
+                f"  selection: code-override fired — archetype={shape}, "
+                f"justification={override_just[:160]!r}"
+            )
+
     # Agentic selection may surface an out-of-pool candidate via
     # broadening-search (chosen_index: -2). Validate the required
     # external_* fields are present; if they're missing, the agent
@@ -5886,6 +5979,16 @@ def process_target(target: Target) -> dict:
                 if "selection_context_efficiency" in selection:
                     result["selection_context_efficiency"] = (
                         selection["selection_context_efficiency"]
+                    )
+                # Code-override audit field (REMYX-130 Path B) — attached
+                # once before the branch logic so every downstream path
+                # (in-pool, extension, external, skip) carries it. Field
+                # is only set when the agent populated and validated it
+                # (`select_recommendation` drops it on contract violations
+                # and on non-no-code candidates).
+                if selection.get("code_override_justification"):
+                    result["selection_code_override_justification"] = (
+                        selection["code_override_justification"]
                     )
             if selection is not None and selection.get("chosen_index") == -1:
                 # Agentic selection rejected every candidate after verification

--- a/tests/test_selection_code_override.py
+++ b/tests/test_selection_code_override.py
@@ -1,0 +1,274 @@
+"""Tests for the code-override carve-out in the selection-pass (REMYX-130 Path B).
+
+The override lets the selection-pass agent pick a `no-code-link` candidate
+(``license_compat <= 0.30``) under three conditions:
+
+  1. Method is conceptually self-contained
+  2. Verified existing call site with a clear contract match
+  3. Integration archetype is `addition` or `simplification`
+
+The override fires only when the agent populates the new
+``code_override_justification`` field. ``select_recommendation`` validates
+the override is restricted to the eligible archetypes and to actual
+no-code-link candidates; misuse falls back to ``chosen_index = -1``.
+
+The empirical anchor: PR #47 (Exploration Structure in LLM Agents)
+shipped from a no-code paper because its analytical contribution was
+conceptually self-contained. Without this carve-out the agent had to
+side-step the existing license penalty implicitly; with it the override
+is explicit, auditable, and trackable across runs.
+
+Run with: pytest tests/test_selection_code_override.py -q
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import pytest  # noqa: E402
+
+import run  # noqa: E402
+from run import Recommendation, Target  # noqa: E402
+
+
+def _rec(
+    arxiv_id: str = "2606.99999v1",
+    license_compat: float = 0.3,
+    license_class: str = "no-code-link",
+    tier: str = "moderate",
+    relevance: float = 0.85,
+) -> Recommendation:
+    """Build a minimal Recommendation for selection-pass plumbing tests."""
+    return Recommendation(
+        paper_title=f"Test paper {arxiv_id}",
+        arxiv_id=arxiv_id,
+        tier=tier,
+        z_score=0.0,
+        spec_md="",
+        paper_abstract="abstract",
+        domain_summary="domain",
+        raw_paper_md="md",
+        relevance_score=relevance,
+        license_class=license_class,
+        license_compat=license_compat,
+    )
+
+
+def _target() -> Target:
+    return Target(repo="owner/repo", interest_id="iid")
+
+
+def _mock_streaming(verdict_json: str):
+    """Build a monkeypatch target that returns (ok=True, output, events=[])
+    for ``_run_claude_oneshot_streaming``, so ``select_recommendation`` runs
+    its post-process validation against synthetic agent output."""
+    def _inner(*args, **kwargs):
+        return True, verdict_json, []
+    return _inner
+
+
+# ─── Prompt-content regression checks ─────────────────────────────────────
+
+
+def test_prompt_template_includes_override_carve_out():
+    """The override section must be in the template; remove it and the
+    no-code-link carve-out has no behavioral contract."""
+    assert "Overriding the no-code penalty" in run._SELECTION_PROMPT_TEMPLATE
+
+
+def test_prompt_template_documents_three_conditions():
+    """The carve-out's three conditions must each be named in the prompt
+    so the agent has a contract to verify against, not an implicit
+    norm to guess at."""
+    template = run._SELECTION_PROMPT_TEMPLATE
+    assert "conceptually self-contained" in template
+    assert "Verified existing call site" in template
+    assert "addition` or `simplification" in template
+
+
+def test_prompt_template_documents_schema_field():
+    """The schema must document the new field; an undocumented field is
+    indistinguishable from a typo in the model's output."""
+    assert "code_override_justification" in run._SELECTION_PROMPT_TEMPLATE
+
+
+# ─── Validation: override accepted for eligible archetypes ────────────────
+
+
+def test_override_accepted_for_addition(monkeypatch, tmp_path):
+    """No-code candidate + addition archetype + justification → override
+    fires; chosen_index is preserved."""
+    candidates = [_rec(arxiv_id="2606.00001v1", license_compat=0.3)]
+    verdict = (
+        '{"chosen_index": 0, "integration_shape": "addition", '
+        '"chosen_call_site": "src/x.py:f", '
+        '"verification_summary": "verified", '
+        '"reasoning": "fits", '
+        '"code_override_justification": "Method is a classification scheme '
+        'over the event stream; abstract specifies the four labels and the '
+        'derivation rule without ambiguity.", '
+        '"rejected": []}'
+    )
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", _mock_streaming(verdict))
+    monkeypatch.setattr(run, "_repo_layout_manifest", lambda *a, **k: "")
+    # Need at least two candidates for select_recommendation to engage
+    candidates.append(_rec(arxiv_id="2606.00002v1"))
+    result = run.select_recommendation(tmp_path, "pkg", candidates, target=_target())
+    assert result is not None
+    assert result["chosen_index"] == 0
+    assert "code_override_justification" in result
+    assert "classification scheme" in result["code_override_justification"]
+
+
+def test_override_accepted_for_simplification(monkeypatch, tmp_path):
+    """Simplification is the second eligible archetype; override accepted."""
+    candidates = [
+        _rec(arxiv_id="2606.00001v1", license_compat=0.3),
+        _rec(arxiv_id="2606.00002v1"),
+    ]
+    verdict = (
+        '{"chosen_index": 0, "integration_shape": "simplification", '
+        '"contract_match": "matches", "migration_cost": "1 file", '
+        '"verification_summary": "verified", "reasoning": "fits", '
+        '"code_override_justification": "Pipeline collapse rule is '
+        'arithmetic on existing knobs.", "rejected": []}'
+    )
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", _mock_streaming(verdict))
+    monkeypatch.setattr(run, "_repo_layout_manifest", lambda *a, **k: "")
+    result = run.select_recommendation(tmp_path, "pkg", candidates, target=_target())
+    assert result["chosen_index"] == 0
+    assert "code_override_justification" in result
+
+
+# ─── Validation: override rejected for ineligible archetypes ──────────────
+
+
+def test_override_rejected_for_replacement(monkeypatch, tmp_path):
+    """Replacement touches existing code in production — the bar for
+    borrowing from a no-code paper there is higher. Override must
+    fail-closed: chosen_index falls back to -1."""
+    candidates = [
+        _rec(arxiv_id="2606.00001v1", license_compat=0.3),
+        _rec(arxiv_id="2606.00002v1"),
+    ]
+    verdict = (
+        '{"chosen_index": 0, "integration_shape": "replacement", '
+        '"contract_match": "matches", "migration_cost": "5 files", '
+        '"verification_summary": "verified", "reasoning": "swap-in", '
+        '"code_override_justification": "Method is clear enough.", '
+        '"rejected": []}'
+    )
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", _mock_streaming(verdict))
+    monkeypatch.setattr(run, "_repo_layout_manifest", lambda *a, **k: "")
+    result = run.select_recommendation(tmp_path, "pkg", candidates, target=_target())
+    assert result["chosen_index"] == -1
+
+
+def test_override_rejected_for_extension(monkeypatch, tmp_path):
+    """Extension has no call site at all — combining 'no code' + 'no
+    anchoring call site' is speculation, not a contract-anchored
+    override. Override falls back to -1."""
+    candidates = [
+        _rec(
+            arxiv_id="2606.00001v1",
+            license_compat=0.3,
+            tier="high",
+            relevance=0.92,
+        ),
+        _rec(arxiv_id="2606.00002v1"),
+    ]
+    verdict = (
+        '{"chosen_index": 0, "integration_shape": "extension", '
+        '"team_direction_signal": "README roadmap item", '
+        '"proposed_call_site": "after stage_a", '
+        '"verification_summary": "verified", "reasoning": "extension fit", '
+        '"code_override_justification": "Empirical method, ports cleanly.", '
+        '"rejected": []}'
+    )
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", _mock_streaming(verdict))
+    monkeypatch.setattr(run, "_repo_layout_manifest", lambda *a, **k: "")
+    result = run.select_recommendation(tmp_path, "pkg", candidates, target=_target())
+    assert result["chosen_index"] == -1
+
+
+# ─── Validation: override ignored on code-bearing candidates ──────────────
+
+
+def test_override_ignored_on_code_bearing_candidate(monkeypatch, tmp_path):
+    """Justification field set on a code-bearing pick (compat > 0.30)
+    is dropped silently — the override only applies to actual
+    no-code-link candidates. chosen_index stays; justification is gone."""
+    candidates = [
+        _rec(
+            arxiv_id="2606.00001v1",
+            license_compat=1.0,
+            license_class="permissive",
+        ),
+        _rec(arxiv_id="2606.00002v1"),
+    ]
+    verdict = (
+        '{"chosen_index": 0, "integration_shape": "addition", '
+        '"chosen_call_site": "src/x.py:f", '
+        '"verification_summary": "verified", "reasoning": "fits", '
+        '"code_override_justification": "Not applicable here.", '
+        '"rejected": []}'
+    )
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", _mock_streaming(verdict))
+    monkeypatch.setattr(run, "_repo_layout_manifest", lambda *a, **k: "")
+    result = run.select_recommendation(tmp_path, "pkg", candidates, target=_target())
+    assert result["chosen_index"] == 0
+    # Override-not-applicable: the field is dropped, not retained.
+    assert "code_override_justification" not in result
+
+
+# ─── Validation: missing-override path stays compatible ───────────────────
+
+
+def test_no_override_field_passes_through(monkeypatch, tmp_path):
+    """When the agent doesn't populate the override field, existing
+    behavior holds — chosen_index is preserved, no validation fires.
+    This is the no-code candidate that the agent picked WITHOUT
+    explicit override; the existing license penalty applies via the
+    relevance ranker / pre-filter but does not auto-fail at the
+    selection-pass stage."""
+    candidates = [
+        _rec(arxiv_id="2606.00001v1", license_compat=0.3),
+        _rec(arxiv_id="2606.00002v1"),
+    ]
+    verdict = (
+        '{"chosen_index": 0, "integration_shape": "addition", '
+        '"chosen_call_site": "src/x.py:f", '
+        '"verification_summary": "verified", "reasoning": "fits", '
+        '"rejected": []}'
+    )
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", _mock_streaming(verdict))
+    monkeypatch.setattr(run, "_repo_layout_manifest", lambda *a, **k: "")
+    result = run.select_recommendation(tmp_path, "pkg", candidates, target=_target())
+    assert result["chosen_index"] == 0
+    assert "code_override_justification" not in result
+
+
+def test_empty_override_string_treated_as_absent(monkeypatch, tmp_path):
+    """Empty / whitespace-only justification is treated as no override —
+    same path as the field being absent. Prevents the agent from
+    sneaking the override past validation by populating an empty
+    string."""
+    candidates = [
+        _rec(arxiv_id="2606.00001v1", license_compat=0.3),
+        _rec(arxiv_id="2606.00002v1"),
+    ]
+    verdict = (
+        '{"chosen_index": 0, "integration_shape": "replacement", '
+        '"contract_match": "matches", "migration_cost": "1 file", '
+        '"verification_summary": "verified", "reasoning": "swap", '
+        '"code_override_justification": "   ", "rejected": []}'
+    )
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", _mock_streaming(verdict))
+    monkeypatch.setattr(run, "_repo_layout_manifest", lambda *a, **k: "")
+    result = run.select_recommendation(tmp_path, "pkg", candidates, target=_target())
+    # Empty override means the replacement validation should NOT trigger
+    # the override-with-wrong-archetype fall-through; the pick proceeds
+    # as a normal replacement pick.
+    assert result["chosen_index"] == 0
+    assert "code_override_justification" not in result


### PR DESCRIPTION
## Summary

The license-class enrichment treats `no-code-link` as a binary penalty (`compat=0.30`) and the selection-pass agent picks this up as a near-veto. The current strictness is right for complex algorithmic methods that need reference code to disambiguate, but it's over-conservative for empirical / analytical papers whose contribution is conceptually self-contained — classification schemes, signals, measurements that can be ported from prose alone.

The empirical anchor: the Exploration Structure paper (arXiv:2606.11976) had `license_class=no-code-link`, `compat=0.30`, and the selection-pass agent picked it anyway and implemented it cleanly in 210 lines (`src/exploration_structure.py`). The implementation worked because the paper's analytical contribution was conceptually self-contained. Without an explicit carve-out, that override was implicit and unauditable.

## What this adds

- **Prompt contract** names three conditions for overriding the no-code penalty:
  1. Method is conceptually self-contained
  2. Verified existing call site with clear contract match
  3. Integration shape is `addition` or `simplification` (NOT `replacement` or `extension`)
- **New schema field** `code_override_justification` on the selection JSON — required when the agent overrides, omitted otherwise. 1-2 sentences naming the specific self-contained signal/scheme/measurement being ported and why it does not need reference code to disambiguate.
- **Post-process validation** in `select_recommendation`:
  - Misuse on `replacement` or `extension` archetypes → `chosen_index = -1` (fail closed)
  - Misuse on a code-bearing candidate (compat > 0.30) → field dropped silently (override only applies to actual no-code-link candidates)
  - Empty / whitespace justification → normalized to absent
- **Audit trail** — `process_target` threads the justification into the run result as `selection_code_override_justification` so it flows into step summary and telemetry.

## Test plan

- [x] 10 new tests in `tests/test_selection_code_override.py` covering the prompt contract (carve-out section, three conditions, schema field), the eligible-archetype acceptance paths (addition + simplification), the rejection paths (replacement, extension, code-bearing candidate), and the empty-string normalization
- [x] Full suite: 516 pass (was 506, +10)

## Sequencing

This is the Path B experiment — fast prompt-level change to measure whether the override fires meaningfully and whether downstream merge rates hold. Once we have 4-6 weeks of usage data, the durable engine-side fix (per-paper `method_self_containedness` enrichment) becomes the next investment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)