### PR TITLE
Restore workflow GITHUB_TOKEN to agent subprocess env (REMYX-131 Path B)

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -3650,10 +3650,12 @@ def _record_claude_usage(env: dict) -> None:
 # inherits whatever env we pass; if we passed `os.environ` verbatim, the
 # agent's tool calls (Bash, `printenv`, `git config --list`, `curl -v`)
 # could echo secrets the parent runner holds — REMYX_API_KEY,
-# GITHUB_TOKEN / INPUT_GITHUB_TOKEN, INPUT_* action inputs, GITHUB_ACTOR,
-# etc. Stripping at the launch boundary stops secrets from entering the
-# agent's context in the first place; pairs with v1.6.4's outbound-body
-# scrubber (which catches secrets at egress).
+# INPUT_GITHUB_TOKEN (the bot's installation token), INPUT_* action
+# inputs, GITHUB_ACTOR, etc. Stripping at the launch boundary stops
+# those from entering the agent's context in the first place; pairs
+# with v1.6.4's outbound-body scrubber (catches secrets at egress),
+# v1.6.8's per-pattern diagnostic logging, and v1.6.10's narrow
+# prompt-level redaction rules.
 #
 # Whitelist contains only what the CLI legitimately needs:
 #   - Auth: ANTHROPIC_API_KEY (required), plus optional ANTHROPIC_BASE_URL
@@ -3663,6 +3665,34 @@ def _record_claude_usage(env: dict) -> None:
 #   - Temp dirs: TMPDIR / TMP / TEMP
 #   - XDG paths for the CLI's per-user state
 #   - CI sentinels (CI, GITHUB_ACTIONS) — informational, carry no secrets
+#   - GitHub auth for the agent's `gh` CLI verification tools — see
+#     REMYX-131 / Path B below
+#
+# GITHUB_TOKEN (the workflow's built-in runner token, NOT the bot's
+# installation token) is included so the selection-pass agent's `gh`
+# CLI invocations (gh code-search, gh issue list, gh api repos/.../
+# contents/..., gh issue view) can authenticate. Without it, the agent
+# falls back to unauthenticated GitHub API at 60 req/hr per shared
+# runner IP and can't view private-repo content at all — observed
+# verification-quality degradation in the 2026-06-17 v1.6.10 dispatch
+# whose selection_reasoning explicitly noted "Search and issue tools
+# are unauthenticated here."
+#
+# Trade-off: the workflow GITHUB_TOKEN is repo-scoped (the agent
+# can't reach other repos with it) but its scope is set by the
+# workflow's `permissions:` block, which currently includes
+# `pull-requests: write` / `issues: write`. That's broader than
+# read-only verification needs, and the leak vector is real if the
+# agent echoes the value verbatim. We accept the trade-off because
+# the egress defenses landed in v1.6.4 / v1.6.8 / v1.6.10 catch the
+# echo at multiple layers, and the bot's installation token (via
+# INPUT_GITHUB_TOKEN) stays stripped — the agent never sees the
+# higher-privilege cross-repo token the orchestrator uses for PR /
+# Issue creation.
+#
+# REMYX-131 Path A (engine-side scoped read-only token mint) is the
+# principled long-term fix; this whitelist entry is the Path B fast
+# unblock pending that work.
 #
 # If a Claude CLI feature legitimately requires a new env var, add it
 # explicitly with a comment naming the case. Don't broaden to `ANTHROPIC_*`
@@ -3689,6 +3719,11 @@ _CLAUDE_ENV_WHITELIST: tuple[str, ...] = (
     "XDG_CACHE_HOME",
     "CI",
     "GITHUB_ACTIONS",
+    # Workflow built-in token — repo-scoped — for the agent's `gh`
+    # verification tooling. NOT the bot's installation token (that
+    # arrives via INPUT_GITHUB_TOKEN, which stays stripped). See the
+    # comment block above for the trade-off rationale.
+    "GITHUB_TOKEN",
 )
 
 

--- a/tests/test_claude_subprocess_env.py
+++ b/tests/test_claude_subprocess_env.py
@@ -71,10 +71,24 @@ def test_whitelist_excludes_remyx_api_key():
     assert "REMYX_API_KEY" not in run._CLAUDE_ENV_WHITELIST
 
 
