### PR TITLE
Run refinement chain inline by default after recommend mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Sett
 | `claude-timeout` | `900` | Wall-clock seconds for the Claude Code implementation step. Bump for very large repos; lower to cap cost. |
 | `pin-arxiv` | `''` | Optional `arxiv_id`. When set and present in the candidate pool, the action implements that exact paper and skips the selection pass — use it for reproducible eval re-runs. Empty = normal selection. |
 | `mode` | `recommend` | `recommend` (classic per-run flow) / `weekly-summary` (post a weekly digest to a Discussion — see [Weekly Discussion summary](#weekly-discussion-summary-opt-in)) |
+| `chain` | `true` | When `true`, `recommend` mode continues into the refinement chain (fidelity audit → convention pass → test gate) on the draft PR it just filed, within the same run — no extra workflow files required. Set `false` for cost-sensitive runs or to drive the chain via separate workflows with `mode: fidelity/convention/test`. |
 | `weekly-discussion-id` | `''` | Discussion number (from its URL) or GraphQL node ID. Only read in `weekly-summary` mode. |
 
 ## Outputs
@@ -101,6 +102,9 @@ Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Sett
 |---|---|---|
 | `status` | always | Run outcome — see status codes below |
 | `pr_url` | `pr_opened*` | URL of the opened PR |
+| `pr_number` | `pr_opened*` | Number of the opened PR (handed to the inline refinement chain) |
+| `chain_fidelity_status` / `chain_convention_status` / `chain_test_status` | chain ran | Per-phase outcome of the inline refinement chain (`recommend` mode, `chain: true`) |
+| `chain_draft_dropped` | chain ran | `true` if the test gate flipped the draft to ready-for-review |
 | `issue_url` | `issue_opened*` | URL of the opened Issue |
 | `arxiv` | when a paper was picked | arxiv_id |
 | `tier` | when a paper was picked | `high` / `moderate` / `low` / `noise` |
@@ -110,9 +114,9 @@ Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Sett
 
 ## Costs
 
-- **Claude Code**: ~$2–3 per PR-track run (pre-flight + selection + implementation + self-review). Issue-track runs cost less since they skip the implementation pass. You bring `ANTHROPIC_API_KEY`.
+- **Claude Code**: ~$2–3 per PR-track run for the recommend pass alone (pre-flight + selection + implementation + self-review). With the inline refinement chain on (the default), a full PR-track run is ~$5–6 and ~15–25 min, since fidelity audit + convention pass + test gate each add a Claude pass. Set `chain: false` to keep runs at the recommend-only cost. Issue-track runs cost less since they skip the implementation pass and never enter the chain. You bring `ANTHROPIC_API_KEY`.
 - **Remyx API**: included in your engine.remyx.ai subscription.
-- **GitHub Actions**: ~6–8 min on `ubuntu-latest` per run.
+- **GitHub Actions**: ~6–8 min per recommend-only run; ~15–25 min with the chain (single workflow run on `ubuntu-latest`).
 
 With the default cadence guard (gate enabled), expect ~$2–4/mo Claude at typical engagement patterns.
 
@@ -235,7 +239,14 @@ Pre-flight Claude pass: PR or Issue?
                      diff preserved in Issue body for manual review)
                                       ↓
                      Commit (bundle scrubbed) + push + open draft PR
+                                      ↓
+                     Inline refinement chain (chain: true, default):
+                       fidelity audit  → Coverage matrix on PR body
+                       convention pass → align to repo conventions
+                       test gate       → lint + tests; drop draft on pass
 ```
+
+When `chain: true` (the default), the same run continues into the refinement chain on the PR it just filed — fidelity audit, then (only if the audit ran) convention pass and test gate — so the whole pipeline is one workflow run with no extra workflow files. The chain phases are also invokable individually via `mode: fidelity/convention/test` + `pr-number` for the separate-workflow pattern or to re-run a single phase. Opt out of the inline chain with `chain: false`.
 
 The Remyx engine (commit-history extraction, candidate pool, embedding pre-filter, ranking) runs server-side. This action is a pure consumer.
 

--- a/action.yml
+++ b/action.yml
@@ -47,12 +47,29 @@ inputs:
           after the convention pass; requires ``pr-number``.
     required: false
     default: 'recommend'
+  chain:
+    description: |
+      When true (default), recommend mode automatically continues into the
+      refinement chain (fidelity audit → convention pass → test gate) on the
+      draft PR it just filed, within the same workflow run. This is the
+      zero-config rollout: customers get the full chain without deploying
+      the standalone outrider-fidelity / outrider-convention / outrider-test
+      workflows or wiring the label triggers.
+
+      Set to 'false' for cost-sensitive runs (recommend-only is ~$1-3 vs
+      ~$5-6 with the chain) or when you intentionally run the chain via the
+      separate-workflow pattern with `mode: fidelity/convention/test`.
+    required: false
+    default: 'true'
   pr-number:
     description: |
-      PR number to operate on. Only read in ``mode: fidelity``. Set
-      from the workflow's pull_request event payload — see
-      `docs/refinement_pass.md` for the recommended workflow snippet.
-      Empty in recommend / weekly-summary modes.
+      PR number to operate on. Read in the per-phase chain modes
+      (``fidelity`` / ``convention`` / ``test``); set from the workflow's
+      pull_request event payload (or a workflow_dispatch input) when
+      driving a single phase against an existing PR. Empty in recommend /
+      weekly-summary modes — the inline chain (``chain: true``, default)
+      threads the just-opened PR number through automatically, so most
+      installs never set this.
     required: false
     default: ''
   weekly-discussion-id:
@@ -275,6 +292,9 @@ runs:
         # PR number to audit in fidelity mode (set from the workflow's
         # pull_request event payload; empty in recommend / weekly-summary).
         INPUT_PR_NUMBER: ${{ inputs.pr-number }}
+        # Inline refinement chain toggle (recommend mode continues into
+        # fidelity → convention → test by default; 'false' opts out).
+        INPUT_CHAIN: ${{ inputs.chain }}
         # Weekly Discussion summary (opt-in second scheduled job).
         REMYX_MODE: ${{ inputs.mode }}
         REMYX_WEEKLY_DISCUSSION_ID: ${{ inputs.weekly-discussion-id }}

--- a/src/run.py
+++ b/src/run.py
@@ -1181,6 +1181,13 @@ class Target:
     # LLM selection pass) so eval re-runs are reproducible. Empty = normal
     # selection.
     pin_arxiv: str = ""
+    # Inline refinement chain: when True (default), recommend mode continues
+    # sequentially into fidelity audit → convention pass → test gate on the
+    # just-opened PR, so the chain runs by default without the customer
+    # deploying the standalone outrider-fidelity/convention/test workflows.
+    # Set to False (action input `chain: false`) for cost-sensitive runs or
+    # when using the separate-workflow chain pattern.
+    chain_enabled: bool = True
     notes: str = ""
 
 
@@ -5528,8 +5535,13 @@ def detect_default_branch(workdir: Path) -> str:
 def open_pr(
     target: Target, branch: str, title: str, body: str, draft: bool,
     base: str = "main",
-) -> str:
-    """Open a PR on the target repo; returns the PR URL."""
+) -> tuple[str, int]:
+    """Open a PR on the target repo; returns ``(pr_url, pr_number)``.
+
+    The number is threaded back so recommend mode can hand it to the inline
+    refinement chain (fidelity → convention → test all key off the PR
+    number) without a second API round-trip to look it up.
+    """
     log.info(f"  → opening {'draft' if draft else ''} PR on {target.repo} "
              f"(base={base})")
     pr = gh_api("POST", f"/repos/{target.repo}/pulls", {
@@ -5539,7 +5551,7 @@ def open_pr(
         "body": body,
         "draft": draft,
     })
-    return pr["html_url"]
+    return pr["html_url"], pr["number"]
 
 
 def open_issue(
@@ -7051,11 +7063,12 @@ def process_target(target: Target) -> dict:
         commit_and_push(
             workdir, branch, pr_title, repo=target.repo, base_branch=default_branch
         )
-        pr_url = open_pr(
+        pr_url, pr_number = open_pr(
             target, branch, pr_title, pr_body, draft=draft, base=default_branch
         )
         result["status"] = "pr_opened_draft" if draft else "pr_opened"
         result["pr_url"] = pr_url
+        result["pr_number"] = pr_number
         log.info(f"  ✓ {result['status']}: {pr_url}")
         return result
 
@@ -7247,6 +7260,13 @@ def build_target_from_env() -> Target:
         log.error(f"INPUT_CLAUDE_TIMEOUT={timeout_raw!r} is not an integer.")
         sys.exit(2)
 
+    # Inline refinement chain toggle. Default on; any of the usual falsey
+    # spellings disables it so cost-sensitive customers can opt out via
+    # `chain: false` in the action's `with:` block.
+    chain_enabled = _optional_env("INPUT_CHAIN", "true").strip().lower() not in (
+        "false", "0", "no", "off",
+    )
+
     return Target(
         repo=repo,
         interest_id=interest_id,
@@ -7257,6 +7277,7 @@ def build_target_from_env() -> Target:
         test_integration_policy=test_integration_policy,
         claude_timeout_s=claude_timeout_s,
         pin_arxiv=_optional_env("INPUT_PIN_ARXIV", ""),
+        chain_enabled=chain_enabled,
         notes="",
     )
 
@@ -10881,6 +10902,57 @@ def _post_run_telemetry(result: dict, target: "Target") -> None:
         log.warning(f"  run telemetry POST failed (non-fatal): {str(e)[:200]}")
 
 
+def run_refinement_chain(target: Target, pr_number: int) -> dict:
+    """Continue a freshly-filed recommend-mode PR into the refinement chain.
+
+    Runs the three phases sequentially on ``pr_number`` —
+    ``run_fidelity_audit`` → ``run_convention_pass`` → ``run_test_gate`` —
+    so the chain runs by default inside the recommend workflow run rather
+    than requiring the customer to deploy the standalone
+    outrider-fidelity/convention/test workflows.
+
+    Convention and test only run once fidelity actually audited the PR
+    (status ``fidelity_audited*``); a skip/failure short-circuits the
+    chain since the downstream phases have nothing meaningful to act on.
+    Convention and test run as a pair after that — the test gate is what
+    flips the draft to ready, so it runs regardless of the convention
+    phase's individual outcome.
+
+    The phase runners read the PR number from ``INPUT_PR_NUMBER`` (the same
+    seam the standalone ``mode: <phase>`` workflows use), so we set it here
+    before delegating. Returns a dict of per-phase statuses for telemetry
+    and the run summary.
+    """
+    log.info(f"  → continuing into refinement chain on PR #{pr_number}")
+    # The phase runners read INPUT_PR_NUMBER from the environment (shared
+    # seam with the standalone workflow_dispatch chain). Set it so the
+    # inline call targets the PR recommend mode just opened.
+    os.environ["INPUT_PR_NUMBER"] = str(pr_number)
+
+    chain: dict = {"pr_number": pr_number}
+
+    log.info("  ─── chain phase: fidelity audit ───")
+    fidelity = run_fidelity_audit(target)
+    chain["fidelity_status"] = fidelity.get("status")
+    if not str(fidelity.get("status", "")).startswith("fidelity_audited"):
+        log.info(
+            f"  ↪ fidelity did not audit (status={fidelity.get('status')!r}); "
+            f"skipping convention + test phases"
+        )
+        return chain
+
+    log.info("  ─── chain phase: convention pass ───")
+    convention = run_convention_pass(target)
+    chain["convention_status"] = convention.get("status")
+
+    log.info("  ─── chain phase: test gate ───")
+    test = run_test_gate(target)
+    chain["test_status"] = test.get("status")
+    chain["draft_dropped"] = test.get("draft_dropped", False)
+
+    return chain
+
+
 def main():
     # Mode dispatch: "recommend" is the classic
     # scout-and-implement run; "weekly-summary" aggregates the past week
@@ -10932,6 +11004,26 @@ def main():
         log.exception(f"  ✗ unhandled error: {e}")
         result = {"repo": target.repo, "status": failure_status, "error": str(e)}
 
+    # Inline refinement chain: once recommend mode files a draft
+    # PR, continue sequentially into fidelity → convention → test on that PR
+    # so the chain runs by default — no standalone workflow files required.
+    # Gated on `chain_enabled` (action input `chain`, default true) and on a
+    # PR actually having opened. Runs before the cost-totals block so the
+    # chain's Claude spend rolls into this run's reported totals.
+    if (
+        mode == "recommend"
+        and target.chain_enabled
+        and str(result.get("status", "")).startswith("pr_opened")
+        and result.get("pr_number")
+    ):
+        try:
+            result["chain"] = run_refinement_chain(target, result["pr_number"])
+        except Exception as e:
+            log.exception(f"  ✗ refinement chain failed (non-fatal): {e}")
+            result["chain"] = {"error": str(e)}
+    elif mode == "recommend" and not target.chain_enabled:
+        log.info("  chain disabled (chain: false); skipping refinement chain")
+
     # Token/cost totals across every Claude pass this run, captured even when
     # process_target raised.
     result["cost_usd"] = round(_RUN_COST["cost_usd"], 4)
@@ -10956,6 +11048,20 @@ def main():
                 f.write(f"status={result.get('status', 'unknown')}\n")
                 if "pr_url" in result:
                     f.write(f"pr_url={result['pr_url']}\n")
+                if "pr_number" in result:
+                    f.write(f"pr_number={result['pr_number']}\n")
+                # Inline refinement-chain phase outcomes (recommend mode with
+                # chain enabled). Lets downstream steps branch on whether the
+                # draft was dropped to ready, etc.
+                chain = result.get("chain") or {}
+                if "fidelity_status" in chain:
+                    f.write(f"chain_fidelity_status={chain['fidelity_status']}\n")
+                if "convention_status" in chain:
+                    f.write(f"chain_convention_status={chain['convention_status']}\n")
+                if "test_status" in chain:
+                    f.write(f"chain_test_status={chain['test_status']}\n")
+                if "draft_dropped" in chain:
+                    f.write(f"chain_draft_dropped={str(chain['draft_dropped']).lower()}\n")
                 if "issue_url" in result:
                     f.write(f"issue_url={result['issue_url']}\n")
                 if "discussion_comment_url" in result:

--- a/tests/test_inline_refinement_chain.py
+++ b/tests/test_inline_refinement_chain.py
@@ -1,0 +1,195 @@
+"""Tests for the inline refinement chain.
+
+After recommend mode files a draft PR, the same run.py invocation continues
+sequentially into the chain — fidelity audit → convention pass → test gate —
+on the just-opened PR, so the chain runs by default without the customer
+deploying the standalone outrider-fidelity/convention/test workflows.
+
+Coverage:
+  - `build_target_from_env` parses `INPUT_CHAIN` into `Target.chain_enabled`
+    (default on; the usual falsey spellings opt out).
+  - `run_refinement_chain` runs all three phases when fidelity audits, and
+    short-circuits when fidelity skips/fails. It sets INPUT_PR_NUMBER so the
+    phase runners (which read it from the env) target the right PR.
+  - `main()`'s recommend path invokes the chain only when `chain_enabled` is
+    set AND a PR actually opened.
+
+Run with: pytest tests/test_inline_refinement_chain.py -q
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+def _base_env(monkeypatch, **overrides):
+    """Minimal env for build_target_from_env / main(); clears chain-related
+    vars so each test controls them explicitly."""
+    for var in (
+        "INPUT_CHAIN", "INPUT_PR_NUMBER", "REMYX_MODE", "INPUT_MODE",
+        "GITHUB_OUTPUT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("TARGET_REPO", "owner/repo")
+    monkeypatch.setenv("INPUT_INTEREST_ID", "11111111-1111-1111-1111-111111111111")
+    for var, value in overrides.items():
+        monkeypatch.setenv(var, value)
+
+
+# ─── build_target_from_env: INPUT_CHAIN → chain_enabled ─────────────────────
+
+
+def test_chain_enabled_defaults_true(monkeypatch):
+    _base_env(monkeypatch)
+    target = run.build_target_from_env()
+    assert target.chain_enabled is True
+
+
+@pytest.mark.parametrize("value", ["false", "False", "0", "no", "off", "OFF"])
+def test_chain_disabled_falsey_spellings(monkeypatch, value):
+    _base_env(monkeypatch, INPUT_CHAIN=value)
+    target = run.build_target_from_env()
+    assert target.chain_enabled is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "anything"])
+def test_chain_enabled_truthy_spellings(monkeypatch, value):
+    _base_env(monkeypatch, INPUT_CHAIN=value)
+    target = run.build_target_from_env()
+    assert target.chain_enabled is True
+
+
+# ─── run_refinement_chain: phase sequencing + gating ────────────────────────
+
+
+def _record_phases(monkeypatch, fidelity_status):
+    """Stub the three phase runners; return the call-order list. Convention
+    and test report fixed terminal statuses."""
+    calls = []
+
+    def fake_fidelity(target):
+        calls.append(("fidelity", run.os.environ.get("INPUT_PR_NUMBER")))
+        return {"status": fidelity_status}
+
+    def fake_convention(target):
+        calls.append(("convention", run.os.environ.get("INPUT_PR_NUMBER")))
+        return {"status": "convention_aligned"}
+
+    def fake_test(target):
+        calls.append(("test", run.os.environ.get("INPUT_PR_NUMBER")))
+        return {"status": "test_passed", "draft_dropped": True}
+
+    monkeypatch.setattr(run, "run_fidelity_audit", fake_fidelity)
+    monkeypatch.setattr(run, "run_convention_pass", fake_convention)
+    monkeypatch.setattr(run, "run_test_gate", fake_test)
+    return calls
+
+
+def test_chain_runs_all_phases_when_fidelity_audits(monkeypatch):
+    _base_env(monkeypatch)
+    calls = _record_phases(monkeypatch, "fidelity_audited")
+    chain = run.run_refinement_chain(run.Target(repo="owner/repo"), 42)
+
+    assert [c[0] for c in calls] == ["fidelity", "convention", "test"]
+    # Every phase saw the PR number via INPUT_PR_NUMBER.
+    assert all(prn == "42" for _, prn in calls)
+    assert chain == {
+        "pr_number": 42,
+        "fidelity_status": "fidelity_audited",
+        "convention_status": "convention_aligned",
+        "test_status": "test_passed",
+        "draft_dropped": True,
+    }
+
+
+def test_chain_runs_all_phases_on_needs_judgment(monkeypatch):
+    # `fidelity_audited_needs_judgment` is still an audited state — chain
+    # continues (prefix match).
+    _base_env(monkeypatch)
+    calls = _record_phases(monkeypatch, "fidelity_audited_needs_judgment")
+    run.run_refinement_chain(run.Target(repo="owner/repo"), 7)
+    assert [c[0] for c in calls] == ["fidelity", "convention", "test"]
+
+
+@pytest.mark.parametrize("skip_status", [
+    "fidelity_skipped_no_reference",
+    "fidelity_skipped_not_bot",
+    "fidelity_failed_clone",
+])
+def test_chain_short_circuits_when_fidelity_does_not_audit(monkeypatch, skip_status):
+    _base_env(monkeypatch)
+    calls = _record_phases(monkeypatch, skip_status)
+    chain = run.run_refinement_chain(run.Target(repo="owner/repo"), 42)
+
+    assert [c[0] for c in calls] == ["fidelity"]  # convention/test never ran
+    assert chain == {"pr_number": 42, "fidelity_status": skip_status}
+
+
+# ─── main(): recommend-mode continuation gated by chain_enabled ─────────────
+
+
+def _stub_main_tail(monkeypatch):
+    """No-op the heavy side-effects so main() can run headless."""
+    monkeypatch.setattr(run, "_write_step_summary", lambda result: None)
+    monkeypatch.setattr(run, "_post_run_telemetry", lambda result, target: None)
+
+
+def _make_recommend_main(monkeypatch, *, chain_enabled, process_result):
+    _stub_main_tail(monkeypatch)
+    target = run.Target(repo="owner/repo", chain_enabled=chain_enabled)
+    monkeypatch.setattr(run, "build_target_from_env", lambda: target)
+    monkeypatch.setattr(run, "process_target", lambda t: dict(process_result))
+
+    invoked = []
+    monkeypatch.setattr(
+        run, "run_refinement_chain",
+        lambda t, pr: invoked.append(pr) or {"pr_number": pr},
+    )
+    return invoked
+
+
+def test_main_invokes_chain_when_enabled_and_pr_opened(monkeypatch):
+    _base_env(monkeypatch)
+    invoked = _make_recommend_main(
+        monkeypatch, chain_enabled=True,
+        process_result={"repo": "owner/repo", "status": "pr_opened", "pr_number": 99},
+    )
+    run.main()
+    assert invoked == [99]
+
+
+def test_main_invokes_chain_on_draft_pr(monkeypatch):
+    # pr_opened_draft also starts with "pr_opened" — chain should run.
+    _base_env(monkeypatch)
+    invoked = _make_recommend_main(
+        monkeypatch, chain_enabled=True,
+        process_result={"repo": "owner/repo", "status": "pr_opened_draft", "pr_number": 5},
+    )
+    run.main()
+    assert invoked == [5]
+
+
+def test_main_skips_chain_when_disabled(monkeypatch):
+    _base_env(monkeypatch)
+    invoked = _make_recommend_main(
+        monkeypatch, chain_enabled=False,
+        process_result={"repo": "owner/repo", "status": "pr_opened", "pr_number": 99},
+    )
+    run.main()
+    assert invoked == []
+
+
+def test_main_skips_chain_when_no_pr_opened(monkeypatch):
+    # An Issue-routed run (no PR) must not trigger the chain even with
+    # chain_enabled, since there's no PR number to operate on.
+    _base_env(monkeypatch)
+    invoked = _make_recommend_main(
+        monkeypatch, chain_enabled=True,
+        process_result={"repo": "owner/repo", "status": "issue_opened"},
+    )
+    run.main()
+    assert invoked == []


### PR DESCRIPTION
## What

Recommend mode now continues sequentially into the refinement chain — **fidelity audit → convention pass → test gate**, on the draft PR it just filed, within the same workflow run. Previously the chain only ran if a user deployed three standalone workflow files plus label triggers, so it was invisible to most installs. This makes it zero-config and on by default.

## Changes

- **`chain` action input** (default `true`) → `Target.chain_enabled`. Set `chain: false` for cost-sensitive runs or to keep using the separate-workflow chain pattern.
- **`open_pr`** returns the PR number; **`process_target`** threads it out on `pr_opened*` so the chain can target the just-opened PR (via `INPUT_PR_NUMBER`, the same seam the per-phase `mode:` workflows use).
- **`run_refinement_chain`** runs fidelity, then convention + test only if the audit actually ran; non-fatal on error, and runs before the cost-totals block so chain spend rolls into the run's reported cost.
- Phase outcomes surfaced to `$GITHUB_OUTPUT` (`chain_fidelity_status` / `chain_convention_status` / `chain_test_status`, `chain_draft_dropped`) alongside `pr_number`.
- README (Inputs / Outputs / Costs / "How it works") and `action.yml` docs updated; fixed a dangling `docs/refinement_pass.md` pointer.

## Cost / time

Recommend-only stays ~\$2–3 / ~6–8 min. A full PR-track run with the chain is ~\$5–6 / ~15–25 min as a single workflow run. `chain: false` reverts to recommend-only cost.

## Tests

New `tests/test_inline_refinement_chain.py` (20 tests): `INPUT_CHAIN` parsing, phase sequencing + short-circuit when fidelity doesn't audit, and `main()`'s continuation gated by `chain_enabled` + a PR actually opening. 

## Notes

- The per-phase modes (`mode: fidelity/convention/test` + `pr-number`) still work for the separate-workflow pattern and single-phase re-runs.
- No PR label is added/skipped: recommend mode never applied the chain trigger label, so there's no double-fire to guard against here.