### PR TITLE
Narrow redaction rules in self-review + pre-flight prompts (REMYX-129 Follow-up 1)

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -527,6 +527,29 @@ Route to ISSUE only if any of these is likely true of THAT scoped slice:
 
 Otherwise route to PR.
 
+NEVER include token-shaped strings in any JSON field — the JSON you
+write here flows verbatim into a public-repo PR or Issue body, and a
+credential pattern in that body aborts the run via the outbound
+scrubber. Specifically:
+
+  - If a tool result contains an `Authorization:` header (e.g. from
+    `curl -v`, `wget -d`, or any HTTP-debug output), do not quote the
+    header verbatim. Describe what the call did instead.
+  - If `git config --list` or a similar command exposes
+    `http.https://github.com/.extraheader`, do not include the value
+    in any field.
+  - Do not run `env`, `printenv`, or `cat` against any `.env`,
+    `credentials*`, or `*.key` file. If you happen to see such content
+    in tool output, do not quote it.
+  - If any string in any tool result looks like a credential (starts
+    with `sk-ant-`, `ghp_`, `ghs_`, `gho_`, `gha_`, `github_pat_`, or
+    `rmxu_`; or matches `Bearer` followed by 32+ random characters),
+    replace it with `[REDACTED]` before including any surrounding
+    context in your output.
+
+Honest summarization of what tools did is fine and encouraged; only
+verbatim quotes of headers / env values / tokens are forbidden.
+
 Output a single JSON object. Start with `{` and end with `}`. No
 Markdown fences, no prose before or after. Schema:
 