-def test_whitelist_excludes_github_token():
-    """The GitHub installation token is the bot's PR/Issue auth — needed
-    by the orchestrator (gh_api) but never by the agent's subprocess."""
-    assert "GITHUB_TOKEN" not in run._CLAUDE_ENV_WHITELIST
+def test_whitelist_includes_workflow_github_token():
+    """The workflow's built-in GITHUB_TOKEN is allowed through so the
+    selection-pass agent's `gh` CLI invocations can authenticate
+    (REMYX-131 Path B). Without it, the agent falls back to
+    unauthenticated GitHub API at 60 req/hr per shared runner IP and
+    can't view private-repo content. Trade-off justified by the
+    egress defenses (v1.6.4 scrubber + v1.6.8 diagnostic + v1.6.10
+    prompt redaction)."""
+    assert "GITHUB_TOKEN" in run._CLAUDE_ENV_WHITELIST
+
+
+def test_whitelist_excludes_bot_installation_token():
+    """The bot's installation token arrives via INPUT_GITHUB_TOKEN
+    (the orchestrator uses it for PR/Issue creation through gh_api).
+    The agent must NOT see this token — it's strictly more
+    privileged than the workflow built-in (cross-repo, write scopes
+    the bot was granted). Keeping it stripped preserves the
+    least-privilege principle even after restoring GITHUB_TOKEN."""
     assert "INPUT_GITHUB_TOKEN" not in run._CLAUDE_ENV_WHITELIST
 
 
@@ -90,14 +104,24 @@ def test_whitelist_excludes_action_inputs():
 
 
 def test_whitelist_excludes_github_metadata_vars():
-    """GITHUB_* identifies the runner, the actor, and ship history. These
-    aren't secrets per se but they don't belong in the agent's env either;
-    legitimate cases (repo identity) are passed through prompt context."""
+    """Most GITHUB_* vars identify the runner, the actor, and ship
+    history. They aren't secrets per se but they don't belong in the
+    agent's env either; legitimate cases (repo identity) are passed
+    through prompt context.
+
+    Two exceptions are allowed: ``GITHUB_ACTIONS`` (informational CI
+    sentinel) and ``GITHUB_TOKEN`` (workflow built-in token for the
+    agent's ``gh`` CLI verification tooling — see the
+    ``test_whitelist_includes_workflow_github_token`` test for the
+    rationale)."""
+    allowed_github_prefix = {"GITHUB_ACTIONS", "GITHUB_TOKEN"}
     for name in run._CLAUDE_ENV_WHITELIST:
-        assert not name.startswith("GITHUB_") or name == "GITHUB_ACTIONS", (
-            f"GITHUB_* var {name!r} in whitelist (other than GITHUB_ACTIONS "
-            f"sentinel) — these should be stripped"
-        )
+        if name.startswith("GITHUB_"):
+            assert name in allowed_github_prefix, (
+                f"GITHUB_* var {name!r} in whitelist (not one of the "
+                f"two intentional exceptions {allowed_github_prefix}) "
+                f"— these should be stripped"
+            )
 
 
 # ─── _claude_subprocess_env: builds the minimal env dict ─────────
