### PR TITLE
Phase A: paper-anchored fidelity audit when no reference URL

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -1876,6 +1876,92 @@ def _fetch_arxiv_abstract_page_urls(arxiv_id: str) -> tuple[list[str], list[str]
     return gh, hf
 
 
+# Cached extracted text (title + abstract) per arxiv id. Populated by
+# ``_fetch_arxiv_abstract_text`` for paper-anchored fidelity audits (the
+# Phase A degraded mode used when a paper has no public reference impl).
+_ARXIV_ABSTRACT_TEXT_CACHE: dict[str, str] = {}
+
+# Strip HTML tags + collapse whitespace; the arxiv abstract block has
+# light markup (italics, math, line breaks) but no nested structure that
+# we'd lose to a flat strip.
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_HTML_WHITESPACE_RE = re.compile(r"\s+")
+
+# Match the arxiv abstract page's title + abstract blocks. Both are
+# stable surfaces — arxiv has rendered titles as ``<h1 class="title
+# mathjax">`` and abstracts as ``<blockquote class="abstract mathjax">``
+# for ~15 years. Greedy-stop on the closing tag.
+_ARXIV_TITLE_RE = re.compile(
+    r'<h1[^>]*class="[^"]*\btitle\b[^"]*"[^>]*>(.*?)</h1>',
+    re.IGNORECASE | re.DOTALL,
+)
+_ARXIV_ABSTRACT_BLOCK_RE = re.compile(
+    r'<blockquote[^>]*class="[^"]*\babstract\b[^"]*"[^>]*>(.*?)</blockquote>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _fetch_arxiv_abstract_text(arxiv_id: str) -> str:
+    """Return the paper's title + abstract as plaintext.
+
+    Used by the paper-anchored Phase A audit (Phase A's degraded mode
+    when a paper has no public reference impl). The abstract is the
+    densest method-summary surface we can fetch deterministically
+    without parsing the PDF; for the audit prompt's purposes, "the paper
+    claims X — does the diff implement X" can be answered from the
+    abstract for most papers, and the audit honestly reports its
+    precision floor via the ``Audit anchor`` line in the Coverage
+    matrix.
+
+    Returns ``""`` for any failure (fetch error, no abstract block
+    found, empty arxiv id) — callers treat that as "no paper anchor
+    available" and fall back to the skip path. Never raises.
+    """
+    arxiv_id = (arxiv_id or "").strip()
+    if not arxiv_id:
+        return ""
+    if arxiv_id in _ARXIV_ABSTRACT_TEXT_CACHE:
+        return _ARXIV_ABSTRACT_TEXT_CACHE[arxiv_id]
+    url = f"https://arxiv.org/abs/{arxiv_id}"
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "feature-finder-orchestrator",
+                "Accept": "text/html",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        log.debug(f"  arxiv abstract-text fetch for {arxiv_id} failed: {e}")
+        _ARXIV_ABSTRACT_TEXT_CACHE[arxiv_id] = ""
+        return ""
+
+    parts: list[str] = []
+    m_title = _ARXIV_TITLE_RE.search(html)
+    if m_title:
+        title = _HTML_WHITESPACE_RE.sub(
+            " ", _HTML_TAG_RE.sub("", m_title.group(1))
+        ).strip()
+        if title.lower().startswith("title:"):
+            title = title.split(":", 1)[1].strip()
+        if title:
+            parts.append(f"Title: {title}")
+    m_abs = _ARXIV_ABSTRACT_BLOCK_RE.search(html)
+    if m_abs:
+        abstract = _HTML_WHITESPACE_RE.sub(
+            " ", _HTML_TAG_RE.sub("", m_abs.group(1))
+        ).strip()
+        if abstract.lower().startswith("abstract:"):
+            abstract = abstract.split(":", 1)[1].strip()
+        if abstract:
+            parts.append(f"Abstract: {abstract}")
+    text = "\n\n".join(parts)
+    _ARXIV_ABSTRACT_TEXT_CACHE[arxiv_id] = text
+    return text
+
+
 def _classify_license(spdx: str) -> str:
     """Map an SPDX-ish license id onto an adoption bucket.
 
@@ -8790,10 +8876,122 @@ Return ONLY a valid JSON object (no prose before or after):
 """
 
 
-def _render_coverage_matrix(matrix: dict) -> str:
+def _build_fidelity_audit_prompt_paper_anchored(
+    pr_title: str,
+    pr_body: str,
+    pr_diff: str,
+    arxiv_id: str,
+    paper_text: str,
+) -> str:
+    """Compose the paper-anchored fidelity-audit prompt.
+
+    Used as Phase A's degraded mode when the paper has no public
+    reference impl to clone — the audit anchors against the paper's
+    title + abstract (fetched via ``_fetch_arxiv_abstract_text``)
+    instead of a reference codebase. Lower precision than the
+    reference-anchored variant (abstracts can be vague on
+    implementation-level details), but materially better than skipping
+    the entire chain.
+
+    Output schema matches ``_build_fidelity_audit_prompt`` so the same
+    ``_render_coverage_matrix`` renderer + downstream consumers handle
+    both modes. The ``reference_location`` field is interpreted as
+    "paper section/equation" when paper-anchored (the renderer doesn't
+    care; the value is opaque markdown).
+    """
+    diff_excerpt = pr_diff if len(pr_diff) <= 60_000 else (
+        pr_diff[:60_000] + f"\n... [diff truncated, total {len(pr_diff)} chars] ...\n"
+    )
+    body_excerpt = (pr_body or "")[:4000]
+    paper_excerpt = paper_text[:8000]
+
+    return f"""You are auditing a draft PR's fidelity to the paper it claims to implement.
+
+# PR under audit
+
+**Title**: {pr_title}
+
+**Paper**: arxiv:{arxiv_id or "(unknown)"}
+
+**Audit mode**: paper-anchored (no public reference impl available — comparing the diff against the paper's described method instead of a concrete reference codebase).
+
+## Paper text (title + abstract)
+
+```
+{paper_excerpt}
+```
+
+## PR body
+
+```
+{body_excerpt}
+```
+
+## PR diff
+
+```
+{diff_excerpt}
+```
+
+# Task
+
+Compare the diff against the paper's described method. Produce a structured
+Coverage matrix that classifies each notable piece of the PR as one of:
+
+- **covered**: the PR implements something the paper explicitly describes.
+  Cite the paper's claim (a phrase from the abstract or a section reference
+  if mentioned in the PR body) and the PR location.
+- **deferred**: the PR intentionally leaves something out of scope. Cite what
+  the PR body says about it (e.g., "§4.4 adaptive decay deferred as follow-up").
+- **deviation**: the PR implements something the paper does not describe, or
+  implements it in a way the paper's abstract contradicts. Classify as:
+  - **defensible**: a reasonable adaptation when the paper is silent on
+    implementation specifics (e.g., the abstract describes a "filter" without
+    fixing the algorithm; the diff picks a standard choice).
+  - **needs-judgment**: substantive deviation from a claim the paper makes
+    (e.g., different numerical constants, missing a paper-headline mechanism,
+    computing a different mathematical quantity than the abstract describes).
+
+The abstract is a method-summary surface — it tells you what the paper claims
+to do at a high level, but not the implementation-level specifics. When the
+abstract is silent on a detail in the diff, treat that as **deferred** (out
+of scope of what the abstract covers) rather than a deviation. Reserve
+**needs-judgment** for items where the diff clearly conflicts with what the
+abstract claims.
+
+# Output
+
+Return ONLY a valid JSON object (no prose before or after):
+
+{{
+  "summary": "<one-sentence overall verdict>",
+  "needs_judgment": <true if any item.deviation_class == "needs-judgment">,
+  "items": [
+    {{
+      "name": "<paper claim or feature name>",
+      "draft_location": "<file::symbol or null>",
+      "reference_location": "<paper section/claim or null>",
+      "status": "covered" | "deferred" | "deviation",
+      "deviation_class": null | "defensible" | "needs-judgment",
+      "rationale": "<one to three sentences>"
+    }}
+  ]
+}}
+"""
+
+
+def _render_coverage_matrix(matrix: dict, audit_anchor: str = "reference") -> str:
     """Render the Claude-emitted Coverage matrix as a markdown section
     to append to the PR body. Renders as a table with one row per item
-    plus a summary line + needs-judgment callout."""
+    plus a summary line, an audit-anchor line (sets precision
+    expectations for the maintainer), and a needs-judgment callout.
+
+    ``audit_anchor`` is one of ``"reference"`` (Phase A clone-and-diff
+    against the paper's reference impl — higher precision) or
+    ``"paper"`` (Phase A degraded mode anchored against the paper's
+    abstract text only — lower precision). The line is omitted for
+    unknown values to keep older call sites round-trippable.
+    """
     summary = matrix.get("summary", "(no summary)")
     needs_judgment = bool(matrix.get("needs_judgment", False))
     items = matrix.get("items", [])
@@ -8801,6 +8999,16 @@ def _render_coverage_matrix(matrix: dict) -> str:
     lines = [FIDELITY_COVERAGE_SECTION_HEADER, ""]
     lines.append(f"_{summary}_")
     lines.append("")
+    if audit_anchor == "reference":
+        lines.append("_Audit anchor: reference implementation (diff vs. cloned reference codebase)._")
+        lines.append("")
+    elif audit_anchor == "paper":
+        lines.append(
+            "_Audit anchor: paper abstract (no public reference impl available — "
+            "this audit compares the diff to the paper's described method at the "
+            "abstract level, which is less precise than a code-level comparison)._"
+        )
+        lines.append("")
     if needs_judgment:
         lines.append("> ⚠️ One or more items below need human judgment — see rows marked `deviation (needs-judgment)`.")
         lines.append("")
@@ -8948,15 +9156,31 @@ def run_fidelity_audit(target: Target) -> dict:
     Returns a status dict suitable for the action's $GITHUB_OUTPUT and
     the telemetry post. Status values:
 
-        fidelity_audited                — happy path; Coverage matrix posted
-        fidelity_audited_needs_judgment — happy path + at least one item
-                                          flagged for human review
-        fidelity_skipped_no_pr          — INPUT_PR_NUMBER empty
-        fidelity_skipped_not_bot        — PR not authored by remyx-ai[bot]
-        fidelity_skipped_no_reference   — couldn't extract a reference URL
-        fidelity_failed_clone           — reference clone failed
-        fidelity_failed_claude          — Claude call failed or returned
-                                          unparseable JSON
+        fidelity_audited                       — happy path; Coverage
+                                                 matrix posted (reference
+                                                 impl anchor)
+        fidelity_audited_needs_judgment        — happy path + at least
+                                                 one item flagged for
+                                                 human review (reference
+                                                 impl anchor)
+        fidelity_audited_paper_anchored        — happy path; Coverage
+                                                 matrix posted (paper
+                                                 abstract anchor — used
+                                                 when no public reference
+                                                 impl is available)
+        fidelity_audited_paper_anchored_needs_judgment — paper-anchored
+                                                 happy path + needs-judgment
+        fidelity_skipped_no_pr                 — INPUT_PR_NUMBER empty
+        fidelity_skipped_not_bot               — PR not authored by
+                                                 remyx-ai[bot]
+        fidelity_skipped_no_reference          — couldn't extract a
+                                                 reference URL AND no
+                                                 arxiv id available for
+                                                 the paper-anchored
+                                                 degraded mode
+        fidelity_failed_clone                  — reference clone failed
+        fidelity_failed_claude                 — Claude call failed or
+                                                 returned unparseable JSON
     """
     result: dict = {"repo": target.repo, "mode": "fidelity", "status": "unknown"}
 
@@ -8994,41 +9218,76 @@ def run_fidelity_audit(target: Target) -> dict:
     body = pr.get("body") or ""
     title = pr.get("title") or ""
     arxiv_id, reference_url = _extract_reference_url_from_pr_body(body, target.repo)
-    if not reference_url:
-        result["status"] = "fidelity_skipped_no_reference"
-        result["error"] = "no reference URL extracted from PR body"
-        log.info(f"  ✗ no reference URL in PR #{pr_number} body; skipping")
-        return result
     result["arxiv_id"] = arxiv_id
-    result["reference_url"] = reference_url
 
-    # Workdir layout: ./reference/ holds the cloned ref impl; Claude's
-    # cwd will be the workdir root so it can Read/Glob/Grep into it.
+    # Workdir layout: when reference-anchored, ./reference/ holds the
+    # cloned ref impl and Claude's cwd is the workdir root so it can
+    # Read/Glob/Grep into it. In paper-anchored mode the workdir is
+    # still set up (the Claude one-shot needs a cwd) but ./reference/
+    # is absent — the prompt embeds the paper text directly.
     workdir = Path(tempfile.mkdtemp(prefix="outrider-fidelity-"))
     log.info(f"  → workdir: {workdir}")
 
-    ok, ref_dir, err = _clone_reference_repo(reference_url, workdir)
-    if not ok:
-        result["status"] = "fidelity_failed_clone"
-        result["error"] = err
-        log.error(f"  ✗ {err}")
-        return result
+    audit_anchor: str  # "reference" | "paper"
+    if reference_url:
+        result["reference_url"] = reference_url
+        ok, ref_dir, err = _clone_reference_repo(reference_url, workdir)
+        if not ok:
+            result["status"] = "fidelity_failed_clone"
+            result["error"] = err
+            log.error(f"  ✗ {err}")
+            return result
+        try:
+            pr_diff = _fetch_pr_diff(target, pr_number)
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            result["status"] = "fidelity_failed_claude"
+            result["error"] = f"could not fetch PR diff: {e}"
+            return result
+        prompt = _build_fidelity_audit_prompt(
+            pr_title=title,
+            pr_body=body,
+            pr_diff=pr_diff,
+            arxiv_id=arxiv_id,
+            reference_url=reference_url,
+            reference_root=ref_dir,
+        )
+        audit_anchor = "reference"
+        log.info(f"  → reference-anchored audit ({reference_url})")
+    else:
+        # Phase A degraded mode: no public reference impl available, but
+        # we may still have the paper's title + abstract from arxiv. The
+        # audit compares the diff against the paper's described method
+        # at the abstract level — lower precision than a code-anchored
+        # comparison, but materially better than skipping the entire
+        # chain (B + C still run after this).
+        paper_text = _fetch_arxiv_abstract_text(arxiv_id) if arxiv_id else ""
+        if not paper_text:
+            result["status"] = "fidelity_skipped_no_reference"
+            result["error"] = (
+                "no reference URL extracted from PR body and no arxiv "
+                "abstract available for paper-anchored audit"
+            )
+            log.info(
+                f"  ✗ no reference URL in PR #{pr_number} body and no "
+                f"arxiv abstract for {arxiv_id!r}; skipping"
+            )
+            return result
+        try:
+            pr_diff = _fetch_pr_diff(target, pr_number)
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            result["status"] = "fidelity_failed_claude"
+            result["error"] = f"could not fetch PR diff: {e}"
+            return result
+        prompt = _build_fidelity_audit_prompt_paper_anchored(
+            pr_title=title,
+            pr_body=body,
+            pr_diff=pr_diff,
+            arxiv_id=arxiv_id,
+            paper_text=paper_text,
+        )
+        audit_anchor = "paper"
+        log.info(f"  → paper-anchored audit (arxiv:{arxiv_id}, no reference impl)")
 
-    try:
-        pr_diff = _fetch_pr_diff(target, pr_number)
-    except (urllib.error.HTTPError, urllib.error.URLError) as e:
-        result["status"] = "fidelity_failed_claude"
-        result["error"] = f"could not fetch PR diff: {e}"
-        return result
-
-    prompt = _build_fidelity_audit_prompt(
-        pr_title=title,
-        pr_body=body,
-        pr_diff=pr_diff,
-        arxiv_id=arxiv_id,
-        reference_url=reference_url,
-        reference_root=ref_dir,
-    )
     log.info(f"  → Claude one-shot audit (timeout={target.claude_timeout_s}s)")
     ok, raw = _run_claude_oneshot(workdir, prompt, target.claude_timeout_s, max_turns=20)
     if not ok:
@@ -9042,7 +9301,7 @@ def run_fidelity_audit(target: Target) -> dict:
         result["error"] = f"Claude returned unparseable JSON: {raw[-500:]}"
         return result
 
-    coverage_section = _render_coverage_matrix(matrix)
+    coverage_section = _render_coverage_matrix(matrix, audit_anchor=audit_anchor)
     # Per-phase output goes to the action run-summary panel rather than the
     # PR body; the body is reserved for content the convention pass aligns
     # to upstream conventions.
@@ -9051,9 +9310,18 @@ def run_fidelity_audit(target: Target) -> dict:
     needs_judgment = bool(matrix.get("needs_judgment", False))
     if needs_judgment:
         _add_pr_label(target, pr_number, FIDELITY_LABEL_NEEDS_JUDGMENT)
-        result["status"] = "fidelity_audited_needs_judgment"
+        result["status"] = (
+            "fidelity_audited_paper_anchored_needs_judgment"
+            if audit_anchor == "paper"
+            else "fidelity_audited_needs_judgment"
+        )
     else:
-        result["status"] = "fidelity_audited"
+        result["status"] = (
+            "fidelity_audited_paper_anchored"
+            if audit_anchor == "paper"
+            else "fidelity_audited"
+        )
+    result["audit_anchor"] = audit_anchor
 
     # Transition the trigger label → fidelity-done so the convention pass
     # workflow picks it up.

--- a/tests/test_inline_refinement_chain.py
+++ b/tests/test_inline_refinement_chain.py
@@ -115,6 +115,21 @@ def test_chain_runs_all_phases_on_needs_judgment(monkeypatch):
     assert [c[0] for c in calls] == ["fidelity", "convention", "test"]
 
 
+@pytest.mark.parametrize("audited_status", [
+    "fidelity_audited_paper_anchored",
+    "fidelity_audited_paper_anchored_needs_judgment",
+])
+def test_chain_runs_all_phases_for_paper_anchored_audit(monkeypatch, audited_status):
+    # Phase A's paper-anchored degraded mode still produces an audited
+    # state — B + C must run. Without this the chain bails whenever a
+    # paper lacks a public reference impl (observed on NeMo-Curator
+    # PR #4 during v1.6.15 validation).
+    _base_env(monkeypatch)
+    calls = _record_phases(monkeypatch, audited_status)
+    run.run_refinement_chain(run.Target(repo="owner/repo"), 9)
+    assert [c[0] for c in calls] == ["fidelity", "convention", "test"]
+
+
 @pytest.mark.parametrize("skip_status", [
     "fidelity_skipped_no_reference",
     "fidelity_skipped_not_bot",

--- a/tests/test_paper_anchored_audit.py
+++ b/tests/test_paper_anchored_audit.py
@@ -1,0 +1,193 @@
+"""Tests for Phase A paper-anchored fidelity-audit helpers (REMYX-145).
+
+Covers the three new surfaces:
+  - `_fetch_arxiv_abstract_text` extracts title + abstract from the arxiv
+    abstract page HTML (and gracefully returns "" on failures).
+  - `_build_fidelity_audit_prompt_paper_anchored` produces a prompt that
+    embeds the paper text and instructs Claude to audit against the
+    paper's described method (not a cloned reference codebase).
+  - `_render_coverage_matrix` surfaces the audit anchor in the rendered
+    Coverage section so maintainers can read precision expectations from
+    the artifact itself.
+
+Run with: pytest tests/test_paper_anchored_audit.py -q
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+_ARXIV_PAGE_FIXTURE = """\
+<html><head><title>2606.11127 — arxiv</title></head><body>
+<h1 class="title mathjax">
+  <span class="descriptor">Title:</span>
+  Provenance-Grounded Gating and Adaptive Recovery in Synthetic Post-Training Data Curation
+</h1>
+<blockquote class="abstract mathjax">
+  <span class="descriptor">Abstract:</span>
+  We study quality gating in synthetic data curation pipelines and show
+  that a provenance-grounded gate plus an adaptive recovery loop raises
+  yield substantially over naive discard. The recovery loop diagnoses
+  rejected samples and re-admits geometry near-misses within a bounded
+  margin.
+</blockquote>
+</body></html>
+"""
+
+
+def _fake_urlopen_factory(html: str):
+    """Build a context-manager-returning fake for urllib.request.urlopen."""
+    class _FakeResp:
+        def __init__(self, body):
+            self._body = body
+        def read(self):
+            return self._body.encode("utf-8")
+        def __enter__(self):
+            return self
+        def __exit__(self, *exc):
+            return False
+
+    def _fake(*_args, **_kwargs):
+        return _FakeResp(html)
+    return _fake
+
+
+# ─── _fetch_arxiv_abstract_text ─────────────────────────────────────────────
+
+
+def test_fetch_arxiv_abstract_text_extracts_title_and_abstract():
+    run._ARXIV_ABSTRACT_TEXT_CACHE.pop("2606.11127v1", None)
+    with patch("urllib.request.urlopen", _fake_urlopen_factory(_ARXIV_PAGE_FIXTURE)):
+        text = run._fetch_arxiv_abstract_text("2606.11127v1")
+    assert "Title: Provenance-Grounded Gating" in text
+    assert "Abstract: We study quality gating" in text
+    # "Title:" / "Abstract:" descriptor labels are stripped from the start
+    # of each section value, not carried as a raw prefix on the content.
+    assert "Title: Title:" not in text
+    assert "Abstract: Abstract:" not in text
+
+
+def test_fetch_arxiv_abstract_text_caches_result():
+    run._ARXIV_ABSTRACT_TEXT_CACHE.pop("2606.11127v1", None)
+    call_count = {"n": 0}
+    base_fake = _fake_urlopen_factory(_ARXIV_PAGE_FIXTURE)
+    def counting_fake(*a, **kw):
+        call_count["n"] += 1
+        return base_fake(*a, **kw)
+    with patch("urllib.request.urlopen", counting_fake):
+        run._fetch_arxiv_abstract_text("2606.11127v1")
+        run._fetch_arxiv_abstract_text("2606.11127v1")
+    # Second call hits the cache — only one fetch.
+    assert call_count["n"] == 1
+
+
+def test_fetch_arxiv_abstract_text_returns_empty_on_fetch_failure():
+    run._ARXIV_ABSTRACT_TEXT_CACHE.pop("9999.99999", None)
+    def _raises(*_a, **_k):
+        raise OSError("simulated network failure")
+    with patch("urllib.request.urlopen", _raises):
+        text = run._fetch_arxiv_abstract_text("9999.99999")
+    assert text == ""
+
+
+def test_fetch_arxiv_abstract_text_returns_empty_when_no_blocks_found():
+    # Page exists but has neither <h1 class="title"> nor
+    # <blockquote class="abstract"> — should produce empty text, not
+    # raise. Defensive against arxiv markup drift.
+    run._ARXIV_ABSTRACT_TEXT_CACHE.pop("0000.00000", None)
+    with patch(
+        "urllib.request.urlopen",
+        _fake_urlopen_factory("<html><body><p>unrelated</p></body></html>"),
+    ):
+        text = run._fetch_arxiv_abstract_text("0000.00000")
+    assert text == ""
+
+
+def test_fetch_arxiv_abstract_text_empty_id_short_circuits():
+    # No fetch should happen for empty arxiv ids.
+    called = {"n": 0}
+    def tracker(*_a, **_k):
+        called["n"] += 1
+        raise AssertionError("urlopen should not have been called for empty id")
+    with patch("urllib.request.urlopen", tracker):
+        text = run._fetch_arxiv_abstract_text("")
+    assert text == ""
+    assert called["n"] == 0
+
+
+# ─── _build_fidelity_audit_prompt_paper_anchored ───────────────────────────
+
+
+def test_paper_anchored_prompt_embeds_paper_text_and_signals_anchor():
+    prompt = run._build_fidelity_audit_prompt_paper_anchored(
+        pr_title="Provenance gating in OCRScoringQAStage",
+        pr_body="Recommended paper: arxiv:2606.11127v1\nDelivers adaptive recovery.",
+        pr_diff="diff --git a/ocr_scoring_qa.py b/ocr_scoring_qa.py\n+def _recover_rejected(): ...",
+        arxiv_id="2606.11127v1",
+        paper_text="Title: Provenance-Grounded Gating ...\nAbstract: We study quality gating ...",
+    )
+    # Paper text is in the prompt; the prompt explicitly tells Claude it's
+    # auditing without a cloned reference impl.
+    assert "Provenance-Grounded Gating" in prompt
+    assert "paper-anchored" in prompt.lower()
+    assert "abstract" in prompt.lower()
+    # The output JSON schema stays compatible with the reference-anchored
+    # variant so downstream rendering / status logic doesn't fork.
+    assert '"summary"' in prompt
+    assert '"needs_judgment"' in prompt
+    assert '"items"' in prompt
+    assert '"deviation_class"' in prompt
+
+
+def test_paper_anchored_prompt_truncates_long_diff_inputs():
+    # 60 KB cap on the diff + sentinel marker, mirroring the reference-
+    # anchored prompt's behavior.
+    big_diff = "x" * 200_000
+    prompt = run._build_fidelity_audit_prompt_paper_anchored(
+        pr_title="t", pr_body="b",
+        pr_diff=big_diff,
+        arxiv_id="2606.11127v1", paper_text="Title: x\nAbstract: y",
+    )
+    assert "diff truncated" in prompt
+    assert "200000 chars" in prompt
+
+
+# ─── _render_coverage_matrix audit-anchor surfacing ────────────────────────
+
+
+_MATRIX_FIXTURE = {
+    "summary": "Diff implements the abstract's recovery loop with documented narrowing.",
+    "needs_judgment": False,
+    "items": [
+        {
+            "name": "Adaptive recovery loop",
+            "draft_location": "ocr_scoring_qa.py::_recover_rejected",
+            "reference_location": "abstract: 'adaptive recovery loop diagnoses rejected samples'",
+            "status": "covered",
+            "deviation_class": None,
+            "rationale": "Directly implements the abstract's recover-vs-discard claim.",
+        },
+    ],
+}
+
+
+def test_render_coverage_matrix_surfaces_paper_anchor():
+    out = run._render_coverage_matrix(_MATRIX_FIXTURE, audit_anchor="paper")
+    assert "Audit anchor: paper abstract" in out
+    assert "less precise" in out
+
+
+def test_render_coverage_matrix_surfaces_reference_anchor():
+    out = run._render_coverage_matrix(_MATRIX_FIXTURE, audit_anchor="reference")
+    assert "Audit anchor: reference implementation" in out
+
+
+def test_render_coverage_matrix_default_anchor_is_reference():
+    # Pre-REMYX-145 call sites pass no audit_anchor — they were always
+    # reference-anchored, so the default preserves that behavior.
+    out = run._render_coverage_matrix(_MATRIX_FIXTURE)
+    assert "Audit anchor: reference implementation" in out


### PR DESCRIPTION
## Problem

Phase A skips the entire inline chain when a paper has no public reference impl. The chain dispatcher checks `status.startswith("fidelity_audited")` — and `fidelity_skipped_no_reference` doesn't match, so Phase B (convention) and Phase C (test) also skip, even though they have no dependency on Phase A's output. Concrete impact in a recent trial:

- Phase A skipped → no `## Coverage` matrix posted
- Phase B skipped → PR body kept the original Outrider preamble (the recently-shipped canonical-first body rewrite never ran)
- Phase C skipped → PR left in draft (Phase C is the only step that drops draft)

Papers without public reference impl are a meaningful fraction — closed-source models, brand-new preprints, papers about proprietary systems. The chain shouldn't lose B + C value for any of these.

## Fix — two-mode Phase A

| Mode | Anchor | Precision | Trigger |
|---|---|---|---|
| **A1 reference-anchored** (existing) | Cloned GitHub repo of the paper's reference impl | High — diff vs. concrete code | Reference URL present in PR body |
| **A2 paper-anchored** (new) | arXiv abstract page text | Medium — diff vs. claimed mechanism | Reference URL missing, but arxiv id extractable |

Most plumbing already existed (`_ARXIV_URL_RE`, `_ARXIV_PAGE_CACHE`, `_extract_reference_url_from_pr_body` already returns the arxiv id). The PR adds:

- `_fetch_arxiv_abstract_text(arxiv_id)` — pulls title + abstract from the arxiv abstract page, cached per id, `""` on any failure.
- `_build_fidelity_audit_prompt_paper_anchored(...)` — variant of the audit prompt that anchors against the paper's described method. Same JSON output schema so downstream rendering / status logic doesn't fork.
- `run_fidelity_audit` branches: reference URL → existing clone-and-diff path; else arxiv id + fetchable abstract → paper-anchored path; else → `fidelity_skipped_no_reference` (same skip as today, with a more specific error message).
- New statuses `fidelity_audited_paper_anchored{,_needs_judgment}` — prefix-matched by the chain dispatcher's existing `startswith("fidelity_audited")` check, so B + C run automatically.
- `_render_coverage_matrix` adds an "Audit anchor" line — maintainer reads the precision floor from the artifact itself.

The paper-anchored prompt explicitly tells Claude that the abstract is a method-summary surface (not implementation-level), and to treat abstract-silent details as `deferred` rather than `deviation` — reserving `needs-judgment` for items where the diff clearly conflicts with what the abstract claims. Keeps the audit conservative about its own precision.

## Validation

- `python -m pytest tests/` → 647/647 pass (+12 new)
- New `tests/test_paper_anchored_audit.py` covers the abstract fetcher (extraction, cache, fetch failure, missing blocks, empty id), the new prompt builder (paper text embedding, output schema parity, diff truncation), and the audit-anchor surface in the rendered Coverage matrix
- `tests/test_inline_refinement_chain.py` extended with parametrized cases for both new audited statuses — locks in that B + C still run when Phase A degrades to paper-anchored mode

## Backwards compatibility

- The `audit_anchor` parameter on `_render_coverage_matrix` defaults to `"reference"` so any pre-existing call site keeps its current rendering
- `fidelity_skipped_no_reference` is preserved as a status (now only emitted when *both* reference URL and arxiv abstract are unavailable) — no consumers need to learn a new skip status
- The reference-anchored prompt is unchanged