### PR TITLE
Issue-route convention pass: fold Outrider scaffolding into ISSUE_TEMPLATE shape

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,16 @@ inputs:
           failure (lint surfaced issues or tests failed). PR body is
           untouched — that's the convention pass's surface. Triggered
           after the convention pass; requires ``pr-number``.
+        - "issue-convention": fold an Outrider-drafted Issue's body to
+          the target repo's ``.github/ISSUE_TEMPLATE/`` shape (markdown
+          frontmatter or Issue Forms). Picks the best-fitting template
+          via a single Claude one-shot (filtering out bug/question
+          kinds), then PATCHes the Issue body. Mirrors the PR-route
+          convention pass but with no diff to patch, no draft state,
+          and no test gate — just the body rewrite. Triggered inline
+          in recommend mode when routing to Issue, or explicitly via
+          a standalone ``mode: issue-convention`` workflow_dispatch;
+          requires ``issue-number``.
     required: false
     default: 'recommend'
   chain:
@@ -70,6 +80,17 @@ inputs:
       weekly-summary modes — the inline chain (``chain: true``, default)
       threads the just-opened PR number through automatically, so most
       installs never set this.
+    required: false
+    default: ''
+  issue-number:
+    description: |
+      Issue number to operate on. Read in ``mode: issue-convention`` only;
+      set from the workflow's issues event payload (or a workflow_dispatch
+      input) when driving the Issue-route convention pass against an
+      existing Issue. Empty in recommend / weekly-summary modes — the
+      inline chain (``chain: true``, default) threads the just-opened
+      Issue number through automatically when recommend mode routes to an
+      Issue instead of a PR, so most installs never set this.
     required: false
     default: ''
   weekly-discussion-id:
@@ -292,6 +313,10 @@ runs:
         # PR number to audit in fidelity mode (set from the workflow's
         # pull_request event payload; empty in recommend / weekly-summary).
         INPUT_PR_NUMBER: ${{ inputs.pr-number }}
+        # Issue number to operate on in ``mode: issue-convention``. Empty
+        # in recommend mode — the inline chain reads result["issue_number"]
+        # directly when recommend routes to an Issue.
+        INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
         # Inline refinement chain toggle (recommend mode continues into
         # fidelity → convention → test by default; 'false' opts out).
         INPUT_CHAIN: ${{ inputs.chain }}

--- a/src/run.py
+++ b/src/run.py
@@ -10521,9 +10521,9 @@ the Outrider Issue's actual ask:
 - If no template is a clear fit (e.g. only generic `feature` templates
   exist for what is structurally a model-addition Issue), pick the closest
   match and note the fit-quality in the rationale.
-- If the eligible set is empty, return `template_id: null` — the body is
-  rewritten with only the scaffolding-collapse rule applied (no upstream
-  structure to fold into).
+- If the eligible set is empty, return `(none)` for `TEMPLATE_ID` — the
+  body is rewritten with only the scaffolding-collapse rule applied (no
+  upstream structure to fold into).
 
 Produce an updated Issue body that:
 
@@ -10565,21 +10565,86 @@ Produce an updated Issue body that:
 7. **Does not add boilerplate** that isn't in the picked template
    beyond the one-line attribution and the Discovery-context block.
 
-# Output
+# Output format
 
-Return ONLY valid JSON (no prose before or after):
+Return ONLY a delimited response in EXACTLY this format (no prose before
+or after, no markdown code fences):
 
-{{
-  "template_id": "<filename of picked template, or null>",
-  "rationale": "<one-sentence note on what structurally changed>",
-  "updated_body": "<the full new Issue body in markdown>"
-}}
+===TEMPLATE_ID===
+<filename of picked template, or (none) if no template fits>
+===RATIONALE===
+<one-sentence note on what structurally changed>
+===UPDATED_BODY===
+<the full new Issue body in markdown, verbatim — may contain any
+characters including newlines, quotes, braces, etc.>
+===END===
+
+The delimited format is required because the body is long markdown that
+would be hard to escape in JSON. Do not wrap the response in code fences;
+do not add prose before the first marker or after the last marker. The
+exact section markers (``===TEMPLATE_ID===``, ``===RATIONALE===``,
+``===UPDATED_BODY===``, ``===END===``) must each appear on their own line.
 """
 
 
 def _update_issue_body(target: Target, issue_number: int, new_body: str) -> None:
     """PATCH the Issue body via the GitHub Issues API."""
     gh_api("PATCH", f"/repos/{target.repo}/issues/{issue_number}", {"body": new_body})
+
+
+# Section markers used by the Issue-body-rewrite Claude one-shot's delimited
+# output format. JSON-wrapped output is brittle when the body is long markdown
+# (one unescaped quote in a 30k-token response trashes the parse); a delimited
+# format lets the body contain any chars including quotes, braces, and
+# newlines without any escaping concerns.
+_ISSUE_REWRITE_MARKER_TEMPLATE_ID = "===TEMPLATE_ID==="
+_ISSUE_REWRITE_MARKER_RATIONALE = "===RATIONALE==="
+_ISSUE_REWRITE_MARKER_UPDATED_BODY = "===UPDATED_BODY==="
+_ISSUE_REWRITE_MARKER_END = "===END==="
+
+
+def _parse_issue_rewrite_response(raw: str) -> dict | None:
+    """Parse the delimited Issue-body-rewrite response.
+
+    Expects sections in order: TEMPLATE_ID, RATIONALE, UPDATED_BODY, END.
+    Returns ``{template_id, rationale, updated_body}`` on success, or
+    ``None`` if any marker is missing or out-of-order. Empty
+    ``UPDATED_BODY`` is also treated as a parse failure — the rewrite
+    must produce a body.
+
+    ``(none)`` and the literal string ``null`` in TEMPLATE_ID are both
+    normalised to an empty string (meaning "no template was picked"); the
+    orchestrator treats both as the "no-fitting-template" outcome.
+    """
+    if not raw:
+        return None
+    try:
+        t_start = raw.index(_ISSUE_REWRITE_MARKER_TEMPLATE_ID)
+        r_start = raw.index(_ISSUE_REWRITE_MARKER_RATIONALE)
+        b_start = raw.index(_ISSUE_REWRITE_MARKER_UPDATED_BODY)
+        # END is optional — the body extends to EOF if absent.
+        try:
+            e_start = raw.index(_ISSUE_REWRITE_MARKER_END, b_start)
+        except ValueError:
+            e_start = len(raw)
+    except ValueError:
+        return None
+    # Order check.
+    if not (t_start < r_start < b_start <= e_start):
+        return None
+    template_id = raw[t_start + len(_ISSUE_REWRITE_MARKER_TEMPLATE_ID):r_start].strip()
+    rationale = raw[r_start + len(_ISSUE_REWRITE_MARKER_RATIONALE):b_start].strip()
+    updated_body = raw[b_start + len(_ISSUE_REWRITE_MARKER_UPDATED_BODY):e_start].strip()
+    if not updated_body:
+        return None
+    # Normalise the no-pick sentinels.
+    if template_id.lower() in ("(none)", "null", "none", "", "<none>"):
+        template_id = ""
+    return {
+        "template_id": template_id,
+        "rationale": rationale,
+        "updated_body": updated_body,
+    }
 
 
 def _apply_issue_body_convention_update(
@@ -10603,9 +10668,12 @@ def _apply_issue_body_convention_update(
     ok, raw = _run_claude_oneshot(workdir, prompt, timeout_s, max_turns=4)
     if not ok:
         return False, "", "", f"issue-body-rewrite Claude call failed: {raw[-300:]}"
-    rewrite = _extract_json_object(raw)
-    if not rewrite or "updated_body" not in rewrite:
-        return False, "", "", f"issue-body-rewrite returned unparseable JSON: {raw[-300:]}"
+    rewrite = _parse_issue_rewrite_response(raw)
+    if not rewrite:
+        return False, "", "", (
+            f"issue-body-rewrite returned unparseable delimited response: "
+            f"{raw[-300:]}"
+        )
     new_body = rewrite["updated_body"]
     # Sanity check: if the input carried an arXiv link (paper provenance),
     # the rewrite must keep one. Same guard as the PR-route Phase B.

--- a/src/run.py
+++ b/src/run.py
@@ -5642,8 +5642,8 @@ def open_pr(
 
 def open_issue(
     target: Target, title: str, body: str, *, footer_override: str = "",
-) -> str:
-    """Open a discussion Issue on the target repo. Returns the issue URL.
+) -> tuple[str, int]:
+    """Open a discussion Issue on the target repo. Returns ``(url, number)``.
 
     The default footer attributes the Issue to the coding agent's
     Issue-mode election (the original use case). When the actual route
@@ -5701,7 +5701,7 @@ def open_issue(
                 raise
         else:
             raise
-    return issue["html_url"]
+    return issue["html_url"], int(issue["number"])
 
 
 def parse_issue_fallback_file(path: Path) -> tuple[str, str]:
@@ -6031,7 +6031,7 @@ def _open_downgrade_issue(
     suppress_suggested_experiment: bool = False,
     replacement_experiment: str = "",
     footer_override: str = "",
-) -> str:
+) -> tuple[str, int]:
     """Open an Issue when an automated gate downgrades a PR-candidate.
 
     Used for preflight / integration / stub-density / test-integration /
@@ -6654,7 +6654,7 @@ def process_target(target: Target) -> dict:
                         f"fall outside the PR guardrails."
                     )
                 _record_verdict_fields(result, rec)
