### PR TITLE
Additional logging for agent output

### DIFF
--- a/scripts/calibrate_diff_risk.py
+++ b/scripts/calibrate_diff_risk.py
@@ -3,7 +3,7 @@
 
 Scores every `remyx-recommendation/*` branch in the local clone against its
 merge-base with `origin/main`, producing a Markdown table the maintainer can
-qualitatively review (REMYX-107 step 2). No customer impact; runs entirely
+qualitatively review. No customer impact; runs entirely
 against Outrider's own git history.
 
 Usage (from the repo root):

--- a/src/diff_risk_score.py
+++ b/src/diff_risk_score.py
@@ -120,7 +120,7 @@ def _is_critical(path: str) -> bool:
 #
 # The default mode (base_ref=None) reads from the working tree vs HEAD —
 # Outrider's runtime case where Claude Code's changes are uncommitted. For
-# scoring historical PR branches (REMYX-107 calibration), we instead want
+# scoring historical PR branches (calibration), we instead want
 # the diff between the branch HEAD and its merge-base with main, so the
 # helpers below switch to that comparison when a base_ref is supplied.
 
@@ -319,7 +319,7 @@ def score_diff_risk(
     Default mode (``base_ref=None``): scores the working-tree diff vs HEAD —
     Outrider's runtime case. Branch-vs-base mode (``base_ref`` is a SHA / ref
     name): scores HEAD vs ``base_ref`` — used to retrospectively score
-    historical PR branches against their merge-base (REMYX-107 calibration).
+    historical PR branches against their merge-base (calibration).
 
     Returns a :class:`DiffRisk` whose ``band`` drives the orchestrator's
     risk-aware routing. Pure function of the static diff — no Claude call,

--- a/src/run.py
+++ b/src/run.py
@@ -3743,6 +3743,36 @@ def _claude_subprocess_env() -> dict[str, str]:
     return env
 
 
+def _format_agent_cli_failure(
+    tool: str, returncode: int, stdout: str, stderr: str
+) -> str:
+    """Build an agent-CLI failure diagnostic that puts the real cause where it
+    survives truncation.
+
+    Provider-agnostic: ``tool`` is the CLI's program name (``claude`` today;
+    Aider / Goose / Codex / Copilot as they land), used only for labeling. On
+    a hard reject (usage limit, credit balance, auth) the agent CLI exits fast
+    with the cause on **stderr** and either nothing or a partial, unparseable
+    JSON fragment on stdout. Callers tail-slice this string
+    (``invoke_claude_code`` keeps the last 4KB, the orchestrator stores the
+    last 1KB into ``claude_log_tail``), so the stderr must land at the *end*
+    to survive truncation — otherwise bulky stdout crowds it out and the log
+    tail shows noise instead of the error.
+    """
+    stdout = (stdout or "").strip()
+    stderr = (stderr or "").strip()
+    parts = [f"[{tool} exited {returncode}, no JSON envelope parsed]"]
+    if stdout:
+        # stdout is usually noise / a partial fragment here; cap its head so
+        # it can't push the stderr out of the caller's tail-slice window.
+        head = stdout[:500]
+        if len(stdout) > 500:
+            head += " …(truncated)"
+        parts.append(f"--- STDOUT (head) ---\n{head}")
+    parts.append("--- STDERR ---\n" + (stderr or "(empty)"))
+    return "\n".join(parts)
+
+
 def _run_claude_json(
     cmd_prefix: list[str], prompt: str, cwd: Path, timeout_s: int
 ) -> tuple[bool, str]:
@@ -3775,14 +3805,18 @@ def _run_claude_json(
         _record_claude_usage(env)
         text = env.get("result") or ""
         is_error = bool(env.get("is_error")) or proc.returncode != 0
-        if not text and proc.stderr:
-            text = proc.stderr
+        # On error, always append the CLI stderr — the envelope's `result`
+        # often omits the operational cause (e.g. usage limit) that stderr
+        # carries. Skip if stderr is already echoed inside `result`.
+        if is_error and proc.stderr and proc.stderr.strip() not in text:
+            text = (text + "\n--- STDERR ---\n" + proc.stderr.strip()).strip()
         return (not is_error), text
-    # Envelope didn't parse — preserve old behavior, no usage recorded.
-    output = (proc.stdout or "") + (
-        "\n--- STDERR ---\n" + proc.stderr if proc.stderr else ""
+    # Envelope didn't parse — surface the CLI's exit code and stderr so the
+    # real failure cause reaches `claude_log_tail`. No usage recorded (no
+    # envelope to account).
+    return proc.returncode == 0, _format_agent_cli_failure(
+        cmd_prefix[0], proc.returncode, proc.stdout, proc.stderr
     )
-    return proc.returncode == 0, output
 
 
 def _run_claude_stream(
@@ -3832,14 +3866,17 @@ def _run_claude_stream(
         _record_claude_usage(final)
         text = final.get("result") or ""
         is_error = bool(final.get("is_error")) or proc.returncode != 0
-        if not text and proc.stderr:
-            text = proc.stderr
+        # On error, always append the CLI stderr — the result event's text
+        # often omits the operational cause (e.g. usage limit) that stderr
+        # carries. Skip if stderr is already echoed inside the result text.
+        if is_error and proc.stderr and proc.stderr.strip() not in text:
+            text = (text + "\n--- STDERR ---\n" + proc.stderr.strip()).strip()
         return (not is_error), text, events
-    # No terminal result event — preserve a usable failure signal.
-    output = (proc.stdout or "") + (
-        "\n--- STDERR ---\n" + proc.stderr if proc.stderr else ""
-    )
-    return proc.returncode == 0, output, events
+    # No terminal result event — surface exit code + stderr so the real
+    # failure cause reaches `claude_log_tail`.
+    return proc.returncode == 0, _format_agent_cli_failure(
+        cmd_prefix[0], proc.returncode, proc.stdout, proc.stderr
+    ), events
 
 
 def invoke_claude_code(workdir: Path, timeout_s: int = 900) -> tuple[bool, str]:

--- a/src/run.py
+++ b/src/run.py
@@ -2557,8 +2557,8 @@ def query_remyx_candidates(target: Target) -> list[Recommendation]:
     a lower-ranked candidate is a clean drop-in. Returning the full pool
     lets ``select_recommendation`` pick the most implementable candidate.
 
-    See ``GET /api/v1.0/papers/recommended`` in remyxai/remyx
-    (engine/app/api/papers.py).
+    Backed by the Remyx engine's ``GET /api/v1.0/papers/recommended``
+    endpoint.
     """
     if not target.interest_id:
         raise RuntimeError(
@@ -3666,7 +3666,7 @@ def _record_claude_usage(env: dict) -> None:
 #   - XDG paths for the CLI's per-user state
 #   - CI sentinels (CI, GITHUB_ACTIONS) — informational, carry no secrets
 #   - GitHub auth for the agent's `gh` CLI verification tools — see
-#     REMYX-131 / Path B below
+#     the note below
 #
 # GITHUB_TOKEN (the workflow's built-in runner token, NOT the bot's
 # installation token) is included so the selection-pass agent's `gh`
@@ -3690,9 +3690,9 @@ def _record_claude_usage(env: dict) -> None:
 # higher-privilege cross-repo token the orchestrator uses for PR /
 # Issue creation.
 #
-# REMYX-131 Path A (engine-side scoped read-only token mint) is the
-# principled long-term fix; this whitelist entry is the Path B fast
-# unblock pending that work.
+# An engine-side scoped read-only token mint is the principled
+# long-term fix; this whitelist entry is the fast unblock pending
+# that work.
 #
 # If a Claude CLI feature legitimately requires a new env var, add it
 # explicitly with a comment naming the case. Don't broaden to `ANTHROPIC_*`
@@ -4629,7 +4629,7 @@ def select_recommendation(
             f"  selection: extension pick — direction signal: {tds[:100]!r}, "
             f"adjacent call site: {pcs[:80]!r}"
         )
-    # Code-override audit (Path B from REMYX-130): when the chosen
+    # Code-override audit: when the chosen
     # candidate has no code link (compat <= 0.30) AND the agent
     # populated code_override_justification, validate the override is
     # restricted to the eligible archetypes (addition / simplification)
@@ -5997,7 +5997,7 @@ def _enrich_selection_rejected(
     external tooling parsing the result dict) get self-describing entries.
 
     The license fields are the empirically-load-bearing axis identified by
-    the REMYX-101 cross-portfolio sprint (21 of 25 high-tier rejected
+    cross-portfolio analysis (21 of 25 high-tier rejected
     candidates were ``no-code-link``). Including them in the per-rejected
     record makes that signal queryable at engine scale rather than only
     visible in the per-run step summary.
@@ -6338,7 +6338,7 @@ def process_target(target: Target) -> dict:
                     result["selection_context_efficiency"] = (
                         selection["selection_context_efficiency"]
                     )
-                # Code-override audit field (REMYX-130 Path B) — attached
+                # Code-override audit field — attached
                 # once before the branch logic so every downstream path
                 # (in-pool, extension, external, skip) carries it. Field
                 # is only set when the agent populated and validated it
@@ -8808,7 +8808,7 @@ def _post_run_telemetry(result: dict, target: "Target") -> None:
         # ``recommendation_runs.selection_rejected`` (JSONB) accumulates
         # these for cross-customer analysis: baseline code-availability
         # rate, per-(paper, customer) rejection patterns, deeper-research
-        # prioritization (REMYX-7 / REMYX-100 / REMYX-105). Title is
+        # prioritization. Title is
         # omitted from the wire payload — engine resolves it from
         # ``arxiv_id``; per-rejection reason is truncated to keep payload
         # bounded on rich runs.

--- a/src/run.py
+++ b/src/run.py
@@ -3895,7 +3895,16 @@ def invoke_claude_code(workdir: Path, timeout_s: int = 900) -> tuple[bool, str]:
     if max_turns:
         cmd += ["--max-turns", max_turns]
     ok, text = _run_claude_json(cmd, invocation, workdir, timeout_s)
-    return ok, text[-4000:]   # last 4KB for log brevity
+    if not ok:
+        # The returned `text` is tail-truncated downstream (telemetry keeps
+        # only the last ~1KB), which can clip the CLI's real failure cause.
+        # Emit the full output to the action log here — CI captures stdout
+        # untruncated — so the complete error (e.g. usage limit / credit
+        # balance) is always recoverable from the run logs.
+        log.error(
+            "Claude Code implementation call failed — full output:\n%s", text
+        )
+    return ok, text[-4000:]   # last 4KB retained for the telemetry log tail
 
 
 # ─── Pre-flight routing + self-review (§4, §6) ─────────────────────────────

--- a/tests/test_agent_cli_failure_surfacing.py
+++ b/tests/test_agent_cli_failure_surfacing.py
@@ -1,0 +1,94 @@
+"""Tests for surfacing agent-CLI stderr on failure.
+
+When the agent CLI hard-rejects (usage limit, credit balance, auth) it
+exits fast with the cause on **stderr** and no parseable JSON envelope on
+stdout. The orchestrator stores only the tail of the returned string into
+``claude_log_tail``, so the real cause must reach that tail rather than
+being crowded out by stdout noise. These tests pin that contract.
+
+Run with: pytest tests/test_agent_cli_failure_surfacing.py -q
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+def _fake_proc(stdout="", stderr="", returncode=0):
+    return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+# ─── _format_agent_cli_failure: provider-agnostic, stderr-last ─────────────
+
+
+def test_failure_diagnostic_is_provider_agnostic():
+    """The tool label is parameterized — not hard-coded to Claude."""
+    out = run._format_agent_cli_failure("aider", 1, "", "boom")
+    assert out.startswith("[aider exited 1, no JSON envelope parsed]")
+    assert "claude" not in out.lower()
+
+
+def test_failure_diagnostic_puts_stderr_last():
+    """stderr must be the trailing content so the caller's tail-slice keeps
+    it even when stdout is bulky."""
+    out = run._format_agent_cli_failure(
+        "claude", 1, "x" * 10_000, "Claude AI usage limit reached"
+    )
+    # stderr survives the orchestrator's last-1KB slice.
+    assert "Claude AI usage limit reached" in out[-1000:]
+    # stdout head is capped so it can't dominate the window.
+    assert "…(truncated)" in out
+
+
+def test_failure_diagnostic_marks_empty_stderr():
+    out = run._format_agent_cli_failure("claude", 1, "", "")
+    assert "--- STDERR ---\n(empty)" in out
+
+
+# ─── _run_claude_json: no-envelope path surfaces stderr ────────────────────
+
+
+def test_run_claude_json_no_envelope_surfaces_stderr(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        run.subprocess, "run",
+        lambda *a, **k: _fake_proc(stdout="", stderr="credit balance is too low",
+                                   returncode=1),
+    )
+    ok, text = run._run_claude_json(["claude"], "prompt", tmp_path, 60)
+    assert ok is False
+    assert "credit balance is too low" in text
+    # No usage recorded — there was no envelope to account.
+    assert run._RUN_COST["claude_calls"] == 0
+
+
+def test_run_claude_json_error_envelope_appends_stderr(monkeypatch, tmp_path):
+    """An is_error envelope with a populated `result` still gets stderr
+    appended — the operational cause often lives only on stderr."""
+    run._reset_run_cost()
+    monkeypatch.setattr(
+        run.subprocess, "run",
+        lambda *a, **k: _fake_proc(
+            stdout='{"result": "I could not proceed.", "is_error": true}',
+            stderr="usage limit reached",
+            returncode=0,
+        ),
+    )
+    ok, text = run._run_claude_json(["claude"], "prompt", tmp_path, 60)
+    assert ok is False
+    assert "I could not proceed." in text
+    assert "usage limit reached" in text
+
+
+def test_run_claude_stream_no_result_event_surfaces_stderr(monkeypatch, tmp_path):
+    run._reset_run_cost()
+    monkeypatch.setattr(
+        run.subprocess, "run",
+        lambda *a, **k: _fake_proc(stdout="", stderr="invalid x-api-key",
+                                   returncode=1),
+    )
+    ok, text, events = run._run_claude_stream(["claude"], "prompt", tmp_path, 60)
+    assert ok is False
+    assert "invalid x-api-key" in text

--- a/tests/test_claude_subprocess_env.py
+++ b/tests/test_claude_subprocess_env.py
@@ -1,4 +1,4 @@
-"""Tests for the Claude CLI subprocess env whitelist (REMYX-129 Follow-up 2).
+"""Tests for the Claude CLI subprocess env whitelist.
 
 The Claude CLI subprocess inherits whatever env we pass it. If we pass
 the parent runner's ``os.environ`` verbatim, the agent's Bash tool can
@@ -73,8 +73,8 @@ def test_whitelist_excludes_remyx_api_key():
 
 def test_whitelist_includes_workflow_github_token():
     """The workflow's built-in GITHUB_TOKEN is allowed through so the
-    selection-pass agent's `gh` CLI invocations can authenticate
-    (REMYX-131 Path B). Without it, the agent falls back to
+    selection-pass agent's `gh` CLI invocations can authenticate.
+    Without it, the agent falls back to
     unauthenticated GitHub API at 60 req/hr per shared runner IP and
     can't view private-repo content. Trade-off justified by the
     egress defenses (v1.6.4 scrubber + v1.6.8 diagnostic + v1.6.10
@@ -147,9 +147,8 @@ def test_subprocess_env_returns_only_whitelisted(monkeypatch):
     assert env["ANTHROPIC_API_KEY"] == "sk-test-key"
     assert env["PATH"] == "/usr/bin:/bin"
     assert env["HOME"] == "/home/runner"
-    # Workflow GITHUB_TOKEN is whitelisted for the agent's `gh` CLI auth
-    # (REMYX-131 Path B). The bot's installation token (via
-    # INPUT_GITHUB_TOKEN) stays stripped.
+    # Workflow GITHUB_TOKEN is whitelisted for the agent's `gh` CLI auth.
+    # The bot's installation token (via INPUT_GITHUB_TOKEN) stays stripped.
     assert env["GITHUB_TOKEN"] == "ghs_workflow_token"
 
     # Forbidden vars absent.
@@ -256,7 +255,7 @@ def test_env_strip_complements_outbound_scrubber():
     Two TOKEN-shaped entries are intentional:
       - ANTHROPIC_API_KEY: the Claude CLI's auth requirement
       - GITHUB_TOKEN: the workflow built-in for the agent's `gh` CLI
-        verification tooling (REMYX-131 Path B)
+        verification tooling
     Any other TOKEN-shaped entry should be reviewed before landing."""
     assert hasattr(run, "_scrub_outbound_payload")
     assert hasattr(run, "_claude_subprocess_env")

--- a/tests/test_diff_risk_score.py
+++ b/tests/test_diff_risk_score.py
@@ -215,7 +215,7 @@ def test_run_reexports_scorer_and_threshold():
     assert run.DIFF_RISK_ISSUE_THRESHOLD == diff_risk_score.DIFF_RISK_ISSUE_THRESHOLD
 
 
-# ── branch-vs-base mode (REMYX-107 calibration harness) ────────────────────
+# ── branch-vs-base mode (calibration harness) ──────────────────────────────
 
 
 def test_branch_vs_base_mode_scores_committed_diff():

--- a/tests/test_outbound_secret_telemetry.py
+++ b/tests/test_outbound_secret_telemetry.py
@@ -1,4 +1,4 @@
-"""Tests for the OutboundSecretError telemetry path (REMYX-129 Follow-up 3).
+"""Tests for the OutboundSecretError telemetry path.
 
 When the v1.6.4 outbound-body scrubber fires, the orchestrator routes
 the abort to the dedicated ``aborted_secret_in_payload`` status:

--- a/tests/test_prompt_redaction_rules.py
+++ b/tests/test_prompt_redaction_rules.py
@@ -1,4 +1,4 @@
-"""Tests for the narrow redaction rules in the self-review + pre-flight prompts (REMYX-129 Follow-up 1).
+"""Tests for the narrow redaction rules in the self-review + pre-flight prompts.
 
 The self-review and pre-flight one-shot passes produce JSON whose
 fields flow verbatim into the PR / Issue body. If those fields

--- a/tests/test_selection_code_override.py
+++ b/tests/test_selection_code_override.py
@@ -1,4 +1,4 @@
-"""Tests for the code-override carve-out in the selection-pass (REMYX-130 Path B).
+"""Tests for the code-override carve-out in the selection-pass.
 
 The override lets the selection-pass agent pick a `no-code-link` candidate
 (``license_compat <= 0.30``) under three conditions:

--- a/tests/test_selection_rejected_telemetry.py
+++ b/tests/test_selection_rejected_telemetry.py
@@ -1,4 +1,4 @@
-"""Tests for the selection_rejected telemetry plumbing (REMYX-133).
+"""Tests for the selection_rejected telemetry plumbing.
 
 The selection-pass produces a per-rejected-candidate list with rich
 free-form rejection rationale. Before this work the data was only
@@ -13,7 +13,7 @@ This module ships:
   1. ``_enrich_selection_rejected`` carries ``license_class`` and
      ``license_compat`` alongside the existing arxiv_id / title /
      reason. These are the empirically load-bearing axis identified
-     by the REMYX-101 cross-portfolio sprint.
+     by cross-portfolio analysis.
   2. ``_compact_selection_rejected_for_telemetry`` produces a wire
      projection: drops ``title`` (engine resolves from arxiv_id),
      truncates ``reason`` to keep payload bounded, caps the list
@@ -234,7 +234,7 @@ def test_compact_no_payload_bloat_on_typical_run():
 
 def test_telemetry_payload_includes_selection_rejected(monkeypatch, tmp_path):
     """The engine-side telemetry POST must include the compacted
-    rejection list. The whole point of REMYX-133 is making this data
+    rejection list. The whole point of this plumbing is making this data
     queryable on engine; if the payload doesn't carry it, all the
     upstream enrichment is wasted."""
     captured = {}

--- a/tests/test_step_summary_selection_reasoning.py
+++ b/tests/test_step_summary_selection_reasoning.py
@@ -148,7 +148,7 @@ def test_renders_above_cost_line(tmp_path, monkeypatch):
     assert out.index("Why this selection") < out.index("Cost & tokens")
 
 
-# ── claude_failed rendering (REMYX-106) ────────────────────────────────────
+# ── claude_failed rendering ─────────────────────────────────────────────────
 
 
 def test_step_summary_credit_balance_renders_topup_section(tmp_path, monkeypatch):


### PR DESCRIPTION
## Surface the Claude CLI's real error on implementation failure

When the implementation `claude` call hard-fails (exits fast with no JSON output e.g. usage limit / credit balance), the run ended `claude_failed` with `claude_log_tail` showing the **prompt**, not the CLI error, making the cause impossible to diagnose from telemetry.
  
  ### Changes
  - `_run_claude_json` / `_run_claude_stream`: on failure, surface the CLI `stderr` (placed last so it survives the log-tail truncation), and append it to error envelopes whose `result` omits the operational cause.
  - `invoke_claude_code`: on failure, `log.error` the full, untruncated output so the complete error is always recoverable from the CI step log.
  - Add provider-agnostic helper `_format_agent_cli_failure` so future agent CLIs get the same treatment.
  - Add `tests/test_agent_cli_failure_surfacing.py`; full suite green.