### PR TITLE
Log per-pattern match lengths when the outbound scrubber raises

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -1307,11 +1307,33 @@ def _scrub_outbound_payload(payload: Any, _path: str = "") -> None:
     if isinstance(payload, str):
         hits = _scan_for_secrets(payload)
         if hits:
+            # Diagnostic: log per-pattern match counts and lengths before
+            # raising. Lengths discriminate real-token matches (typically
+            # 40-100+ chars) from prose false positives (near the regex
+            # minimum — e.g. 32-40 chars on the bearer pattern). The
+            # matched content itself is never logged or included in the
+            # exception message; only the lengths leave the runner.
+            lengths_by_pattern: dict[str, list[int]] = {}
+            for name, pat in _OUTBOUND_SECRET_PATTERNS:
+                if name in hits:
+                    lengths_by_pattern[name] = [
+                        m.end() - m.start() for m in pat.finditer(payload)
+                    ]
+            detail = ", ".join(
+                f"{n}(lens={lengths_by_pattern[n]})" for n in hits
+            )
+            log.error(
+                f"outbound-payload scrubber matched at field {_path!r}: "
+                f"{detail}; refusing to send"
+            )
             raise OutboundSecretError(
                 f"Outbound payload field {_path!r} matched credential "
                 f"pattern(s) {hits}; refusing to send the API request. "
                 f"Investigate the body-assembly path before retrying — "
-                f"this is a leak-prevention abort, not a content issue."
+                f"this is a leak-prevention abort, not a content issue. "
+                f"See preceding log line for match lengths per pattern; "
+                f"a match length near the regex minimum often indicates "
+                f"a prose false positive vs. a real credential."
             )
         return
     if isinstance(payload, dict):

--- a/tests/test_outbound_secret_scrubber.py
+++ b/tests/test_outbound_secret_scrubber.py
@@ -198,6 +198,96 @@ def test_outbound_secret_error_inherits_from_runtime_error():
 # ─── End-to-end: gh_api refuses to send a body containing a token ─
 
 