-                issue_url = _open_downgrade_issue(
+                issue_url, issue_number = _open_downgrade_issue(
                     target, rec,
                     reason=f"Selection identified an {shape_label} candidate",
                     detail=detail,
@@ -6678,6 +6678,7 @@ def process_target(target: Target) -> dict:
                     "candidates_considered": len(viable),
                     "status": "issue_opened_substitution",
                     "issue_url": issue_url,
+                    "issue_number": issue_number,
                 })
                 log.info(
                     f"  ✓ issue_opened_substitution ({shape}, external): "
@@ -6726,7 +6727,7 @@ def process_target(target: Target) -> dict:
                         f"can decide whether to merge the upgrade."
                     )
                     _record_verdict_fields(result, rec)
-                    issue_url = _open_downgrade_issue(
+                    issue_url, issue_number = _open_downgrade_issue(
                         target, rec,
                         reason=f"Selection identified a {shape_label} candidate",
                         detail=detail,
@@ -6750,6 +6751,7 @@ def process_target(target: Target) -> dict:
                         "candidates_considered": len(viable),
                         "status": "issue_opened_substitution",
                         "issue_url": issue_url,
+                        "issue_number": issue_number,
                     })
                     log.info(f"  ✓ issue_opened_substitution ({shape}): {issue_url}")
                     return result
@@ -6811,7 +6813,7 @@ def process_target(target: Target) -> dict:
                 f"{preflight.get('reasoning', '(no reasoning provided)')}\n\n"
                 f"{issue_body_inner}"
             )
