### PR TITLE
Ship per-candidate code/license metadata in run telemetry

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -6025,6 +6025,32 @@ def _compact_selection_rejected_for_telemetry(
     return compact
 
 
+def _candidate_enrichment(candidates: "list[Recommendation]") -> list[dict]:
+    """Per-candidate code/model/license metadata for the run-telemetry payload.
+
+    Lets the recommendation service fill gaps in a paper's stored metadata from
+    what this run resolved. ``license_compat`` is omitted on purpose: it's
+    scored relative to the target repository, not a property of the paper.
+    Only candidates with a resolved code/model URL or license are included, to
+    keep the payload small.
+    """
+    out = []
+    for c in candidates:
+        if not c.arxiv_id:
+            continue
+        if not (c.paper_github_url or c.paper_huggingface_url or c.paper_license):
+            continue
+        out.append({
+            "arxiv_id": c.arxiv_id,
+            "github": c.paper_github_url or "",
+            "huggingface": c.paper_huggingface_url or "",
+            "paper_license": c.paper_license or "",
+            "license_source": c.license_source or "",
+            "license_class": c.license_class or "",
+        })
+    return out
+
+
 def _resolve_external_candidate(selection: dict) -> "Recommendation | None":
     """Construct a synthetic Recommendation from the selection pass's
     external_* fields. Used when chosen_index = -2 — selection surfaced
@@ -6229,6 +6255,10 @@ def process_target(target: Target) -> dict:
              f"(dropped {dropped_low_conf} low-confidence, "
              f"{dropped_pr_exists} open PRs, "
              f"{dropped_issue_exists} prior Issues)")
+
+    # Per-candidate code/model/license metadata for the run-telemetry payload.
+    # Set once here (viable is final) so every return path carries it.
+    result["candidate_enrichment"] = _candidate_enrichment(viable)
 
     # 4. Workdir + selection. Clone first (the selection pass needs the
     #    repo's module layout), then let Claude pick the candidate most
@@ -8732,6 +8762,7 @@ def _post_run_telemetry(result: dict, target: "Target") -> None:
         "candidates_considered": result.get("candidates_considered"),
         "refine_queries": result.get("refine_queries"),
         "license_class_counts": result.get("license_class_counts"),
+        "candidate_enrichment": result.get("candidate_enrichment"),
         "selection_reasoning_excerpt": reasoning[:2048] or None,
         "selection_integration_shape": result.get("selection_integration_shape"),
         "selection_coverage": result.get("selection_coverage"),

--- a/tests/test_candidate_enrichment.py
+++ b/tests/test_candidate_enrichment.py
@@ -1,0 +1,62 @@
+"""Tests for _candidate_enrichment — the per-candidate code/model/license
+metadata included in the run-telemetry payload.
+
+Run with: pytest tests/test_candidate_enrichment.py -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+from run import Recommendation  # noqa: E402
+
+
+def _rec(arxiv_id, *, github="", hf="", license_="", source="", lclass="unknown"):
+    return Recommendation(
+        paper_title=f"Paper {arxiv_id}",
+        arxiv_id=arxiv_id,
+        tier="high",
+        z_score=0.0,
+        spec_md="",
+        paper_abstract="",
+        domain_summary="",
+        raw_paper_md="",
+        relevance_score=0.9,
+        paper_github_url=github,
+        paper_huggingface_url=hf,
+        paper_license=license_,
+        license_source=source,
+        license_class=lclass,
+        license_compat=0.42,
+    )
+
+
+def test_maps_fields_and_omits_compat():
+    out = run._candidate_enrichment([
+        _rec("2606.1", github="https://github.com/a/b", license_="MIT",
+             source="github", lclass="permissive"),
+    ])
+    assert out == [{
+        "arxiv_id": "2606.1",
+        "github": "https://github.com/a/b",
+        "huggingface": "",
+        "paper_license": "MIT",
+        "license_source": "github",
+        "license_class": "permissive",
+    }]
+    # license_compat is target-relative, not a property of the paper.
+    assert "license_compat" not in out[0]
+
+
+def test_excludes_candidates_without_code_or_license():
+    out = run._candidate_enrichment([
+        _rec("2606.2", lclass="no-code-link"),             # nothing resolved
+        _rec("2606.3", hf="https://huggingface.co/o/m"),   # has a model URL
+    ])
+    assert [c["arxiv_id"] for c in out] == ["2606.3"]
+
+
+def test_skips_blank_arxiv_id():
+    out = run._candidate_enrichment([_rec("", github="https://github.com/a/b")])
+    assert out == []


### PR DESCRIPTION
# Ship per-candidate code/license metadata in run telemetry

Adds a `candidate_enrichment` list to the `/outrider/runs` telemetry payload so the recommendation service can fill gaps in a paper's stored metadata from what a run already resolved.

## Changes
- New `_candidate_enrichment(viable)` helper builds, per candidate: {arxiv_id, github, huggingface, paper_license, license_source, license_class}`.
  - Only candidates with a resolved code/model URL or license are included (keeps the payload small).
  - `license_compat` is intentionally omitted. It's scored relative to the target repository, not a property of the paper.
- Attached once to `result` where the viable set is final, so every outcome path (PR / Issue / skip) carries it; included in the `_post_run_telemetry` payload.
- Unit test: `tests/test_candidate_enrichment.py` (field mapping, compat omitted, exclusion of signal-less candidates, blank-id skip).

## Verification
A live run on a test repo shipped the field in the payload, and the recommendation service consumed it to backfill 20 papers' metadata.