+# ─── Diagnostic logging (v1.6.8) ─────────────────────────────────
+
+
+def test_scrub_logs_pattern_lengths_before_raising(monkeypatch, caplog):
+    """When the scrubber raises, it must log the match lengths per
+    pattern at ERROR level so the operator can triage false positives
+    (typically near the regex minimum) vs. real tokens (40+ chars)."""
+    import logging
+    import run as run_module
+
+    body = {"body": f"see {_SYNTH_SK_ANT} for context"}
+    caplog.set_level(logging.ERROR, logger=run_module.log.name)
+    with pytest.raises(OutboundSecretError):
+        _scrub_outbound_payload(body)
+    # Diagnostic line should mention the field path, the pattern name,
+    # and the match lengths.
+    log_text = " ".join(r.message for r in caplog.records if r.levelno >= logging.ERROR)
+    assert "body" in log_text
+    assert "anthropic_api_key" in log_text
+    assert "lens=" in log_text
+
+
+def test_scrub_diagnostic_does_not_leak_match_content(monkeypatch, caplog):
+    """The diagnostic log line must contain ONLY pattern name + match
+    lengths — never the matched content. If the log itself leaked
+    secrets, the defense would propagate them further than the
+    original API call would have."""
+    import logging
+    import run as run_module
+
+    body = {"body": f"prefix {_SYNTH_SK_ANT} suffix"}
+    caplog.set_level(logging.ERROR, logger=run_module.log.name)
+    with pytest.raises(OutboundSecretError):
+        _scrub_outbound_payload(body)
+    log_text = " ".join(r.message for r in caplog.records if r.levelno >= logging.ERROR)
+    # The synthetic payload was many 'A's; no consecutive run of As
+    # should appear in the diagnostic.
+    assert "AAAA" not in log_text
+
+
+def test_scrub_diagnostic_distinguishes_multiple_pattern_hits(monkeypatch, caplog):
+    """When multiple patterns match (e.g. both github_token and
+    bearer_token in the same body), the diagnostic must report lengths
+    for each pattern separately — so the operator can see at a glance
+    which one was likely a false positive."""
+    import logging
+    import run as run_module
+
+    body = {"body": f"{_SYNTH_GHS} and {_SYNTH_BEARER}"}
+    caplog.set_level(logging.ERROR, logger=run_module.log.name)
+    with pytest.raises(OutboundSecretError):
+        _scrub_outbound_payload(body)
+    log_text = " ".join(r.message for r in caplog.records if r.levelno >= logging.ERROR)
+    assert "github_token" in log_text
+    assert "authorization_header" in log_text or "bearer_token" in log_text
+
+
+def test_scrub_diagnostic_reports_length_close_to_regex_minimum(monkeypatch, caplog):
+    """Prose false positives match near the regex minimum (e.g.
+    `Bearer <32-char-prose>`); real tokens are typically 40-100+
+    chars. The diagnostic length tells the two apart at a glance.
+    Verify the reported length matches the actual match length."""
+    import logging
+    import run as run_module
+
+    # Synthesize a minimum-length bearer match: "Bearer " + exactly 32 chars.
+    near_min = "Bearer " + ("A" * 32)
+    body = {"body": near_min}
+    caplog.set_level(logging.ERROR, logger=run_module.log.name)
+    with pytest.raises(OutboundSecretError):
+        _scrub_outbound_payload(body)
+    log_text = " ".join(r.message for r in caplog.records if r.levelno >= logging.ERROR)
+    # The full match includes "Bearer " + 32 As = 39 chars.
+    assert "lens=[39]" in log_text or "39" in log_text
+
+
+def test_exception_message_references_log_diagnostic(monkeypatch):
+    """The exception message itself should point the operator to the
+    preceding log line for length details — readers of the exception
+    alone (without log access) shouldn't have to guess where to look."""
+    body = {"body": _SYNTH_GHS}
+    with pytest.raises(OutboundSecretError) as excinfo:
+        _scrub_outbound_payload(body)
+    msg = str(excinfo.value)
+    assert "preceding log" in msg or "log line" in msg
+
+
+# ─── Existing gh_api end-to-end ──────────────────────────────────
+
+
 def test_gh_api_refuses_to_send_payload_with_anthropic_key(monkeypatch):
     """If a body with a leaked token reaches gh_api, the request must
     be aborted before any network call. urlopen would have to NOT be


### PR DESCRIPTION
## Summary

The v1.6.4 outbound-body scrubber fails closed on credential-shape matches. The failure is the safe behavior; the missing piece was diagnostics — when the scrubber tripped, the operator knew WHICH pattern matched but not WHICH content triggered it. Triage was equivalent to flying blind.

This PR adds per-pattern match-length logging at ERROR level before the `OutboundSecretError` raises. The match LENGTHS are the load-bearing piece: real GitHub installation tokens are ~80 chars, PATs ~93 chars, JWTs 100+ chars; prose false positives match near the regex minimum (32-40 chars on the bearer pattern). Length-per-pattern is enough to triage prose-vs-token at a glance.

## No-leak property preserved

The matched bytes themselves are **never logged** — only the JSON path, the pattern name, and the match length. A diagnostic log line that propagated the credential further would defeat the entire defense. Tested explicitly: a synthetic `AAAA...`-padded payload doesn't appear in the diagnostic.

## Example output

When a body field trips both `github_token` and `bearer_token`:

```
ERROR  outbound-payload scrubber matched at field 'body': github_token(lens=[40]), bearer_token(lens=[68]); refusing to send
```

Reading at a glance: the github_token match is exactly 40 chars (likely a real `ghs_` install token); the bearer_token match is 68 chars (likely a real bearer). Or: both at lengths near 32-40 → likely prose false positive.

## Test plan

- [x] 5 new tests in `tests/test_outbound_secret_scrubber.py` (now 27 total in that file, was 22):
  - Diagnostic emitted at ERROR with pattern name + lengths
  - Diagnostic doesn't leak match content (synthetic 'A'-padded match)
  - Multiple-pattern hits reported separately
  - Reported length matches actual match length
  - Exception message references the log line for length details
- [x] Full suite: 533 pass (was 528, +5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)