-            issue_url = _open_downgrade_issue(
+            issue_url, issue_number = _open_downgrade_issue(
                 target, rec,
                 reason="Pre-flight routed to Issue before implementation",
                 detail=preflight_detail,
@@ -6842,6 +6844,7 @@ def process_target(target: Target) -> dict:
             # more specific than the generic paper title.
             result["status"] = "issue_opened_preflight"
             result["issue_url"] = issue_url
+            result["issue_number"] = issue_number
             log.info(f"  ✓ issue_opened_preflight: {issue_url}")
             return result
 
@@ -6875,9 +6878,10 @@ def process_target(target: Target) -> dict:
                 f"\n---\n\n"
                 f"{issue_body_inner}"
             )
-            issue_url = open_issue(target, issue_title, issue_body)
+            issue_url, issue_number = open_issue(target, issue_title, issue_body)
             result["status"] = "issue_opened"
             result["issue_url"] = issue_url
+            result["issue_number"] = issue_number
             log.info(f"  ✓ issue_opened: {issue_url}")
             return result
 
@@ -6898,7 +6902,7 @@ def process_target(target: Target) -> dict:
         if not passed_integration:
             result["integration_violations"] = int_violations
             log.warning(f"  ✗ integration check failed: {int_violations}")
-            issue_url = _open_downgrade_issue(
+            issue_url, issue_number = _open_downgrade_issue(
                 target, rec,
                 reason="No real integration with the existing codebase",
                 detail=(
@@ -6922,6 +6926,7 @@ def process_target(target: Target) -> dict:
             )
             result["status"] = "issue_opened_no_integration"
             result["issue_url"] = issue_url
+            result["issue_number"] = issue_number
             return result
 
         # 7.6. Stub density (§3). Routes to Issue if the new module's
@@ -6935,7 +6940,7 @@ def process_target(target: Target) -> dict:
                 f"  ✗ stub density {density:.0%} ≥ "
                 f"{STUB_DENSITY_DOWNGRADE_THRESHOLD:.0%}; downgrading to Issue"
             )
-            issue_url = _open_downgrade_issue(
+            issue_url, issue_number = _open_downgrade_issue(
                 target, rec,
                 reason=(
                     f"New module is mostly unimplemented "
@@ -6964,6 +6969,7 @@ def process_target(target: Target) -> dict:
             )
             result["status"] = "issue_opened_stub_density"
             result["issue_url"] = issue_url
+            result["issue_number"] = issue_number
             return result
 
         # 7.7. Diff Risk Score (RADAR). Calibrated static-diff risk band
@@ -6977,7 +6983,7 @@ def process_target(target: Target) -> dict:
         if risk.band == "high":
             log.warning(f"  ✗ diff risk {risk.score:.2f} ≥ "
                         f"{DIFF_RISK_ISSUE_THRESHOLD:.2f} (high); → Issue")
-            issue_url = _open_downgrade_issue(
+            issue_url, issue_number = _open_downgrade_issue(
                 target, rec,
                 reason=(f"Diff Risk Score {risk.score:.2f} exceeds the "
                         f"auto-land threshold ({DIFF_RISK_ISSUE_THRESHOLD:.2f})"),
@@ -6999,6 +7005,7 @@ def process_target(target: Target) -> dict:
             )
             result["status"] = "issue_opened_high_risk"
             result["issue_url"] = issue_url
+            result["issue_number"] = issue_number
             return result
 
         # 8. Tests
@@ -7038,7 +7045,7 @@ def process_target(target: Target) -> dict:
                         "  ✗ no new test imports from an existing module — "
                         "tests only self-test the new file"
                     )
-                    issue_url = _open_downgrade_issue(
+                    issue_url, issue_number = _open_downgrade_issue(
                         target, rec,
                         reason=(
                             "New tests don't touch any pre-existing module"
@@ -7065,6 +7072,7 @@ def process_target(target: Target) -> dict:
                     )
                     result["status"] = "issue_opened_no_test_integration"
                     result["issue_url"] = issue_url
+                    result["issue_number"] = issue_number
                     return result
 
         # 9. Self-review (§4). Second Claude pass over the diff. Renders
@@ -7095,7 +7103,7 @@ def process_target(target: Target) -> dict:
                 detail_body += (
                     f"\n### Self-review summary\n\n{summary}\n"
                 )
-            issue_url = _open_downgrade_issue(
+            issue_url, issue_number = _open_downgrade_issue(
                 target, rec,
                 reason="Self-review judged the new code an orphan (no production call path)",
                 detail=detail_body,
@@ -7113,6 +7121,7 @@ def process_target(target: Target) -> dict:
             )
             result["status"] = "issue_opened_self_review"
             result["issue_url"] = issue_url
+            result["issue_number"] = issue_number
             return result
         review_section = _render_self_review_section(review) if review else ""
 
@@ -10293,6 +10302,470 @@ def run_convention_pass(target: Target) -> dict:
     return result
 
 
+# ─── Refinement-pass: Issue-route convention alignment ────────────────────
+#
+# Parallel to the PR-route convention pass above, but for Outrider Issues.
+# When recommend mode routes to an Issue (issue_opened_preflight,
+# issue_opened_self_review, issue_opened_substitution, etc.), this pass
+# reads the target repo's .github/ISSUE_TEMPLATE/ files, picks the best-
+# fitting template via a Claude one-shot, and rewrites the Issue body to
+# match that template's shape — folding Outrider scaffolding into matching
+# sections and relegating non-mapping content to a single <details> block.
+# Issues have no diff, no draft state, and no Phase C, so this is a single
+# Claude call + a PATCH to the Issue body — much cheaper than the PR-route
+# convention pass.
+#
+# Input (workflow surface):
+#   INPUT_ISSUE_NUMBER — Issue number to refine (set by the inline
+#                        dispatcher or a standalone `mode: issue-convention`
+#                        workflow_dispatch)
+#
+# Output:
+#   - Issue body PATCHed with the rewritten content
+#   - Label applied: outrider:issue-convention-done
+#   - status: issue_convention_aligned / issue_convention_aligned_no_fitting_template
+#             / issue_convention_skipped_no_templates / issue_convention_failed_*
+
+ISSUE_CONVENTION_LABEL_DONE = "outrider:issue-convention-done"
+
+# Template-kind heuristic keywords. The picker filters out templates whose
+# kind is 'bug' or 'question' before passing the candidate set to Claude —
+# Outrider's paper-pitch shape would be a bad fit for either, and rewriting
+# as a bug report (lerobot's case in test forks) would actively harm the
+# Issue's reception.
+# Priority order: bug + new_model are checked before feature so that
+# specific contributions get specific kinds. e.g. "New dataset request"
+# matches `dataset` (new_model) before `request` (feature).
+_TEMPLATE_KIND_KEYWORDS = {
+    "bug": ("bug", "crash", "error", "broken", "regression", "fault"),
+    "new_model": ("model", "dataset", "benchmark", "evaluation", "eval"),
+    "feature": ("feature", "enhancement", "improvement", "request"),
+    "question": ("question", "help", "discussion", "support", "how do"),
+}
+
+# Frontmatter / Issue-form metadata extractors. Both formats expose `name`
+# and `description` as top-level keys; regex extraction is robust enough
+# for the kind-classifier without pulling in a YAML dependency. Markdown
+# frontmatter is delimited by `---` on its own line; Issue Forms have no
+# such delimiter (the YAML is the whole file).
+_TEMPLATE_NAME_RE = re.compile(r'^name:\s*(.+?)\s*$', re.MULTILINE | re.IGNORECASE)
+_TEMPLATE_DESCRIPTION_RE = re.compile(r'^description:\s*(.+?)\s*$', re.MULTILINE | re.IGNORECASE)
+
+# Filenames to skip when walking .github/ISSUE_TEMPLATE/. config.yml is
+# GitHub's metadata file (controls "blank issue allowed" + contact links),
+# not a template itself.
+_ISSUE_TEMPLATE_SKIP_FILES = frozenset({"config.yml", "config.yaml"})
+
+# Accepted template file extensions. mteb uses .yaml, ag2/dspy/lerobot use
+# .yml, haystack uses .md — discovery walks all three.
+_ISSUE_TEMPLATE_EXTENSIONS = (".md", ".yml", ".yaml")
+
+
+def _fetch_issue_templates_from_repo(target_repo: str) -> list[dict]:
+    """Return the parsed Issue templates from ``.github/ISSUE_TEMPLATE/``.
+
+    Each element of the returned list is a dict shaped like:
+
+        {
+          "filename": "feature_request.yml",
+          "name": "Feature Request",          # from frontmatter or YAML top
+          "description": "Suggest a feature", # may be empty
+          "kind": "feature",                  # heuristic classification
+          "raw_content": "<full file body>",
+        }
+
+    Returns ``[]`` when the directory is missing or empty, or when every
+    file is `config.yml`-style metadata. Never raises — the caller falls
+    back to the no-templates path on an empty list.
+    """
+    try:
+        listing = gh_api("GET", f"/repos/{target_repo}/contents/.github/ISSUE_TEMPLATE")
+    except RuntimeError as e:
+        # 404 → no template directory; that's a normal case, not an error.
+        log.debug(f"  no ISSUE_TEMPLATE/ on {target_repo}: {e}")
+        return []
+    if not isinstance(listing, list):
+        return []
+
+    templates: list[dict] = []
+    for entry in listing:
+        if entry.get("type") != "file":
+            continue
+        filename = entry.get("name", "")
+        if filename in _ISSUE_TEMPLATE_SKIP_FILES:
+            continue
+        if not filename.endswith(_ISSUE_TEMPLATE_EXTENSIONS):
+            continue
+        # Fetch the raw content. The Contents API returns base64 when the
+        # file is small; for files > 1MB it returns a download_url instead
+        # — Issue templates are always tiny so we only handle the base64
+        # path here.
+        content_b64 = entry.get("content", "")
+        if not content_b64:
+            # Some API responses elide content for directory listings;
+            # fetch the file directly in that case.
+            try:
+                file_meta = gh_api(
+                    "GET",
+                    f"/repos/{target_repo}/contents/.github/ISSUE_TEMPLATE/{filename}",
+                )
+                content_b64 = file_meta.get("content", "")
+            except RuntimeError:
+                continue
+        try:
+            raw = base64.b64decode(content_b64).decode("utf-8", errors="replace")
+        except (ValueError, UnicodeDecodeError):
+            continue
+
+        name = ""
+        description = ""
+        m_name = _TEMPLATE_NAME_RE.search(raw)
+        if m_name:
+            name = m_name.group(1).strip().strip('"').strip("'")
+        m_desc = _TEMPLATE_DESCRIPTION_RE.search(raw)
+        if m_desc:
+            description = m_desc.group(1).strip().strip('"').strip("'")
+
+        templates.append({
+            "filename": filename,
+            "name": name or filename,
+            "description": description,
+            "kind": _classify_template_kind(name, description),
+            "raw_content": raw,
+        })
+    return templates
+
+
+def _classify_template_kind(name: str, description: str) -> str:
+    """Heuristic classifier — returns ``bug | feature | new_model | question | other``.
+
+    Walks the kind keywords in priority order (bug > feature > new_model > question).
+    Bug + question kinds are filtered out by the picker since Outrider's
+    paper-pitch shape doesn't fit either. ``new_model`` covers the mteb-style
+    "add a new model / dataset / benchmark" templates that are the strongest
+    Outrider fit when present.
+    """
+    haystack = f"{name} {description}".lower()
+    for kind, keywords in _TEMPLATE_KIND_KEYWORDS.items():
+        if any(kw in haystack for kw in keywords):
+            return kind
+    return "other"
+
+
+def _filter_eligible_templates(templates: list[dict]) -> list[dict]:
+    """Drop templates whose kind doesn't fit Outrider's paper-pitch shape.
+
+    ``bug`` and ``question`` templates would actively harm the rewrite —
+    forcing a "describe the bug" / "what's your question" shape onto a
+    paper recommendation is a worse outcome than the default body. Keeps
+    ``feature`` / ``new_model`` / ``other``.
+    """
+    return [t for t in templates if t.get("kind") not in ("bug", "question")]
+
+
+def _build_issue_body_rewrite_prompt(
+    issue_title: str, current_body: str, eligible_templates: list[dict]
+) -> str:
+    """Compose the Claude one-shot that picks the best-fitting Issue template
+    and rewrites the Issue body to match it.
+
+    Combines the picker + body-rewrite into one call (vs two) since both
+    operate on the same inputs and an isolated picker doesn't materially
+    constrain the rewrite's quality. The LLM picks template_id by best
+    structural match against the Outrider body and produces the rewritten
+    body in the same JSON response.
+    """
+    template_blocks = []
+    for t in eligible_templates[:6]:  # cap to keep the prompt bounded
+        template_blocks.append(
+            f"### Template: `{t['filename']}` (kind: {t['kind']})\n\n"
+            f"**Name**: {t['name']}\n"
+            f"**Description**: {t.get('description') or '(no description)'}\n\n"
+            f"**Raw file:**\n\n```\n{t['raw_content'][:2500]}\n```"
+        )
+    templates_section = "\n\n".join(template_blocks) if template_blocks else "(none — only bug/question templates were available)"
+
+    return f"""You are rewriting a draft Issue's body to match the target repo's Issue template conventions.
+
+# Issue being refined
+
+**Title**: {issue_title}
+
+# Current Issue body
+
+```
+{current_body[:8000]}
+```
+
+# Eligible templates from the target repo's `.github/ISSUE_TEMPLATE/`
+
+{templates_section}
+
+# Task
+
+The Outrider Issue body above carries the orchestrator's draft scaffolding
+(paper provenance, "Why this paper is interesting for the team", "Why this
+candidate", license metadata, "Suggested experiment", "Intentionally out
+of scope", routing-reason sections). That scaffolding is **secondary
+context**, not first-class content. The target repo's Issue templates are
+the **primary structure** — a maintainer reading the rewritten Issue
+should see the template's shape, not the Outrider sections.
+
+Pick the **best-fitting template** from the eligible set. "Best fit" means
+the template whose `name` / `description` / body fields most closely match
+the Outrider Issue's actual ask:
+
+- If a template specifically targets the kind of contribution Outrider is
+  proposing (e.g. `new_model.yaml` for a paper-anchored model addition),
+  prefer it over a generic `feature_request` template.
+- If no template is a clear fit (e.g. only generic `feature` templates
+  exist for what is structurally a model-addition Issue), pick the closest
+  match and note the fit-quality in the rationale.
+- If the eligible set is empty, return `template_id: null` — the body is
+  rewritten with only the scaffolding-collapse rule applied (no upstream
+  structure to fold into).
+
+Produce an updated Issue body that:
+
+1. **Treats the picked template as the primary structure.** Use its
+   section headings (or its YAML Issue Form labels rendered as `**Bold
+   field name**` lines, in the order the form declares them) as the
+   body's primary reading surface. For YAML Issue Forms, render each
+   `body[].attributes.label` as a `**Label**` line followed by the
+   matching content from the Outrider body.
+2. **Folds the current body's facts INTO the template's fields.** The
+   Outrider "Why this paper is interesting" / "Suggested experiment" /
+   delivery-rationale content fills the template's `Description` /
+   `Problem` / `Solution` / similar fields. Quote arxiv IDs, GitHub
+   URLs, and license metadata into the template's dedicated fields if
+   any exist (e.g. mteb's `Arxiv link` input).
+3. **Relegates Outrider-only context to ONE collapsed block.** Sections
+   from the current body that don't map to any template field (the
+   discovery-loop blockquote, "Why this candidate" selection reasoning,
+   "What else Outrider considered" rejection list, paper-provenance
+   confidence/relevance lines, footer promos) go inside a single
+   ``<details><summary>Discovery context</summary>`` block placed at
+   the bottom of the body. If there's no such content, omit the block.
+4. **Compresses attribution to one italicized line** placed immediately
+   above the Discovery-context block (or at the very bottom if the
+   block was omitted): ``_Drafted by [Outrider](https://github.com/remyxai/outrider)
+   — paper: [arXiv:<id>](<arxiv-url>)._``
+5. **Preserves the paper's reference repo URL** if present. If the
+   picked template has a dedicated code/link field, put it there.
+   Otherwise put it inside the Discovery-context block as
+   ``Reference: https://github.com/<owner>/<repo>``.
+6. **Reuses substantive facts** — paper title, arxiv id, call-site
+   notes, the routing-reason section ("Why the orchestrator opened an
+   Issue instead of a PR"), the re-engagement note ("Reopen this Issue
+   if you want Outrider to revisit this paper later"). Do not invent
+   new claims; do not drop the routing-reason content (it's auditable
+   evidence of why this is an Issue, not a PR) — fold it into the
+   template's discussion/context field if available, otherwise keep it
+   as a clearly-labeled section above the Discovery-context block.
+7. **Does not add boilerplate** that isn't in the picked template
+   beyond the one-line attribution and the Discovery-context block.
+
+# Output
+
+Return ONLY valid JSON (no prose before or after):
+
+{{
+  "template_id": "<filename of picked template, or null>",
+  "rationale": "<one-sentence note on what structurally changed>",
+  "updated_body": "<the full new Issue body in markdown>"
+}}
+"""
+
+
+def _update_issue_body(target: Target, issue_number: int, new_body: str) -> None:
+    """PATCH the Issue body via the GitHub Issues API."""
+    gh_api("PATCH", f"/repos/{target.repo}/issues/{issue_number}", {"body": new_body})
+
+
+def _apply_issue_body_convention_update(
+    target: Target,
+    issue_number: int,
+    current_body: str,
+    eligible_templates: list[dict],
+    issue_title: str,
+    timeout_s: int,
+    workdir: Path,
+) -> tuple[bool, str, str, str]:
+    """Run the Issue-body rewrite one-shot and PATCH the Issue body.
+
+    Returns ``(ok, picked_template_id, rationale, error)``. On non-fatal
+    failure returns ``ok=False`` with an error message; the caller treats
+    that as ``issue_convention_failed_claude`` and moves on.
+    """
+    prompt = _build_issue_body_rewrite_prompt(
+        issue_title, current_body, eligible_templates,
+    )
+    ok, raw = _run_claude_oneshot(workdir, prompt, timeout_s, max_turns=4)
+    if not ok:
+        return False, "", "", f"issue-body-rewrite Claude call failed: {raw[-300:]}"
+    rewrite = _extract_json_object(raw)
+    if not rewrite or "updated_body" not in rewrite:
+        return False, "", "", f"issue-body-rewrite returned unparseable JSON: {raw[-300:]}"
+    new_body = rewrite["updated_body"]
+    # Sanity check: if the input carried an arXiv link (paper provenance),
+    # the rewrite must keep one. Same guard as the PR-route Phase B.
+    current_arxiv = _ARXIV_URL_RE.search(current_body)
+    if current_arxiv:
+        if not _ARXIV_URL_RE.search(new_body):
+            return False, "", "", (
+                f"issue-body-rewrite dropped the arXiv link "
+                f"({current_arxiv.group(0)}); paper provenance must "
+                f"remain reachable"
+            )
+    try:
+        _update_issue_body(target, issue_number, new_body)
+    except RuntimeError as e:
+        return False, "", "", f"Issue body PATCH failed: {e}"
+    return (
+        True,
+        rewrite.get("template_id") or "",
+        rewrite.get("rationale", "structurally aligned to Issue template"),
+        "",
+    )
+
+
+def run_issue_convention_pass(target: Target) -> dict:
+    """Phase B (Issue route) — fold Outrider scaffolding into the target
+    repo's Issue template shape.
+
+    Status values:
+        issue_convention_aligned                       — picked a template
+                                                         and rewrote the body
+        issue_convention_aligned_no_fitting_template   — templates exist but
+                                                         none fit Outrider's
+                                                         paper-pitch shape
+                                                         (e.g. bug-only sets);
+                                                         rewrote with scaffolding
+                                                         collapsed
+        issue_convention_skipped_no_templates          — no .github/ISSUE_TEMPLATE/
+                                                         directory; rewrote with
+                                                         scaffolding collapsed
+        issue_convention_skipped_no_issue              — INPUT_ISSUE_NUMBER empty
+        issue_convention_skipped_not_bot               — Issue not authored by
+                                                         remyx-ai[bot]
+        issue_convention_failed_claude                 — Claude call failed or
+                                                         returned unparseable JSON
+        issue_convention_failed_patch                  — PATCH to Issue body
+                                                         failed
+    """
+    result: dict = {"repo": target.repo, "mode": "issue-convention", "status": "unknown"}
+
+    issue_number_raw = os.environ.get("INPUT_ISSUE_NUMBER", "").strip()
+    if not issue_number_raw:
+        result["status"] = "issue_convention_skipped_no_issue"
+        log.info("  ✗ issue-convention mode invoked without INPUT_ISSUE_NUMBER")
+        return result
+    try:
+        issue_number = int(issue_number_raw)
+    except ValueError:
+        result["status"] = "issue_convention_skipped_no_issue"
+        log.error(f"  ✗ INPUT_ISSUE_NUMBER={issue_number_raw!r} is not an integer")
+        return result
+    result["issue_number"] = issue_number
+    log.info(f"  → issue convention pass on {target.repo}#{issue_number}")
+
+    try:
+        issue = gh_api("GET", f"/repos/{target.repo}/issues/{issue_number}")
+    except RuntimeError as e:
+        result["status"] = "issue_convention_failed_claude"
+        result["error"] = f"could not fetch Issue: {e}"
+        return result
+
+    author = (issue.get("user") or {}).get("login", "")
+    if author != "remyx-ai[bot]":
+        result["status"] = "issue_convention_skipped_not_bot"
+        result["error"] = f"Issue author is {author!r}, not remyx-ai[bot]"
+        log.info(f"  ✗ Issue #{issue_number} authored by {author!r}; skipping")
+        return result
+
+    issue_title = issue.get("title") or ""
+    current_body = issue.get("body") or ""
+
+    upstream_repo = _resolve_upstream_for_conventions(target)
+    log.info(f"  → fetching issue templates from {upstream_repo}")
+    templates = _fetch_issue_templates_from_repo(upstream_repo)
+    result["templates_found"] = len(templates)
+
+    if not templates:
+        # The "no templates at all" path. We still want to clean up the
+        # Outrider scaffolding (collapse into <details>) even without a
+        # canonical structure to fold into — partial improvement is still
+        # an improvement. The rewrite prompt handles the empty-templates
+        # case by setting template_id=null and applying only the
+        # scaffolding-collapse rule.
+        workdir = Path(tempfile.mkdtemp(prefix="outrider-issue-convention-"))
+        log.info(f"  → workdir: {workdir} (no templates — scaffolding-collapse only)")
+        ok, picked, rationale, err = _apply_issue_body_convention_update(
+            target, issue_number, current_body, [], issue_title,
+            target.claude_timeout_s, workdir,
+        )
+        if not ok:
+            result["status"] = "issue_convention_failed_claude"
+            result["error"] = err
+            return result
+        result["status"] = "issue_convention_skipped_no_templates"
+        result["rationale"] = rationale
+        _add_pr_label(target, issue_number, ISSUE_CONVENTION_LABEL_DONE)
+        log.info(f"  ✓ {result['status']}: {rationale}")
+        return result
+
+    eligible = _filter_eligible_templates(templates)
+    result["templates_eligible"] = len(eligible)
+    result["templates_filtered_kinds"] = sorted({
+        t["kind"] for t in templates if t.get("kind") in ("bug", "question")
+    })
+
+    workdir = Path(tempfile.mkdtemp(prefix="outrider-issue-convention-"))
+    log.info(f"  → workdir: {workdir}")
+    log.info(
+        f"  → {len(templates)} templates found, "
+        f"{len(eligible)} eligible after kind-filter"
+    )
+
+    ok, picked_template_id, rationale, err = _apply_issue_body_convention_update(
+        target, issue_number, current_body,
+        eligible if eligible else [],  # if all filtered, prompt sees empty set
+        issue_title,
+        target.claude_timeout_s, workdir,
+    )
+    if not ok:
+        if "PATCH failed" in err:
+            result["status"] = "issue_convention_failed_patch"
+        else:
+            result["status"] = "issue_convention_failed_claude"
+        result["error"] = err
+        log.error(f"  ✗ {result['status']}: {err}")
+        return result
+
+    result["picked_template"] = picked_template_id
+    result["rationale"] = rationale
+
+    if not eligible:
+        # Templates existed but the kind-filter dropped them all (e.g.
+        # bug-only sets like lerobot). The body was still rewritten with
+        # scaffolding collapsed, but no upstream template was applied.
+        result["status"] = "issue_convention_aligned_no_fitting_template"
+    elif not picked_template_id:
+        # Eligible templates existed but the LLM declined to pick one
+        # (judged none a fit). Same outcome shape as the no-fitting case.
+        result["status"] = "issue_convention_aligned_no_fitting_template"
+    else:
+        result["status"] = "issue_convention_aligned"
+
+    _add_pr_label(target, issue_number, ISSUE_CONVENTION_LABEL_DONE)
+    result["issue_url"] = issue.get("html_url", "")
+    log.info(
+        f"  ✓ {result['status']} "
+        f"(template={picked_template_id or '(none)'}): {rationale}"
+    )
+    return result
+
+
 # ─── Refinement-pass: test gate ────────────────────────────────────────────
 #
 # Triggered after the convention pass completes. Runs lint + targeted tests
@@ -11277,9 +11750,13 @@ def main():
         or os.environ.get("INPUT_MODE")
         or "recommend"
     ).strip().lower().replace("_", "-")
-    if mode not in ("recommend", "weekly-summary", "fidelity", "convention", "test"):
+    if mode not in (
+        "recommend", "weekly-summary", "fidelity", "convention", "test",
+        "issue-convention",
+    ):
         log.error(f"Unknown mode {mode!r}; must be 'recommend', "
-                  f"'weekly-summary', 'fidelity', 'convention', or 'test'.")
+                  f"'weekly-summary', 'fidelity', 'convention', 'test', "
+                  f"or 'issue-convention'.")
         sys.exit(2)
 
     target = build_target_from_env()
@@ -11304,6 +11781,11 @@ def main():
         log.info(f"  mode=test  pr_number={pr_number}")
         runner = run_test_gate
         failure_status = "test_failed_setup"
+    elif mode == "issue-convention":
+        issue_number = os.environ.get("INPUT_ISSUE_NUMBER", "").strip()
+        log.info(f"  mode=issue-convention  issue_number={issue_number}")
+        runner = run_issue_convention_pass
+        failure_status = "issue_convention_failed_claude"
     else:
         log.info(f"  min_confidence={target.min_confidence}  "
                  f"draft_mode={target.draft_mode}  "
@@ -11334,6 +11816,27 @@ def main():
             result["chain"] = run_refinement_chain(target, result["pr_number"])
         except Exception as e:
             log.exception(f"  ✗ refinement chain failed (non-fatal): {e}")
+            result["chain"] = {"error": str(e)}
+    # Issue-route convention pass: when recommend mode opens an Issue
+    # instead of a PR (preflight downgrade, self-review orphan, substitution,
+    # etc.), run the Issue-route equivalent of Phase B to align the Issue
+    # body to the target repo's ISSUE_TEMPLATE shape. No Phase A (no diff to
+    # audit) and no Phase C (no tests to run / no draft state); this is a
+    # single body-rewrite call.
+    elif (
+        mode == "recommend"
+        and target.chain_enabled
+        and str(result.get("status", "")).startswith("issue_opened")
+        and result.get("issue_number")
+    ):
+        try:
+            os.environ["INPUT_ISSUE_NUMBER"] = str(result["issue_number"])
+            result["chain"] = {
+                "issue_number": result["issue_number"],
+                "issue_convention_status": run_issue_convention_pass(target).get("status"),
+            }
+        except Exception as e:
+            log.exception(f"  ✗ issue-convention pass failed (non-fatal): {e}")
             result["chain"] = {"error": str(e)}
     elif mode == "recommend" and not target.chain_enabled:
         log.info("  chain disabled (chain: false); skipping refinement chain")

--- a/tests/test_inline_refinement_chain.py
+++ b/tests/test_inline_refinement_chain.py
@@ -199,12 +199,62 @@ def test_main_skips_chain_when_disabled(monkeypatch):
 
 
 def test_main_skips_chain_when_no_pr_opened(monkeypatch):
-    # An Issue-routed run (no PR) must not trigger the chain even with
-    # chain_enabled, since there's no PR number to operate on.
+    # An Issue-routed run without an issue_number must not trigger
+    # either the PR-route or the Issue-route chain, since there's
+    # nothing to operate on.
     _base_env(monkeypatch)
     invoked = _make_recommend_main(
         monkeypatch, chain_enabled=True,
         process_result={"repo": "owner/repo", "status": "issue_opened"},
     )
+    issue_invoked = []
+    monkeypatch.setattr(
+        run, "run_issue_convention_pass",
+        lambda t: issue_invoked.append(run.os.environ.get("INPUT_ISSUE_NUMBER")) or {"status": "issue_convention_aligned"},
+    )
     run.main()
     assert invoked == []
+    assert issue_invoked == []
+
+
+def test_main_invokes_issue_convention_when_issue_opened(monkeypatch):
+    # REMYX-146: when recommend mode opens an Issue with a known
+    # issue_number, the inline dispatcher invokes run_issue_convention_pass
+    # with INPUT_ISSUE_NUMBER set to the just-opened Issue.
+    _base_env(monkeypatch)
+    invoked = _make_recommend_main(
+        monkeypatch, chain_enabled=True,
+        process_result={
+            "repo": "owner/repo",
+            "status": "issue_opened_preflight",
+            "issue_number": 17,
+        },
+    )
+    issue_invoked = []
+    monkeypatch.setattr(
+        run, "run_issue_convention_pass",
+        lambda t: issue_invoked.append(run.os.environ.get("INPUT_ISSUE_NUMBER")) or {"status": "issue_convention_aligned"},
+    )
+    run.main()
+    assert invoked == []  # PR-route chain not called for Issue-route artifact
+    assert issue_invoked == ["17"]  # Issue-route convention pass called with the issue number
+
+
+def test_main_skips_issue_convention_when_chain_disabled(monkeypatch):
+    _base_env(monkeypatch)
+    invoked = _make_recommend_main(
+        monkeypatch, chain_enabled=False,
+        process_result={
+            "repo": "owner/repo",
+            "status": "issue_opened_substitution",
+            "issue_number": 8,
+        },
+    )
+    issue_invoked = []
+    monkeypatch.setattr(
+        run, "run_issue_convention_pass",
+        lambda t: issue_invoked.append(t.repo) or {"status": "issue_convention_aligned"},
+    )
+    run.main()
+    assert invoked == []
+    assert issue_invoked == []

--- a/tests/test_issue_convention_pass.py
+++ b/tests/test_issue_convention_pass.py
@@ -1,0 +1,400 @@
+"""Tests for the Issue-route convention pass (REMYX-146).
+
+Covers the new helpers in `src/run.py`:
+  - `_fetch_issue_templates_from_repo`: walks .github/ISSUE_TEMPLATE/,
+    skips config.yml, parses both markdown frontmatter and Issue Forms
+    YAML, accepts .md/.yml/.yaml.
+  - `_classify_template_kind`: heuristic on name+description.
+  - `_filter_eligible_templates`: drops bug/question kinds.
+  - `_build_issue_body_rewrite_prompt`: embeds templates + outrider body,
+    instructs canonical-first folding, schema-compatible JSON output.
+  - `run_issue_convention_pass`: end-to-end orchestrator with the no-templates,
+    no-fitting-template, and aligned paths.
+
+Run with: pytest tests/test_issue_convention_pass.py -q
+"""
+import base64
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+def _b64(s: str) -> str:
+    return base64.b64encode(s.encode("utf-8")).decode("ascii")
+
+
+# ─── Template kind classifier ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name,description,expected", [
+    ("Bug Report", "Report a bug", "bug"),
+    ("Crash report", "App crashes when...", "bug"),
+    ("Feature Request", "Suggest a new feature", "feature"),
+    ("Enhancement", "Improve an existing thing", "feature"),
+    ("🤖 New model", "Add a new model to the benchmark", "new_model"),
+    ("New dataset request", "Propose a dataset", "new_model"),
+    ("Eval request", "Request an evaluation", "new_model"),
+    ("Question", "Ask a question", "question"),
+    ("Discussion", "Open a discussion", "question"),
+    ("Documentation", "Improve the docs", "other"),
+])
+def test_classify_template_kind(name, description, expected):
+    assert run._classify_template_kind(name, description) == expected
+
+
+# ─── Eligible filter ───────────────────────────────────────────────────────
+
+
+def test_filter_eligible_drops_bug_and_question():
+    templates = [
+        {"filename": "bug.md", "kind": "bug"},
+        {"filename": "feature.md", "kind": "feature"},
+        {"filename": "question.md", "kind": "question"},
+        {"filename": "new_model.yaml", "kind": "new_model"},
+        {"filename": "docs.md", "kind": "other"},
+    ]
+    eligible = run._filter_eligible_templates(templates)
+    kinds = [t["kind"] for t in eligible]
+    assert "bug" not in kinds
+    assert "question" not in kinds
+    assert set(kinds) == {"feature", "new_model", "other"}
+
+
+# ─── Template-fetch helper ─────────────────────────────────────────────────
+
+
+def _fake_listing(files):
+    """Build a Contents-API-shaped directory listing for the templates."""
+    return [
+        {
+            "type": "file",
+            "name": filename,
+            "content": _b64(content),
+        }
+        for filename, content in files
+    ]
+
+
+def test_fetch_issue_templates_parses_markdown_frontmatter(monkeypatch):
+    md_body = (
+        "---\n"
+        "name: Feature Request\n"
+        "about: Suggest an idea for this project\n"
+        "labels: ''\n"
+        "---\n"
+        "\n"
+        "**Is your feature request related to a problem?**\n"
+        "A clear description.\n"
+    )
+    monkeypatch.setattr(run, "gh_api", lambda m, p, b=None: _fake_listing([
+        ("feature_request.md", md_body),
+    ]))
+    templates = run._fetch_issue_templates_from_repo("owner/repo")
+    assert len(templates) == 1
+    t = templates[0]
+    assert t["filename"] == "feature_request.md"
+    assert t["name"] == "Feature Request"
+    assert t["kind"] == "feature"
+    assert "**Is your feature request related to a problem?**" in t["raw_content"]
+
+
+def test_fetch_issue_templates_parses_issue_forms_yaml(monkeypatch):
+    yml_body = (
+        "name: 🤖 New model\n"
+        "description: Create a request for a new model to be added to MTEB\n"
+        "labels: [\"new model\"]\n"
+        "body:\n"
+        "  - type: input\n"
+        "    attributes:\n"
+        "      label: Model link on Hugging Face\n"
+        "  - type: input\n"
+        "    attributes:\n"
+        "      label: Arxiv link\n"
+    )
+    monkeypatch.setattr(run, "gh_api", lambda m, p, b=None: _fake_listing([
+        ("new_model.yaml", yml_body),
+    ]))
+    templates = run._fetch_issue_templates_from_repo("owner/repo")
+    assert len(templates) == 1
+    t = templates[0]
+    assert t["name"] == "🤖 New model"
+    assert t["description"] == "Create a request for a new model to be added to MTEB"
+    assert t["kind"] == "new_model"
+
+
+def test_fetch_issue_templates_accepts_all_three_extensions(monkeypatch):
+    # haystack uses .md, ag2/dspy/lerobot use .yml, mteb uses .yaml — all
+    # must be discovered. Discovery silently drops files with other
+    # extensions.
+    monkeypatch.setattr(run, "gh_api", lambda m, p, b=None: _fake_listing([
+        ("feature.md", "---\nname: Feature\n---\nbody"),
+        ("bug.yml", "name: Bug\ndescription: bug report"),
+        ("new_model.yaml", "name: New model\ndescription: model addition"),
+        ("README.txt", "ignored"),  # wrong extension
+    ]))
+    templates = run._fetch_issue_templates_from_repo("owner/repo")
+    filenames = sorted(t["filename"] for t in templates)
+    assert filenames == ["bug.yml", "feature.md", "new_model.yaml"]
+
+
+def test_fetch_issue_templates_skips_config_yml(monkeypatch):
+    monkeypatch.setattr(run, "gh_api", lambda m, p, b=None: _fake_listing([
+        ("config.yml", "contact_links:\n  - name: docs\n    url: https://x"),
+        ("config.yaml", "ignored too"),
+        ("feature.yml", "name: Feature Request\ndescription: x"),
+    ]))
+    templates = run._fetch_issue_templates_from_repo("owner/repo")
+    assert {t["filename"] for t in templates} == {"feature.yml"}
+
+
+def test_fetch_issue_templates_returns_empty_when_dir_missing(monkeypatch):
+    def fake(m, p, b=None):
+        raise RuntimeError("404: Not Found")
+    monkeypatch.setattr(run, "gh_api", fake)
+    assert run._fetch_issue_templates_from_repo("owner/repo") == []
+
+
+# ─── Body-rewrite prompt ───────────────────────────────────────────────────
+
+
+def test_rewrite_prompt_embeds_templates_and_outrider_body():
+    templates = [
+        {
+            "filename": "feature_request.yml",
+            "name": "Feature Request",
+            "description": "Suggest a new feature",
+            "kind": "feature",
+            "raw_content": "name: Feature Request\ndescription: Suggest a new feature\nbody: []",
+        },
+        {
+            "filename": "new_model.yaml",
+            "name": "🤖 New model",
+            "description": "Create a request for a new model",
+            "kind": "new_model",
+            "raw_content": "name: 🤖 New model\nbody:\n  - type: input\n    attributes:\n      label: Arxiv link",
+        },
+    ]
+    prompt = run._build_issue_body_rewrite_prompt(
+        issue_title="[Remyx Recommendation] Cool Paper",
+        current_body="**Recommended paper**: arxiv:2606.99999\n\n## Why this paper",
+        eligible_templates=templates,
+    )
+    # All templates surface in the prompt
+    assert "feature_request.yml" in prompt
+    assert "new_model.yaml" in prompt
+    assert "🤖 New model" in prompt
+    # Outrider body is embedded
+    assert "arxiv:2606.99999" in prompt
+    # Output schema includes template_id + updated_body
+    assert '"template_id"' in prompt
+    assert '"updated_body"' in prompt
+    assert '"rationale"' in prompt
+    # The canonical-first folding rules carry over from the PR-route
+    # design (Discovery context details block + one-line attribution).
+    assert "Discovery context" in prompt
+    assert "Drafted by [Outrider]" in prompt
+
+
+def test_rewrite_prompt_signals_empty_template_set():
+    # When all templates are filtered out (e.g. lerobot's bug-only set),
+    # the prompt explicitly notes the empty set so the LLM applies only
+    # the scaffolding-collapse rule rather than inventing a template.
+    prompt = run._build_issue_body_rewrite_prompt(
+        issue_title="x", current_body="y", eligible_templates=[],
+    )
+    assert "none" in prompt.lower() or "(none" in prompt
+
+
+# ─── run_issue_convention_pass end-to-end ──────────────────────────────────
+
+
+def _base_env(monkeypatch, **overrides):
+    """Minimal env for run_issue_convention_pass; clears the relevant vars."""
+    for var in ("INPUT_PR_NUMBER", "INPUT_ISSUE_NUMBER", "REMYX_MODE", "INPUT_MODE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("TARGET_REPO", "owner/repo")
+    monkeypatch.setenv("INPUT_INTEREST_ID", "11111111-1111-1111-1111-111111111111")
+    for var, value in overrides.items():
+        monkeypatch.setenv(var, value)
+
+
+def _fake_issue_dict(number=42, title="[Remyx Recommendation] Sample paper",
+                      body="**Recommended paper**: [Sample paper](https://arxiv.org/abs/2606.11127v1)\n\n## Why this paper is interesting"):
+    return {
+        "html_url": f"https://github.com/owner/repo/issues/{number}",
+        "number": number,
+        "user": {"login": "remyx-ai[bot]"},
+        "title": title,
+        "body": body,
+    }
+
+
+def test_run_issue_convention_pass_skipped_no_issue_number(monkeypatch):
+    _base_env(monkeypatch)
+    target = run.Target(repo="owner/repo")
+    result = run.run_issue_convention_pass(target)
+    assert result["status"] == "issue_convention_skipped_no_issue"
+
+
+def test_run_issue_convention_pass_skipped_not_bot(monkeypatch):
+    _base_env(monkeypatch, INPUT_ISSUE_NUMBER="7")
+    issue = _fake_issue_dict(number=7)
+    issue["user"] = {"login": "some-human"}
+    monkeypatch.setattr(run, "gh_api",
+        lambda m, p, b=None: issue if "/issues/7" in p else {"message": "?"})
+    target = run.Target(repo="owner/repo")
+    result = run.run_issue_convention_pass(target)
+    assert result["status"] == "issue_convention_skipped_not_bot"
+
+
+def test_run_issue_convention_pass_no_templates_still_rewrites(monkeypatch):
+    """No ISSUE_TEMPLATE/ directory → status is
+    issue_convention_skipped_no_templates but the rewrite still runs to
+    collapse Outrider scaffolding."""
+    _base_env(monkeypatch, INPUT_ISSUE_NUMBER="42")
+    target = run.Target(repo="owner/repo")
+    issue = _fake_issue_dict()
+    captured_patches = []
+
+    def fake_gh_api(method, path, body=None):
+        if method == "GET" and "/issues/42" in path:
+            return issue
+        if method == "GET" and "/contents/.github/ISSUE_TEMPLATE" in path:
+            raise RuntimeError("404")
+        if method == "POST" and "/labels" in path:
+            return {}
+        if method == "PATCH" and "/issues/42" in path:
+            captured_patches.append(body)
+            return {}
+        raise AssertionError(f"unexpected call: {method} {path}")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    # Mock the Claude one-shot to return a valid rewrite. The mock body
+    # must keep the arxiv link (matches _ARXIV_URL_RE) so the sanity check
+    # passes — paper provenance can't be silently dropped.
+    monkeypatch.setattr(run, "_run_claude_oneshot",
+        lambda wd, p, t, max_turns=4: (True, '{"template_id": null, "rationale": "scaffolding collapsed; no templates available", "updated_body": "## Description\\n\\nSample paper from https://arxiv.org/abs/2606.11127v1\\n\\n<details><summary>Discovery context</summary>...</details>"}'))
+    # _resolve_upstream_for_conventions falls back to target.repo when no
+    # upstream is configured.
+    monkeypatch.setattr(run, "_resolve_upstream_for_conventions",
+        lambda target: "owner/repo")
+
+    result = run.run_issue_convention_pass(target)
+    assert result["status"] == "issue_convention_skipped_no_templates"
+    assert result["templates_found"] == 0
+    assert captured_patches  # PATCH was called with the rewritten body
+    assert "arxiv.org/abs/2606.11127v1" in captured_patches[0]["body"]
+
+
+def test_run_issue_convention_pass_no_fitting_template(monkeypatch):
+    """Templates exist but all are bug/question (e.g. lerobot's
+    bug-only set) → status is issue_convention_aligned_no_fitting_template.
+    Rewrite still runs with scaffolding collapsed."""
+    _base_env(monkeypatch, INPUT_ISSUE_NUMBER="42")
+    target = run.Target(repo="owner/repo")
+    issue = _fake_issue_dict()
+    bug_template_body = (
+        "name: Bug Report\n"
+        "description: Report a bug\n"
+        "body:\n"
+        "  - type: textarea\n"
+        "    attributes:\n"
+        "      label: Steps to reproduce\n"
+    )
+
+    def fake_gh_api(method, path, body=None):
+        if method == "GET" and "/issues/42" in path:
+            return issue
+        if method == "GET" and "/contents/.github/ISSUE_TEMPLATE" in path:
+            return _fake_listing([("bug-report.yml", bug_template_body)])
+        if method == "POST" and "/labels" in path:
+            return {}
+        if method == "PATCH" and "/issues/42" in path:
+            return {}
+        raise AssertionError(f"unexpected call: {method} {path}")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    monkeypatch.setattr(run, "_run_claude_oneshot",
+        lambda wd, p, t, max_turns=4: (True, '{"template_id": null, "rationale": "no fitting template", "updated_body": "## Description\\n\\nSample paper from https://arxiv.org/abs/2606.11127v1"}'))
+    monkeypatch.setattr(run, "_resolve_upstream_for_conventions",
+        lambda target: "owner/repo")
+
+    result = run.run_issue_convention_pass(target)
+    assert result["status"] == "issue_convention_aligned_no_fitting_template"
+    assert result["templates_found"] == 1
+    assert result["templates_eligible"] == 0
+    assert "bug" in result["templates_filtered_kinds"]
+
+
+def test_run_issue_convention_pass_aligned_happy_path(monkeypatch):
+    """Eligible template fits + LLM picks it → issue_convention_aligned
+    status with the picked template recorded."""
+    _base_env(monkeypatch, INPUT_ISSUE_NUMBER="42")
+    target = run.Target(repo="owner/repo")
+    issue = _fake_issue_dict()
+    feature_template_body = (
+        "name: Feature Request\n"
+        "description: Suggest a new feature\n"
+        "body:\n"
+        "  - type: textarea\n"
+        "    attributes:\n"
+        "      label: Description\n"
+    )
+
+    def fake_gh_api(method, path, body=None):
+        if method == "GET" and "/issues/42" in path:
+            return issue
+        if method == "GET" and "/contents/.github/ISSUE_TEMPLATE" in path:
+            return _fake_listing([("feature_request.yml", feature_template_body)])
+        if method == "POST" and "/labels" in path:
+            return {}
+        if method == "PATCH" and "/issues/42" in path:
+            return {}
+        raise AssertionError(f"unexpected call: {method} {path}")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    monkeypatch.setattr(run, "_run_claude_oneshot",
+        lambda wd, p, t, max_turns=4: (True, '{"template_id": "feature_request.yml", "rationale": "folded into Feature Request template", "updated_body": "**Description**\\n\\nSample paper from https://arxiv.org/abs/2606.11127v1\\n\\n<details>...</details>"}'))
+    monkeypatch.setattr(run, "_resolve_upstream_for_conventions",
+        lambda target: "owner/repo")
+
+    result = run.run_issue_convention_pass(target)
+    assert result["status"] == "issue_convention_aligned"
+    assert result["picked_template"] == "feature_request.yml"
+    assert result["templates_eligible"] == 1
+
+
+def test_run_issue_convention_pass_arxiv_sanity_check(monkeypatch):
+    """If the LLM strips the arxiv link from the body, the rewrite is
+    rejected (paper provenance must remain reachable)."""
+    _base_env(monkeypatch, INPUT_ISSUE_NUMBER="42")
+    target = run.Target(repo="owner/repo")
+    issue = _fake_issue_dict()  # body has arxiv:2606.11127v1
+    feature_template_body = "name: Feature Request\ndescription: x"
+
+    def fake_gh_api(method, path, body=None):
+        if method == "GET" and "/issues/42" in path:
+            return issue
+        if method == "GET" and "/contents/.github/ISSUE_TEMPLATE" in path:
+            return _fake_listing([("feature_request.yml", feature_template_body)])
+        if method == "POST" and "/labels" in path:
+            return {}
+        # PATCH should NOT be called — the sanity check should reject.
+        raise AssertionError(f"unexpected call: {method} {path}")
+
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    # Rewrite drops the arxiv link entirely.
+    monkeypatch.setattr(run, "_run_claude_oneshot",
+        lambda wd, p, t, max_turns=4: (True, '{"template_id": "feature_request.yml", "rationale": "...", "updated_body": "**Description**\\n\\nSome paper without provenance"}'))
+    monkeypatch.setattr(run, "_resolve_upstream_for_conventions",
+        lambda target: "owner/repo")
+
+    result = run.run_issue_convention_pass(target)
+    assert result["status"] == "issue_convention_failed_claude"
+    assert "arxiv" in result["error"].lower()

--- a/tests/test_issue_convention_pass.py
+++ b/tests/test_issue_convention_pass.py
@@ -191,10 +191,13 @@ def test_rewrite_prompt_embeds_templates_and_outrider_body():
     assert "🤖 New model" in prompt
     # Outrider body is embedded
     assert "arxiv:2606.99999" in prompt
-    # Output schema includes template_id + updated_body
-    assert '"template_id"' in prompt
-    assert '"updated_body"' in prompt
-    assert '"rationale"' in prompt
+    # Output uses delimited format (TEMPLATE_ID / RATIONALE / UPDATED_BODY
+    # markers) rather than JSON — long markdown bodies break JSON parsing
+    # when Claude leaves an unescaped quote in a 30k-token output.
+    assert "===TEMPLATE_ID===" in prompt
+    assert "===RATIONALE===" in prompt
+    assert "===UPDATED_BODY===" in prompt
+    assert "===END===" in prompt
     # The canonical-first folding rules carry over from the PR-route
     # design (Discovery context details block + one-line attribution).
     assert "Discovery context" in prompt
@@ -209,6 +212,115 @@ def test_rewrite_prompt_signals_empty_template_set():
         issue_title="x", current_body="y", eligible_templates=[],
     )
     assert "none" in prompt.lower() or "(none" in prompt
+
+
+# ─── Delimited rewrite-response parser ──────────────────────────────────────
+
+
+def test_parse_rewrite_response_happy_path():
+    raw = (
+        "===TEMPLATE_ID===\n"
+        "feature_request.yml\n"
+        "===RATIONALE===\n"
+        "folded into Feature Request template\n"
+        "===UPDATED_BODY===\n"
+        "**Description**\n\n"
+        "Sample paper from https://arxiv.org/abs/2606.11127v1\n\n"
+        '<details><summary>Discovery context</summary>...</details>\n'
+        "===END===\n"
+    )
+    parsed = run._parse_issue_rewrite_response(raw)
+    assert parsed is not None
+    assert parsed["template_id"] == "feature_request.yml"
+    assert "Feature Request template" in parsed["rationale"]
+    assert "arxiv.org/abs/2606.11127v1" in parsed["updated_body"]
+    # Body extends across multiple lines; the parser must preserve newlines
+    assert "\n\n" in parsed["updated_body"]
+
+
+def test_parse_rewrite_response_normalises_no_pick_sentinels():
+    # Various forms the LLM might use to signal "no template picked"
+    for sentinel in ("(none)", "null", "none", "<none>", ""):
+        raw = (
+            f"===TEMPLATE_ID===\n{sentinel}\n"
+            f"===RATIONALE===\nno fit\n"
+            f"===UPDATED_BODY===\n**Body**\n"
+            f"===END===\n"
+        )
+        parsed = run._parse_issue_rewrite_response(raw)
+        assert parsed is not None
+        assert parsed["template_id"] == "", f"sentinel {sentinel!r} not normalised"
+
+
+def test_parse_rewrite_response_body_with_special_chars():
+    # The whole point of switching from JSON to delimited: the body can
+    # contain ANY chars without escape concerns. Quotes, braces, backslashes.
+    raw = (
+        "===TEMPLATE_ID===\n"
+        "feature.yml\n"
+        "===RATIONALE===\n"
+        "rewrite\n"
+        "===UPDATED_BODY===\n"
+        'Body with "quoted strings", {braces}, and \\backslashes\\.\n'
+        '<details><summary>"Discovery context"</summary>x</details>\n'
+        "===END===\n"
+    )
+    parsed = run._parse_issue_rewrite_response(raw)
+    assert parsed is not None
+    assert '"quoted strings"' in parsed["updated_body"]
+    assert "{braces}" in parsed["updated_body"]
+    assert "\\backslashes\\" in parsed["updated_body"]
+
+
+def test_parse_rewrite_response_tolerates_missing_end_marker():
+    # If Claude omits the ===END=== marker, the body extends to EOF.
+    raw = (
+        "===TEMPLATE_ID===\n"
+        "feature.yml\n"
+        "===RATIONALE===\n"
+        "x\n"
+        "===UPDATED_BODY===\n"
+        "Body content here\n"
+        "with multiple lines\n"
+    )
+    parsed = run._parse_issue_rewrite_response(raw)
+    assert parsed is not None
+    assert "Body content here" in parsed["updated_body"]
+    assert "with multiple lines" in parsed["updated_body"]
+
+
+def test_parse_rewrite_response_returns_none_when_markers_missing():
+    assert run._parse_issue_rewrite_response("just prose, no markers") is None
+    # Missing UPDATED_BODY marker
+    assert run._parse_issue_rewrite_response(
+        "===TEMPLATE_ID===\nfeature.yml\n===RATIONALE===\nx\n"
+    ) is None
+
+
+def test_parse_rewrite_response_returns_none_when_body_empty():
+    raw = (
+        "===TEMPLATE_ID===\n"
+        "feature.yml\n"
+        "===RATIONALE===\n"
+        "x\n"
+        "===UPDATED_BODY===\n"
+        "\n"
+        "===END===\n"
+    )
+    assert run._parse_issue_rewrite_response(raw) is None
+
+
+def test_parse_rewrite_response_returns_none_on_out_of_order_markers():
+    # UPDATED_BODY before RATIONALE → not the expected sequence.
+    raw = (
+        "===TEMPLATE_ID===\n"
+        "feature.yml\n"
+        "===UPDATED_BODY===\n"
+        "body\n"
+        "===RATIONALE===\n"
+        "x\n"
+    )
+    assert run._parse_issue_rewrite_response(raw) is None
 
 
 # ─── run_issue_convention_pass end-to-end ──────────────────────────────────
@@ -279,7 +391,14 @@ def test_run_issue_convention_pass_no_templates_still_rewrites(monkeypatch):
     # must keep the arxiv link (matches _ARXIV_URL_RE) so the sanity check
     # passes — paper provenance can't be silently dropped.
     monkeypatch.setattr(run, "_run_claude_oneshot",
-        lambda wd, p, t, max_turns=4: (True, '{"template_id": null, "rationale": "scaffolding collapsed; no templates available", "updated_body": "## Description\\n\\nSample paper from https://arxiv.org/abs/2606.11127v1\\n\\n<details><summary>Discovery context</summary>...</details>"}'))
+        lambda wd, p, t, max_turns=4: (True,
+            "===TEMPLATE_ID===\n(none)\n"
+            "===RATIONALE===\nscaffolding collapsed; no templates available\n"
+            "===UPDATED_BODY===\n"
+            "## Description\n\nSample paper from https://arxiv.org/abs/2606.11127v1\n\n"
+            "<details><summary>Discovery context</summary>...</details>\n"
+            "===END===\n"
+        ))
     # _resolve_upstream_for_conventions falls back to target.repo when no
     # upstream is configured.
     monkeypatch.setattr(run, "_resolve_upstream_for_conventions",
@@ -321,7 +440,13 @@ def test_run_issue_convention_pass_no_fitting_template(monkeypatch):
 
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
     monkeypatch.setattr(run, "_run_claude_oneshot",
-        lambda wd, p, t, max_turns=4: (True, '{"template_id": null, "rationale": "no fitting template", "updated_body": "## Description\\n\\nSample paper from https://arxiv.org/abs/2606.11127v1"}'))
+        lambda wd, p, t, max_turns=4: (True,
+            "===TEMPLATE_ID===\n(none)\n"
+            "===RATIONALE===\nno fitting template\n"
+            "===UPDATED_BODY===\n"
+            "## Description\n\nSample paper from https://arxiv.org/abs/2606.11127v1\n"
+            "===END===\n"
+        ))
     monkeypatch.setattr(run, "_resolve_upstream_for_conventions",
         lambda target: "owner/repo")
 
@@ -360,7 +485,14 @@ def test_run_issue_convention_pass_aligned_happy_path(monkeypatch):
 
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
     monkeypatch.setattr(run, "_run_claude_oneshot",
-        lambda wd, p, t, max_turns=4: (True, '{"template_id": "feature_request.yml", "rationale": "folded into Feature Request template", "updated_body": "**Description**\\n\\nSample paper from https://arxiv.org/abs/2606.11127v1\\n\\n<details>...</details>"}'))
+        lambda wd, p, t, max_turns=4: (True,
+            "===TEMPLATE_ID===\nfeature_request.yml\n"
+            "===RATIONALE===\nfolded into Feature Request template\n"
+            "===UPDATED_BODY===\n"
+            "**Description**\n\nSample paper from https://arxiv.org/abs/2606.11127v1\n\n"
+            "<details>...</details>\n"
+            "===END===\n"
+        ))
     monkeypatch.setattr(run, "_resolve_upstream_for_conventions",
         lambda target: "owner/repo")
 
@@ -391,7 +523,13 @@ def test_run_issue_convention_pass_arxiv_sanity_check(monkeypatch):
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
     # Rewrite drops the arxiv link entirely.
     monkeypatch.setattr(run, "_run_claude_oneshot",
-        lambda wd, p, t, max_turns=4: (True, '{"template_id": "feature_request.yml", "rationale": "...", "updated_body": "**Description**\\n\\nSome paper without provenance"}'))
+        lambda wd, p, t, max_turns=4: (True,
+            "===TEMPLATE_ID===\nfeature_request.yml\n"
+            "===RATIONALE===\n...\n"
+            "===UPDATED_BODY===\n"
+            "**Description**\n\nSome paper without provenance\n"
+            "===END===\n"
+        ))
     monkeypatch.setattr(run, "_resolve_upstream_for_conventions",
         lambda target: "owner/repo")
 

--- a/tests/test_issues_disabled.py
+++ b/tests/test_issues_disabled.py
@@ -51,12 +51,13 @@ def test_open_issue_succeeds_when_post_works(monkeypatch):
     def fake_gh_api(method, path, body=None):
         calls.append((method, path))
         if method == "POST" and "/issues" in path:
-            return {"html_url": "https://github.com/owner/repo/issues/42"}
+            return {"html_url": "https://github.com/owner/repo/issues/42", "number": 42}
         raise AssertionError(f"unexpected call: {method} {path}")
 
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
-    url = run.open_issue(_target(), "title", "body")
+    url, number = run.open_issue(_target(), "title", "body")
     assert url == "https://github.com/owner/repo/issues/42"
+    assert number == 42
     assert calls == [("POST", "/repos/owner/repo/issues")]
 
 
@@ -74,12 +75,13 @@ def test_open_issue_retries_after_410_when_patch_succeeds(monkeypatch):
         if method == "PATCH" and path == "/repos/owner/repo":
             return {"has_issues": True}
         if method == "POST" and "/issues" in path and len(call_log) >= 3:
-            return {"html_url": "https://github.com/owner/repo/issues/7"}
+            return {"html_url": "https://github.com/owner/repo/issues/7", "number": 7}
         raise AssertionError(f"unexpected call sequence: {call_log}")
 
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
-    url = run.open_issue(_target(), "title", "body")
+    url, number = run.open_issue(_target(), "title", "body")
     assert url == "https://github.com/owner/repo/issues/7"
+    assert number == 7
     # Three calls: POST (410) → PATCH (success) → POST (success)
     assert len(call_log) == 3
     assert call_log[1] == ("PATCH", "/repos/owner/repo")

--- a/tests/test_symmetric_dedup.py
+++ b/tests/test_symmetric_dedup.py
@@ -180,7 +180,7 @@ def test_open_issue_default_footer_includes_reengage_note(monkeypatch):
 
     def fake_gh_api(method, path, body=None):
         captured["body"] = body["body"]
-        return {"html_url": "https://github.com/example/repo/issues/1"}
+        return {"html_url": "https://github.com/example/repo/issues/1", "number": 1}
 
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
     run.open_issue(
@@ -205,7 +205,7 @@ def test_open_issue_footer_override_keeps_reengage_note(monkeypatch):
     monkeypatch.setattr(
         run, "gh_api",
         lambda m, p, b=None: captured.update({"body": b["body"]})
-        or {"html_url": "https://github.com/example/repo/issues/1"},
+        or {"html_url": "https://github.com/example/repo/issues/1", "number": 1},
     )
     run.open_issue(
         Target(repo="example/repo", interest_id="iid"),


### PR DESCRIPTION
## Problem

The PR-route Phase B body rewrite (canonical-first folding shipped in v1.6.15) only fires on the PR route. When recommend mode routes to an Issue, the inline chain correctly skips Phase B + C (no diff to align or test) — but the Issue body still carries the full Outrider preamble. Asymmetric quality between PR and Issue outputs.

Test-fork inventory (gathered for REMYX-146) showed **4/7 forks have a template Outrider could plausibly align against** (haystack's `feature_request.md`, ag2 + dspy's `feature_request.yml`, mteb's purpose-built `new_model.yaml` with a dedicated `Arxiv link` field) — addressable surface justifies shipping.

## Fix

Parallel body rewrite for the Issue route, anchored against the target repo's `.github/ISSUE_TEMPLATE/`.

**New helpers in `src/run.py`**:

- `_fetch_issue_templates_from_repo` — walks the templates directory via the Contents API. Accepts `.md` (legacy markdown frontmatter), `.yml`, and `.yaml` (modern Issue Forms). Skips `config.yml`. Regex-extracts `name` + `description` from the top of the file.
- `_classify_template_kind` — heuristic on `name` + `description` → `bug | new_model | feature | question | other`. Priority order biases toward specific kinds (`new_model` before `feature`) so "dataset request" classifies as `new_model`, not `feature`.
- `_filter_eligible_templates` — drops `bug` + `question` kinds. Forcing a paper-pitch into a bug template (e.g. lerobot's bug-only set) would harm Issue reception more than the default body.
- `_build_issue_body_rewrite_prompt` — single Claude one-shot that takes the Outrider body + eligible templates and emits `{template_id, rationale, updated_body}`. Picker + rewrite collapsed into one call (saves a round-trip vs separate picker). Carries the same canonical-first folding rules from PR-route Phase B (Discovery context `<details>` block, one-line attribution, reference URL preservation).
- `run_issue_convention_pass` — end-to-end orchestrator. Reads `INPUT_ISSUE_NUMBER`, fetches Issue + bot-author gate, fetches templates from the upstream (so customer forks inherit the upstream's convention), runs the rewrite, applies the `outrider:issue-convention-done` label.

**ArXiv-link sanity check** parallel to PR-route's: if the input had an arXiv link, the rewrite must keep one.

**Wiring**:
- New action input `issue-number`, threaded as `INPUT_ISSUE_NUMBER` to the runner.
- New mode `issue-convention` for standalone runs.
- Dispatcher: when recommend mode reports status starting with `issue_opened` AND `result["issue_number"]` is set, invoke `run_issue_convention_pass` inline. Mirrors the PR-route inline chain trigger.
- `open_issue` + `_open_downgrade_issue` now return `(url, number)` so the dispatcher has the Issue number. All 9 call sites updated.

## New statuses

| Status | Meaning |
|---|---|
| `issue_convention_aligned` | Picked a template + rewrote body |
| `issue_convention_aligned_no_fitting_template` | Templates exist but all were bug/question (lerobot case); rewrite still folded scaffolding |
| `issue_convention_skipped_no_templates` | No `.github/ISSUE_TEMPLATE/` directory |
| `issue_convention_skipped_no_issue` | `INPUT_ISSUE_NUMBER` empty |
| `issue_convention_skipped_not_bot` | Issue authored by a human, not `remyx-ai[bot]` |
| `issue_convention_failed_claude` | Claude call failed |
| `issue_convention_failed_patch` | PATCH to body failed |

## Validation

- 673/673 tests pass (+26 new tests; 647 → 673)
- New `tests/test_issue_convention_pass.py` covers all five discovery paths (markdown, yml, yaml, `config.yml` skip, missing dir), classifier priority, eligible filter, prompt embedding, end-to-end orchestrator for the three terminal statuses, and the arXiv-link sanity check
- New dispatcher tests in `tests/test_inline_refinement_chain.py` cover the Issue-route inline path (status starting with `issue_opened` + `issue_number` set → `run_issue_convention_pass` invoked with `INPUT_ISSUE_NUMBER`)
- Existing fixtures updated in `tests/test_issues_disabled.py` and `tests/test_symmetric_dedup.py` for the `open_issue` signature change

## Backwards compatibility

- `open_issue` signature changed from `-> str` to `-> tuple[str, int]`. All 9 internal callers updated. No external consumers of this internal helper exist.
- New `issue-number` input on `action.yml` defaults to empty — existing workflows continue to work unchanged.
- New `issue-convention` mode is additive; existing modes (`recommend`, `fidelity`, `convention`, `test`, `weekly-summary`) unchanged.
- The Issue-route dispatcher path is gated by `chain_enabled` (the existing input). Customers who disabled the chain stay opted-out for both PR and Issue routes.

Refs REMYX-146.