### PR TITLE
Canonical agent-instruction-file set in the orientation block (arXiv:2606.13449)

### DIFF
--- a/src/instruction_files.py
+++ b/src/instruction_files.py
@@ -1,0 +1,125 @@
+"""Canonical agent-instruction-file discovery for the orientation pass.
+
+Adapted from *Toward Instructions-as-Code: Understanding the Impact of
+Instruction Files on Agentic Pull Requests* (arXiv:2606.13449). Analyzing
+15,549 agentic PRs across 148 projects, that paper finds two things: the
+mere *presence* of instruction files does not reliably improve merge rate
+(27.7% of projects improved, 26.35% regressed), but the projects that did
+improve ship instruction files that are **substantially longer** and
+**structured into more sections and sub-sections**. The takeaway the
+authors name "Instructions-as-Code" is that it is the structural quality of
+the guidance an agent receives — not its bare existence — that correlates
+with better pull requests.
+
+Outrider's implementation pass already injects a target repo's contributor
+guides into the Claude Code prompt, but it looked for only a hand-picked
+subset (``CLAUDE.md``, ``AGENTS.md``, ``CONTRIBUTING.md``, ``CONTEXT.md``).
+This module ports the paper's *result*, not a model or training procedure:
+
+  1. It completes the **canonical set** of agent-instruction files the study
+     and the major coding-agent vendors treat as authoritative, adding
+     ``.cursorrules`` (Cursor) and ``.github/copilot-instructions.md``
+     (GitHub Copilot). Repos without these files are unaffected — the
+     discovery contract stays "file present in workdir → read/truncate".
+  2. It exposes the per-file **structural signal** the paper found
+     predictive (length in lines, count of markdown sections), so the
+     orientation block can carry that signal forward rather than discarding
+     it.
+
+Everything here is read from files already on disk in the workdir — no new
+instrumentation, matching the orientation pass's existing I/O contract.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Canonical agent-instruction files, ordered precedence-from-most-specific:
+# per-agent files first, then generic agentic conventions, then human
+# contributor docs, then team-direction context. The original set was
+# CLAUDE / AGENTS / CONTRIBUTING / CONTEXT; this extends it with the
+# cross-vendor instruction files the Instructions-as-Code study treats as
+# canonical. The relative order of the original four is preserved so the
+# agent's context-window position for each guide is stable across runs.
+CANONICAL_INSTRUCTION_FILES: tuple[str, ...] = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".cursorrules",
+    ".github/copilot-instructions.md",
+    "CONTRIBUTING.md",
+    "CONTEXT.md",
+)
+
+# An ATX markdown heading: leading hashes (any level) then a space then text.
+# Used as the paper's "section / sub-section" proxy.
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+\S")
+
+
+def discover_instruction_files(workdir: Path) -> list[Path]:
+    """Return the canonical instruction files that exist in ``workdir``.
+
+    Result is in :data:`CANONICAL_INSTRUCTION_FILES` precedence order, with
+    absent files silently skipped. Relative names with a path separator
+    (e.g. ``.github/copilot-instructions.md``) resolve under ``workdir``.
+    """
+    found: list[Path] = []
+    for name in CANONICAL_INSTRUCTION_FILES:
+        path = workdir / name
+        if path.is_file():
+            found.append(path)
+    return found
+
+
+def section_count(body: str) -> int:
+    """Count markdown headings — the paper's structure proxy.
+
+    Counts ATX headings at any level (``#`` … ``######``), so both sections
+    and sub-sections contribute, matching the paper's "higher number of
+    sections and sub-sections" structural measure.
+    """
+    return sum(1 for line in body.splitlines() if _HEADING_RE.match(line))
+
+
+def structural_summary(body: str) -> str:
+    """One-line Instructions-as-Code structural signal for an instruction file.
+
+    Renders the two dimensions the paper found predictive of merge-rate
+    improvement: length (in lines) and section count. Returns "" for an
+    empty body so callers can omit the annotation cleanly.
+    """
+    body = body.strip()
+    if not body:
+        return ""
+    lines = body.count("\n") + 1
+    sections = section_count(body)
+    line_word = "line" if lines == 1 else "lines"
+    section_word = "section" if sections == 1 else "sections"
+    return f"_{lines} {line_word} · {sections} {section_word}_"
+
+
+def render_instruction_files(workdir: Path, cap: int = 3000) -> str:
+    """Read the canonical instruction files and render them as one block.
+
+    Each present file becomes a ``### `<name>``` chunk: a structural-signal
+    line (length + section count, per the Instructions-as-Code finding)
+    followed by the file body truncated to ``cap`` characters. Files are
+    emitted in :data:`CANONICAL_INSTRUCTION_FILES` precedence order; empty or
+    unreadable files are skipped. Returns "" when no canonical file is
+    present, so callers can omit the section entirely.
+    """
+    chunks: list[str] = []
+    for path in discover_instruction_files(workdir):
+        try:
+            body = path.read_text(errors="replace").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        name = path.relative_to(workdir).as_posix()
+        snippet = body[:cap] + ("\n…[truncated]" if len(body) > cap else "")
+        summary = structural_summary(body)
+        header = f"### `{name}`"
+        if summary:
+            header = f"{header}\n{summary}"
+        chunks.append(f"{header}\n\n{snippet}")
+    return "\n\n".join(chunks)

--- a/src/run.py
+++ b/src/run.py
@@ -74,6 +74,7 @@ from exploration_structure import (
     exploration_structure_from_events,
     structure_enabled,
 )
+from instruction_files import render_instruction_files
 
 # ─── Configuration ─────────────────────────────────────────────────────────
 
@@ -3084,30 +3085,23 @@ def detect_package_name(workdir: Path) -> str:
 
 
 def _orient_contributor_guides(workdir: Path, cap: int = 3000) -> str:
-    """Read contributor-guide files; concatenate and truncate to ``cap``.
+    """Read the canonical agent-instruction files; concatenate, truncate to ``cap``.
 
-    Includes ``CONTEXT.md`` for repos that ship it: it carries
-    team-direction signal (active investigation areas, stable
-    architecture, out-of-scope boundaries) that the implementation
-    pass can use alongside style-shaped guides like ``CLAUDE.md`` and
-    ``AGENTS.md``. Order is precedence-from-most-specific: per-agent
-    files first, then generic agentic conventions, then human
-    contributor docs, then team-direction context.
+    Covers the full canonical set documented by the Instructions-as-Code
+    study and the major coding-agent vendors — per-agent files
+    (``CLAUDE.md``, ``AGENTS.md``, ``.cursorrules``,
+    ``.github/copilot-instructions.md``), then human contributor docs
+    (``CONTRIBUTING.md``), then team-direction context (``CONTEXT.md``,
+    which carries active investigation areas, stable architecture, and
+    out-of-scope boundaries). Order is precedence-from-most-specific so the
+    agent's context-window position for each guide is stable across runs.
+    Each chunk is annotated with a structural-signal line (length + section
+    count), the dimension the study found predictive of merge-rate gains.
+
+    Delegates to :mod:`instruction_files`; repos without these files are
+    unaffected (empty string out).
     """
-    chunks: list[str] = []
-    for name in ("CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md", "CONTEXT.md"):
-        path = workdir / name
-        if not path.is_file():
-            continue
-        try:
-            body = path.read_text(errors="replace").strip()
-        except OSError:
-            continue
-        if not body:
-            continue
-        snippet = body[:cap] + ("\n…[truncated]" if len(body) > cap else "")
-        chunks.append(f"### `{name}`\n\n{snippet}")
-    return "\n\n".join(chunks)
+    return render_instruction_files(workdir, cap=cap)
 
 
 def _orient_pr_template(workdir: Path, cap: int = 2000) -> str:

--- a/tests/test_instruction_files.py
+++ b/tests/test_instruction_files.py
@@ -1,0 +1,139 @@
+"""Tests for canonical agent-instruction-file discovery in the orientation pass.
+
+Outrider's orientation pass injects a target repo's instruction files into the
+Claude Code prompt. Following *Toward Instructions-as-Code* (arXiv:2606.13449)
+— which finds that the canonical set of instruction files, and especially
+their length/section structure, correlates with agentic-PR merge rate — the
+canonical set is completed (`.cursorrules`, `.github/copilot-instructions.md`)
+and each file is annotated with a structural-signal line.
+
+Covers:
+  - `instruction_files` discovers/renders the full canonical set in order
+  - `section_count` / `structural_summary` compute the paper's structure proxy
+  - The wiring: `run._orient_contributor_guides` (the existing call site) and
+    `run._collect_repo_orientation` surface the newly-added canonical files
+
+Run with: pytest tests/test_instruction_files.py -q
+"""
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import instruction_files  # noqa: E402
+import run  # noqa: E402
+from run import Target  # noqa: E402
+
+
+# ─── instruction_files module ──────────────────────────────────────────────
+
+
+def test_discover_returns_canonical_files_in_precedence_order(tmp_path: Path) -> None:
+    (tmp_path / "CLAUDE.md").write_text("# Claude\n")
+    (tmp_path / "AGENTS.md").write_text("# Agents\n")
+    (tmp_path / ".cursorrules").write_text("be terse\n")
+    gh = tmp_path / ".github"
+    gh.mkdir()
+    (gh / "copilot-instructions.md").write_text("# Copilot\n")
+    (tmp_path / "CONTRIBUTING.md").write_text("# Contributing\n")
+    (tmp_path / "CONTEXT.md").write_text("# Context\n")
+
+    names = [
+        p.relative_to(tmp_path).as_posix()
+        for p in instruction_files.discover_instruction_files(tmp_path)
+    ]
+
+    assert names == [
+        "CLAUDE.md",
+        "AGENTS.md",
+        ".cursorrules",
+        ".github/copilot-instructions.md",
+        "CONTRIBUTING.md",
+        "CONTEXT.md",
+    ]
+
+
+def test_discover_skips_absent_files(tmp_path: Path) -> None:
+    (tmp_path / ".cursorrules").write_text("only this\n")
+    found = instruction_files.discover_instruction_files(tmp_path)
+    assert [p.name for p in found] == [".cursorrules"]
+
+
+def test_section_count_counts_atx_headings() -> None:
+    body = "# Top\nintro\n## Sub A\nx\n### Sub-sub\ny\nnot # a heading\n## Sub B\n"
+    assert instruction_files.section_count(body) == 4
+
+
+def test_structural_summary_reports_length_and_sections() -> None:
+    body = "# Title\n\n## Setup\nrun tests\n\n## Style\nbe terse\n"
+    summary = instruction_files.structural_summary(body)
+    assert "3 sections" in summary
+    assert "lines" in summary
+
+
+def test_structural_summary_empty_body_is_blank() -> None:
+    assert instruction_files.structural_summary("   \n  ") == ""
+
+
+def test_render_truncates_at_cap(tmp_path: Path) -> None:
+    (tmp_path / ".cursorrules").write_text("Z" * 10_000)
+    out = instruction_files.render_instruction_files(tmp_path, cap=400)
+    assert "…[truncated]" in out
+    assert len(out) < 1500
+
+
+def test_render_empty_when_no_canonical_files(tmp_path: Path) -> None:
+    assert instruction_files.render_instruction_files(tmp_path) == ""
+
+
+# ─── wiring: existing run.py call sites pick up the new canonical files ─────
+
+
+def test_orient_contributor_guides_reads_cursorrules_and_copilot(tmp_path: Path) -> None:
+    """The existing call site now surfaces the completed canonical set."""
+    (tmp_path / ".cursorrules").write_text("# Cursor rules\nPrefer small diffs.\n")
+    gh = tmp_path / ".github"
+    gh.mkdir()
+    (gh / "copilot-instructions.md").write_text(
+        "# Copilot instructions\nAlways add a test.\n"
+    )
+
+    body = run._orient_contributor_guides(tmp_path)
+
+    assert "`.cursorrules`" in body
+    assert "Prefer small diffs." in body
+    assert "`.github/copilot-instructions.md`" in body
+    assert "Always add a test." in body
+
+
+def test_orient_contributor_guides_annotates_structure(tmp_path: Path) -> None:
+    """Each instruction file carries the paper's structural-signal line."""
+    (tmp_path / "CLAUDE.md").write_text(
+        "# Guide\n\n## Build\nmake\n\n## Test\npytest\n"
+    )
+
+    body = run._orient_contributor_guides(tmp_path)
+
+    assert "`CLAUDE.md`" in body
+    assert "3 sections" in body  # one #, two ## headings
+
+
+def test_collect_repo_orientation_surfaces_copilot_instructions(tmp_path: Path) -> None:
+    """End-to-end through the orientation assembler: a repo whose only
+    instruction file is .github/copilot-instructions.md still gets it into
+    the orientation block."""
+    gh = tmp_path / ".github"
+    gh.mkdir()
+    (gh / "copilot-instructions.md").write_text(
+        "# Copilot\nFollow the house style.\n"
+    )
+
+    with patch.object(run, "_orient_recent_merged_prs", return_value=""):
+        body = run._collect_repo_orientation(
+            tmp_path, Target(repo="", interest_id="iid"), "demo_pkg"
+        )
+
+    assert "Contributor guides" in body
+    assert "`.github/copilot-instructions.md`" in body
+    assert "Follow the house style." in body


### PR DESCRIPTION
## Summary

Extends `_orient_contributor_guides` to cover the full canonical set of agent-instruction files the *Instructions-as-Code* study (arXiv:2606.13449) identifies as authoritative across major coding-agent vendors. The previous list (CLAUDE.md, AGENTS.md, CONTRIBUTING.md, CONTEXT.md, added in v1.6.5) is extended with the two cross-vendor files the study analyzed against 15,549 agentic PRs:

- `.cursorrules` (Cursor)
- `.github/copilot-instructions.md` (GitHub Copilot)

Also adds the per-file **structural signal** the paper found predictive of merge-rate gains: length (lines) and section count (markdown heading count). Each chunk in the orientation block now carries this signal forward rather than discarding it, so the agent's context-window position for each guide carries the structural metadata too.

## What the paper actually finds

Analyzing 15,549 agentic PRs across 148 projects: 27.7% of projects increased their merge rate by ≥20% after adopting instruction files; 26.35% decreased it. The discriminator isn't presence — it's **structural quality**: projects that improved ship instruction files that are substantially longer AND structured into more sections / sub-sections. The paper names this framing "Instructions-as-Code."

This PR ports the analytical result: it doesn't try to enforce a structural quality bar, but it surfaces the per-file structure signal (length + section count) so downstream consumers can read it.

## Constraints honored

- **No new instrumentation** — reads files already on disk in the workdir, matching the orientation pass's existing I/O contract
- **Backwards compatible** — repos without these new files are unaffected; the discovery contract stays "file present → read/truncate"
- **Order preserved** — the original four files (CLAUDE / AGENTS / CONTRIBUTING / CONTEXT) keep their relative order so the agent's context-window position for each guide is stable across runs

## Structure

- `src/instruction_files.py` — new module (`CANONICAL_INSTRUCTION_FILES`, `discover_instruction_files`, `section_count`, `render_instruction_files`)
- `src/run.py` — `_orient_contributor_guides` now delegates to the new module
- `tests/test_instruction_files.py` — coverage for the new module
- `tests/test_orientation.py` — existing tests updated for the broader file set

## Test plan

- [x] 10 new tests in `tests/test_instruction_files.py`
- [x] Existing orientation tests updated for the broader set
- [x] Full suite: 543 pass (was 533)

🤖 Generated with [Claude Code](https://claude.com/claude-code)