@@ -111,8 +135,9 @@ def test_subprocess_env_returns_only_whitelisted(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     monkeypatch.setenv("HOME", "/home/runner")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_workflow_token")
     monkeypatch.setenv("REMYX_API_KEY", "rmxu_secret")
-    monkeypatch.setenv("GITHUB_TOKEN", "ghs_secret")
+    monkeypatch.setenv("INPUT_GITHUB_TOKEN", "ghs_bot_installation_token")
     monkeypatch.setenv("INPUT_INTEREST_ID", "uuid-here")
     monkeypatch.setenv("RANDOM_UNRELATED_VAR", "should-not-appear")
 
@@ -122,10 +147,14 @@ def test_subprocess_env_returns_only_whitelisted(monkeypatch):
     assert env["ANTHROPIC_API_KEY"] == "sk-test-key"
     assert env["PATH"] == "/usr/bin:/bin"
     assert env["HOME"] == "/home/runner"
+    # Workflow GITHUB_TOKEN is whitelisted for the agent's `gh` CLI auth
+    # (REMYX-131 Path B). The bot's installation token (via
+    # INPUT_GITHUB_TOKEN) stays stripped.
+    assert env["GITHUB_TOKEN"] == "ghs_workflow_token"
 
     # Forbidden vars absent.
     assert "REMYX_API_KEY" not in env
-    assert "GITHUB_TOKEN" not in env
+    assert "INPUT_GITHUB_TOKEN" not in env
     assert "INPUT_INTEREST_ID" not in env
 
     # Unknown vars absent (would-be-fine but shouldn't appear).
@@ -198,14 +227,20 @@ def test_run_claude_stream_passes_stripped_env(monkeypatch, tmp_path):
 
     monkeypatch.setattr(run.subprocess, "run", fake_run)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
-    monkeypatch.setenv("GITHUB_TOKEN", "ghs_should-not-leak")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_workflow_token")
+    monkeypatch.setenv("INPUT_GITHUB_TOKEN", "ghs_bot_installation_token")
     monkeypatch.setenv("INPUT_INTEREST_ID", "uuid")
 
     run._run_claude_stream(["claude"], "prompt", tmp_path, 60)
 
     assert captured["env"] is not None, "env= must be passed; got None"
     assert "ANTHROPIC_API_KEY" in captured["env"]
-    assert "GITHUB_TOKEN" not in captured["env"]
+    # Workflow GITHUB_TOKEN passes through for the agent's `gh` auth.
+    assert captured["env"]["GITHUB_TOKEN"] == "ghs_workflow_token"
+    # Bot installation token (via INPUT_GITHUB_TOKEN) and other INPUT_*
+    # action inputs stay stripped — they're strictly higher-privilege
+    # than the agent needs.
+    assert "INPUT_GITHUB_TOKEN" not in captured["env"]
     assert "INPUT_INTEREST_ID" not in captured["env"]
 
 
@@ -215,13 +250,20 @@ def test_run_claude_stream_passes_stripped_env(monkeypatch, tmp_path):
 def test_env_strip_complements_outbound_scrubber():
     """The env strip and the outbound scrubber are independent layers
     of defense — neither replaces the other. Verify both helpers
-    exist and the env strip doesn't accidentally include any of the
-    same secret patterns the scrubber catches at egress."""
+    exist and the env strip's TOKEN-shaped whitelist entries are
+    intentional (not accidental inclusions).
+
+    Two TOKEN-shaped entries are intentional:
+      - ANTHROPIC_API_KEY: the Claude CLI's auth requirement
+      - GITHUB_TOKEN: the workflow built-in for the agent's `gh` CLI
+        verification tooling (REMYX-131 Path B)
+    Any other TOKEN-shaped entry should be reviewed before landing."""
     assert hasattr(run, "_scrub_outbound_payload")
     assert hasattr(run, "_claude_subprocess_env")
-    # Sanity: the whitelist itself doesn't accidentally name something
-    # secret-shaped (would be a strange whitelist entry).
+    intentional_token_entries = {"ANTHROPIC_API_KEY", "GITHUB_TOKEN"}
     for name in run._CLAUDE_ENV_WHITELIST:
-        assert "TOKEN" not in name.upper() or name == "ANTHROPIC_API_KEY", (
-            f"Whitelist entry {name!r} looks token-shaped — review"
-        )
+        if "TOKEN" in name.upper() or "KEY" in name.upper():
+            assert name in intentional_token_entries, (
+                f"Whitelist entry {name!r} looks token-shaped but isn't on "
+                f"the intentional list {intentional_token_entries} — review"
+            )


### PR DESCRIPTION
## Summary

v1.6.7's Claude CLI subprocess env-strip stripped `GITHUB_TOKEN`, which had the unintended side effect of leaving the selection-pass agent's `gh` CLI invocations unauthenticated. The 2026-06-17 v1.6.10 dispatch surfaced the degradation explicitly in its selection_reasoning:

> "Search and issue tools are **unauthenticated here** and no accessible maintainer thread names an out-of-pool paper, so no out-of-pool pick clears the stricter bar."

The agent self-diagnosed but reached for a stricter verification bar than it would have with authenticated `gh` — pushing extension-archetype picks to fall back to skip when a maintainer thread might have provided the signal needed.

This restores **`GITHUB_TOKEN`** (the workflow built-in, NOT the bot's installation token) to `_CLAUDE_ENV_WHITELIST`.

## What's NOT changing

- The bot's installation token (via `INPUT_GITHUB_TOKEN`) **stays stripped** — strictly more privileged than the workflow token (cross-installation, broader scopes the bot was granted). The agent has no legitimate use case for it. The orchestrator continues to use it via `gh_api` for PR / Issue creation.
- All other `INPUT_*` action inputs stay stripped.
- All `REMYX_*` env vars stay stripped.

## Trade-offs (documented in the comment block above the whitelist)

The leak vector v1.6.7 closed (agent's tool output capturing env content into PR body) is now mitigated by four layers of egress defense shipped earlier today:

1. v1.6.4 outbound-body scrubber refuses to send any payload whose string fields match credential shapes
2. v1.6.8 per-pattern match-length diagnostic logging
3. REMYX-129 Follow-up 3 (PR #55) — `aborted_secret_in_payload` status with step-summary + telemetry
4. REMYX-129 Follow-up 1 (PR #56) — narrow prompt redaction rules

Path A (engine-side scoped read-only token mint) is the principled long-term fix — gives the agent a token whose scopes are exactly what `gh` verification needs and no more. This PR is the **fast unblock Path B** pending that work.

## Test plan

- [x] 13 env-strip tests pass (1 renamed, 1 new, several updated for the new model where `GITHUB_TOKEN` is included but `INPUT_GITHUB_TOKEN` is excluded)
- [x] `test_env_strip_complements_outbound_scrubber` updated to recognize `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` as the two intentional token-shaped entries
- [x] Full suite: 588 pass (was 587, +1 from the new bot-token-exclusion test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)