@@ -953,6 +976,29 @@ a CLI, an existing module) now invokes your new code, set is_orphan=false.
 Separately, list under scoped_out the parts of the paper you deliberately
 left for later (e.g. a trainer/model the repo can't host) — you are not
 required to reproduce the paper's full method, only to deliver its result.
+
+NEVER include token-shaped strings in any JSON field — the JSON you
+write here flows verbatim into a public-repo PR or Issue body, and a
+credential pattern in that body aborts the run via the outbound
+scrubber. Specifically:
+
+  - If a tool result contains an `Authorization:` header (e.g. from
+    `curl -v`, `wget -d`, or any HTTP-debug output), do not quote the
+    header verbatim. Describe what the call did instead.
+  - If `git config --list` or a similar command exposes
+    `http.https://github.com/.extraheader`, do not include the value
+    in any field.
+  - Do not run `env`, `printenv`, or `cat` against any `.env`,
+    `credentials*`, or `*.key` file. If you happen to see such content
+    in tool output, do not quote it.
+  - If any string in any tool result looks like a credential (starts
+    with `sk-ant-`, `ghp_`, `ghs_`, `gho_`, `gha_`, `github_pat_`, or
+    `rmxu_`; or matches `Bearer` followed by 32+ random characters),
+    replace it with `[REDACTED]` before including any surrounding
+    context in your output.
+
+Honest summarization of what tools did is fine and encouraged; only
+verbatim quotes of headers / env values / tokens are forbidden.
 
 --- Diff ---
 

--- a/tests/test_prompt_redaction_rules.py
+++ b/tests/test_prompt_redaction_rules.py
@@ -1,0 +1,139 @@
+"""Tests for the narrow redaction rules in the self-review + pre-flight prompts (REMYX-129 Follow-up 1).
+
+The self-review and pre-flight one-shot passes produce JSON whose
+fields flow verbatim into the PR / Issue body. If those fields
+include verbatim tool-output that contained an Authorization header,
+env-var dump, or token-shaped string, that text lands in a
+public-repo body via the GitHub API.
+
+The v1.6.4 outbound scrubber catches credential-shaped content at
+egress and the v1.6.7 env-strip stops most secrets from being
+reachable by the agent's subprocess in the first place. Both are
+load-bearing. This prompt-level layer is **belt-and-suspenders** — it
+asks the model to redact known shapes before writing the JSON, so the
+common case (model summarizing what tools did) doesn't have to rely
+on the egress scrubber to catch a token quote.
+
+The rules are deliberately NARROW: forbid the specific bad output
+(token shapes / Authorization headers / env-var dumps), not the
+broader category of tool usage. Honest summarization of what tools
+did stays encouraged.
+
+Run with: pytest tests/test_prompt_redaction_rules.py -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# Both prompts share the same redaction rules so tests can pin both
+# at once via parametrize.
+_PROMPTS = {
+    "self_review": run._SELF_REVIEW_PROMPT_TEMPLATE,
+    "preflight":   run._PREFLIGHT_PROMPT_TEMPLATE,
+}
+
+
+# ─── Each prompt includes the redaction section ──────────────────
+
+
+def test_self_review_has_redaction_section():
+    assert "NEVER include token-shaped strings" in _PROMPTS["self_review"]
+
+
+def test_preflight_has_redaction_section():
+    assert "NEVER include token-shaped strings" in _PROMPTS["preflight"]
+
+
+# ─── Each prompt names the four canonical redaction targets ──────
+
+
+def test_each_prompt_names_authorization_header_rule():
+    """The Authorization-header rule is the most-common false-positive
+    source per the v1.6.4 scrubber experience; both prompts must name
+    it explicitly so the model knows the failure mode."""
+    for name, prompt in _PROMPTS.items():
+        assert "Authorization" in prompt, f"missing in {name}"
+        assert "curl -v" in prompt, f"curl -v not cited in {name}"
+
+
+def test_each_prompt_names_git_extraheader_rule():
+    """`git config --list` exposing `http.https://github.com/.extraheader`
+    is a real leak vector from prior incidents; both prompts must
+    name it so the model recognizes the specific value to skip."""
+    for name, prompt in _PROMPTS.items():
+        assert "git config --list" in prompt, f"missing in {name}"
+        assert "extraheader" in prompt, f"extraheader not cited in {name}"
+
+
+def test_each_prompt_forbids_env_dumping():
+    """Forbid `env` / `printenv` / `cat` on credentials files. Each is
+    a routine command the agent might reach for that has no legitimate
+    use during selection / self-review."""
+    for name, prompt in _PROMPTS.items():
+        assert "printenv" in prompt, f"missing in {name}"
+        assert ".env" in prompt, f".env not cited in {name}"
+
+
+def test_each_prompt_names_token_prefixes():
+    """The token-shape prefixes name the credential families the agent
+    is most likely to encounter (Anthropic, GitHub variants, Remyx).
+    Without these, the model has to recognize tokens by shape — naming
+    the prefixes makes the rule mechanical."""
+    for name, prompt in _PROMPTS.items():
+        for prefix in ("sk-ant-", "ghp_", "ghs_", "rmxu_", "github_pat_"):
+            assert prefix in prompt, f"prefix {prefix} missing in {name}"
+
+
+def test_each_prompt_directs_to_redact_marker():
+    """The redaction target is `[REDACTED]` — a specific marker that
+    won't itself match any scrubber pattern. The prompt names this
+    explicitly so the model uses the agreed-upon convention."""
+    for name, prompt in _PROMPTS.items():
+        assert "[REDACTED]" in prompt, f"missing in {name}"
+
+
+def test_each_prompt_allows_honest_summarization():
+    """The rules forbid verbatim quotes, NOT summarization. The prompt
+    explicitly preserves summarization so the model doesn't over-react
+    and produce useless 'I cannot describe what tools did' outputs."""
+    for name, prompt in _PROMPTS.items():
+        assert "summarization" in prompt or "summarize" in prompt, (
+            f"summarization not preserved in {name}"
+        )
+
+
+# ─── Rule scope: narrow, not broad ───────────────────────────────
+
+
+def test_no_prompt_forbids_all_tool_output_quoting():
+    """The original Follow-up 1 sketch suggested forbidding all
+    verbatim tool-output quoting. That's too broad — it breaks
+    legitimate summarization (test counts, file paths, error
+    messages). Pin against that scope creeping back in."""
+    for name, prompt in _PROMPTS.items():
+        # Verify the prompt does NOT contain the broad forbid.
+        assert "no verbatim tool output" not in prompt.lower(), (
+            f"broad rule sneaked into {name}"
+        )
+
+
+def test_no_prompt_forbids_env_var_references():
+    """The agent legitimately discusses code that READS env vars
+    (customer repos commonly use `os.environ.get(...)`). Forbidding
+    all env-var references would break those discussions. The narrow
+    rule forbids `env` / `printenv` (the *commands*) — not the
+    *concept* of env vars."""
+    for name, prompt in _PROMPTS.items():
+        # Verify the prompt does NOT broadly forbid env-var references.
+        for bad in [
+            "do not reference any environment variable",
+            "do not mention environment variables",
+            "do not discuss env vars",
+        ]:
+            assert bad not in prompt.lower(), (
+                f"too-broad rule sneaked into {name}: {bad!r}"
+            )


### PR DESCRIPTION
## Summary

The self-review and pre-flight one-shot passes produce JSON whose fields flow verbatim into PR / Issue bodies. If those fields include tool-output that captured an `Authorization` header, env-var dump, or token-shaped string, that text lands in a public-repo body via the GitHub API.

The v1.6.4 outbound scrubber catches credential-shaped content at egress; the v1.6.7 env-strip stops most secrets from being reachable by the agent's subprocess. Both are load-bearing. This prompt-level layer is **belt-and-suspenders** — asks the model to redact known shapes before writing the JSON, so the common case (model summarizing what tools did) doesn't depend on the egress scrubber to catch a token quote.

## Narrow scope

Forbid the specific bad output, not the broader category of tool usage:

- Authorization headers from `curl -v` / `wget -d` / HTTP-debug output (describe the call, do not quote)
- `git config --list` exposing `http.https://github.com/.extraheader`
- `env` / `printenv` / `cat` on `.env`, `credentials*`, `*.key` files
- Token-shape prefixes (`sk-ant-`, `ghp_`, `ghs_`, `gho_`, `gha_`, `github_pat_`, `rmxu_`, `Bearer X32+`) — replace with `[REDACTED]`

Honest summarization of what tools did stays encouraged.

## Why these two prompts only

- **Self-review + pre-flight** — JSON output goes verbatim into the PR/Issue body. Highest leverage for the change.
- **Selection-pass NOT modified** — its output passes through verification logic that strips it back to a small set of fields; less risk.
- **Implementation-pass NOT modified** — writes code, not body content. Rules there could marginally interfere with legitimate code generation (e.g. customer repos that legitimately use Bearer auth in an API client).

## Test plan

- [x] 10 new tests in `tests/test_prompt_redaction_rules.py`:
  - Both prompts contain the redaction section
  - Both name the four canonical redaction targets (Authorization, extraheader, .env, token prefixes)
  - Both use the agreed `[REDACTED]` marker
  - Both preserve "honest summarization is encouraged"
  - **Scope-creep guards**: explicit assertions that broader formulations ("no verbatim tool output", "do not reference any environment variable") have NOT sneaked back in
- [x] Full suite: 566 pass (was 556, +10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)