### PR TITLE
README: streamline and split reference content into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Outrider — GitHub Action
 
-Scouts the arXiv frontier for your repo and picks the next paper most implementable against your codebase. Verifies each candidate's structural fit against your actual modules (not just keyword relevance), then either opens a draft PR wiring it into an existing call site, opens an Issue when a PR would be premature, or opens an RFC-shape Issue when the candidate proposes a new capability your team has signaled openness to. Won't re-recommend a paper that's already in front of your team — whether Outrider filed it or you did.
-
-<p align="center">
-  <img src="https://github.com/remyxai/outrider/releases/download/readme-assets/outrider-v1.gif" alt="Outrider demo" width="800">
-</p>
+A GitHub Action that picks the next arXiv paper most implementable in your codebase — opens a draft PR wiring it into an existing call site, or an Issue if a PR would be premature. Won't re-recommend a paper that's already in front of your team.
 
 ```yaml
 - uses: remyxai/outrider@v1
@@ -12,32 +8,28 @@ Scouts the arXiv frontier for your repo and picks the next paper most implementa
     interest-id: ${{ vars.REMYX_INTEREST_ID }}
 ```
 
+
 ## What you get
 
-- **Draft PRs** that wire a paper's contribution into an existing module, with a self-review section in the body honestly noting what was implemented vs. left out
-- **Issues** when a PR would be premature — pre-flight, validators, or self-review route the paper to discussion instead of scaffold-shaped PRs
-- **RFC-shape Issues** when the team has signaled openness to a new capability (a README roadmap section, an open `[RFC]` Issue, a CONTEXT.md investment pattern) and a candidate fits as an extension — a clear proposal instead of speculation
-- **No duplicate work** — the same paper isn't re-recommended once any Outrider or maintainer Issue references it; reopen the Issue to re-engage
-- **A selection narrative** in the run's GitHub Actions step summary explaining why this paper (or why nothing actionable this run) — visible at a glance, not buried in logs
-- **Actionable failure guidance**, not opaque errors — when the agent fails on a recognizable cause (Anthropic credit-balance exhausted, invalid API key, rate-limit), the step-summary panel renders the specific remediation (top-up link, key-setup hint, retry note) instead of a buried log line
-- **No stacking unresolved work** by default — a new run skips while a prior Remyx PR or Issue is still open; engagement (merge or close) releases the gate
+- **Draft PRs** that wire a paper's contribution into an existing module, with a self-review section honestly noting what was implemented vs. left out
+- **Issues** when a PR would be premature — pre-flight, validators, or self-review route the paper to discussion instead
+- **No duplicate work** — the same paper isn't re-recommended once any Outrider or maintainer Issue references it; reopen to re-engage
+- **A selection narrative** in the run's GitHub Actions step summary explaining why this paper (or why nothing actionable this run)
 
-## Setup
 
-Two install paths — pick whichever fits.
-
-### One-command install (CLI)
-
-The [`remyxai` CLI](https://github.com/remyxai/remyxai-cli) installs Outrider on a target repo via the Remyx GitHub App: writes the workflow, sets the repo secrets, and opens a bot-authored setup PR. Your local git isn't touched.
+## Quickstart
 
 ```bash
 pip install remyxai
 remyxai outrider init --repo owner/name --auto-interest
 ```
 
-Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Settings) and an Anthropic key (`--anthropic-key` or `ANTHROPIC_API_KEY`). The `--auto-interest` flag auto-creates a `ResearchInterest` from the repo if one doesn't exist; drop it if you already have an interest UUID to wire in. If the Remyx GitHub App isn't installed on the target repo yet, the command surfaces the install link.
+The [`remyxai` CLI](https://github.com/remyxai/remyxai-cli) installs Outrider on a target repo via the Remyx GitHub App: writes the workflow, sets the repo secrets, and opens a bot-authored setup PR. Your local git isn't touched.
 
-### Manual install (5 minutes)
+Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Settings) and an Anthropic key (`--anthropic-key` or `ANTHROPIC_API_KEY`).
+
+<details>
+<summary><b>Manual install (5 minutes)</b></summary>
 
 1. **Sign up at [engine.remyx.ai](https://engine.remyx.ai)** and connect your repo. Remyx ingests your commit history and creates a `ResearchInterest`. Edit its context body to sharpen the framing.
 
@@ -73,244 +65,29 @@ Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Sett
              interest-id: 'YOUR-INTEREST-UUID-HERE'
    ```
 
-   (Tip: the engine.remyx.ai UI has a "copy workflow snippet" button that emits this pre-filled.)
-
 6. **First run**: *Actions tab → Outrider → Run workflow*. Takes 4–6 minutes. A draft PR or Issue appears when complete.
 
-## Inputs
+</details>
 
-| Input | Default | Description |
-|---|---|---|
-| `interest-id` | *(required)* | Remyx ResearchInterest UUID |
-| `github-token` | `${{ github.token }}` | Override only for cross-repo controller patterns |
-| `min-confidence` | `moderate` | Tier gate: `high` / `moderate` / `low` |
-| `draft-mode` | `always` | `always` / `on_test_failure` / `never` |
-| `rate-limit-days` | `7` | Cadence guard. Any value > 0 enables: skip the run if any **open** Remyx PR or Issue exists on the target. Engagement (merge or close) releases the gate. Set `0` to disable. The numeric value is otherwise ignored — kept as an on/off bit for compatibility with workflow files written for the prior sliding-window semantics. |
-| `guardrails-allowlist` | `''` | Extra path globs Claude Code may modify, **added on top of** the defaults (`*.py`, `.remyx-recommendation/**`, `**/*.md`). Most repos won't need this. |
-| `test-integration-policy` | `strict` | `strict` (demote to Issue if new tests don't import an existing module) / `soft` (open draft PR with warning) / `off` (skip the gate). Use `soft` for layer/component repos where standalone modules are the contribution. |
-| `lookback` | `week` | Candidate pool window: `today` / `week` / `month` |
-| `candidate-pool` | `25` | How many candidates the selection pass picks from |
-| `claude-timeout` | `900` | Wall-clock seconds for the Claude Code implementation step. Bump for very large repos; lower to cap cost. |
-| `pin-arxiv` | `''` | Optional `arxiv_id`. When set and present in the candidate pool, the action implements that exact paper and skips the selection pass — use it for reproducible eval re-runs. Empty = normal selection. |
-| `mode` | `recommend` | `recommend` (classic per-run flow) / `weekly-summary` (post a weekly digest to a Discussion — see [Weekly Discussion summary](#weekly-discussion-summary-opt-in)) |
-| `chain` | `true` | When `true`, `recommend` mode continues into the refinement chain (fidelity audit → convention pass → test gate) on the draft PR it just filed, within the same run — no extra workflow files required. Set `false` for cost-sensitive runs or to drive the chain via separate workflows with `mode: fidelity/convention/test`. |
-| `weekly-discussion-id` | `''` | Discussion number (from its URL) or GraphQL node ID. Only read in `weekly-summary` mode. |
-
-## Outputs
-
-| Output | When | Description |
-|---|---|---|
-| `status` | always | Run outcome — see status codes below |
-| `pr_url` | `pr_opened*` | URL of the opened PR |
-| `pr_number` | `pr_opened*` | Number of the opened PR (handed to the inline refinement chain) |
-| `chain_fidelity_status` / `chain_convention_status` / `chain_test_status` | chain ran | Per-phase outcome of the inline refinement chain (`recommend` mode, `chain: true`) |
-| `chain_draft_dropped` | chain ran | `true` if the test gate flipped the draft to ready-for-review |
-| `issue_url` | `issue_opened*` | URL of the opened Issue |
-| `arxiv` | when a paper was picked | arxiv_id |
-| `tier` | when a paper was picked | `high` / `moderate` / `low` / `noise` |
-| `cost_usd` | always | Claude spend for this run |
-| `input_tokens` / `output_tokens` | always | Token usage |
-| `discussion_comment_url` | `weekly_summary_posted` | URL of the posted weekly digest comment |
 
 ## Costs
 
-- **Claude Code**: ~$2–3 per PR-track run for the recommend pass alone (pre-flight + selection + implementation + self-review). With the inline refinement chain on (the default), a full PR-track run is ~$5–6 and ~15–25 min, since fidelity audit + convention pass + test gate each add a Claude pass. Set `chain: false` to keep runs at the recommend-only cost. Issue-track runs cost less since they skip the implementation pass and never enter the chain. You bring `ANTHROPIC_API_KEY`.
-- **Remyx API**: included in your engine.remyx.ai subscription.
-- **GitHub Actions**: ~6–8 min per recommend-only run; ~15–25 min with the chain (single workflow run on `ubuntu-latest`).
+~$5–6 in Claude spend per full PR-route run (recommend + inline refinement chain); ~$1–2 for recommend-only with `chain: false`. With the default cadence guard, expect ~$2–4/mo at typical engagement patterns. You bring `ANTHROPIC_API_KEY`; Remyx API usage is covered by your engine.remyx.ai subscription.
 
-With the default cadence guard (gate enabled), expect ~$2–4/mo Claude at typical engagement patterns.
 
-<details>
-<summary><b>Status codes</b></summary>
+## Examples
 
-| Status | Meaning |
-|---|---|
-| `pr_opened` | PR opened ready-for-review (tests passed, `draft-mode != always`) |
-| `pr_opened_draft` | PR opened as draft |
-| `issue_opened_preflight` | Pre-flight Claude pass routed to Issue before implementation |
-| `issue_opened` | Claude elected Issue-mode (wrote `OPEN_AS_ISSUE.md` instead of code) |
-| `issue_opened_no_integration` | Diff adds code that nothing invokes |
-| `issue_opened_stub_density` | New module is ≥50% stubs (`pass` / `NotImplementedError` / empty bodies) |
-| `issue_opened_no_test_integration` | New tests don't import from any pre-existing module |
-| `issue_opened_self_review` | Self-review judged the new code an orphan, unreachable from production. Body preserves Claude's implementation diff so the maintainer can review or apply it manually |
-| `issue_opened_substitution` | Selection identified a replacement / pipeline-simplification / extension candidate (vs. additive drop-in); routed to Issue because the swap needs dep changes the PR guardrails block, or there's no existing call site to anchor against |
-| `issue_opened_high_risk` | Diff Risk Score gate routed to a human-review Issue instead of a PR (implementation diff preserved in the Issue body). See [Diff Risk Score](#diff-risk-score--adapted-from-automating-low-risk-code-review-at-meta-radar-risk-calibration-and-review-efficiency) |
-| `skipped_low_confidence` | Recommendation below `min-confidence` |
-| `skipped_open_artifact` | An open Remyx PR or Issue from a prior run still exists on the target — engagement (merge or close) releases the gate |
-| `skipped_issues_disabled` | The target repo has its Issues tab disabled (default on forks) and the scoped App token can't re-enable it. Enable with `gh repo edit <repo> --enable-issues` and the next run proceeds |
-| `skipped_pr_exists` | Every candidate already has an open PR |
-| `skipped_issue_exists` | Every candidate already has a prior Issue referencing the arxiv id — Outrider-opened OR maintainer-opened, open OR closed. Step summary differentiates "Already in flight" (open) vs "Already addressed" (closed). Reopen the Issue to re-engage |
-| `skipped_external_issue_exists` | Selection pass surfaced an out-of-pool candidate but it's already in the team's attention — same Outrider/Maintainer × open/closed differentiation as above |
-| `skipped_by_selection_verification` | Selection pass verified every candidate against the repo and rejected all. The `selection_reasoning` payload renders open in the step summary explaining why — the most useful signal for "no actionable paper this run" outcomes |
-| `skipped_test_failure` | Tests failed AND `draft-mode: never` |
-| `claude_failed` | Claude CLI exited non-zero |
-| `rejected_path_violations` | Claude touched files outside the guardrails allowlist |
-| `error` | Unhandled exception |
-| `weekly_summary_posted` | Weekly digest comment posted to the configured Discussion |
-| `weekly_summary_skipped_no_discussion_id` | `mode: weekly-summary` ran without a `weekly-discussion-id` |
-| `weekly_summary_failed` | Weekly mode hit an unhandled error (nothing was posted) |
+- **[smellslikeml/OpenRLHF PR #6](https://github.com/smellslikeml/OpenRLHF/pull/6)** — CFPO cross-modal grounding regularizer ([arXiv:2606.23206](https://arxiv.org/abs/2606.23206)). Full inline chain ran; canonical-first body shape; landed as ready-for-review.
+- **[smellslikeml/NeMo-Curator Issue #5](https://github.com/smellslikeml/NeMo-Curator/issues/5)** — FinerWeb-10BT line-level filtering ([arXiv:2501.07314](https://arxiv.org/abs/2501.07314)). Paper-anchored fidelity audit (no public reference impl); self-review correctly routed to Issue.
 
-</details>
 
-<details>
-<summary><b>Guardrails</b> — what Claude can and can't modify</summary>
+## Documentation
 
-**Allowed paths** (defaults):
-- `*.py` — any Python source, anywhere in the repo
-- `.remyx-recommendation/**` — the spec bundle (scrubbed before commit)
-- `**/*.md` — Markdown anywhere (README, CHANGELOG, docs/, ADR notes); the 50-line edit cap still applies to existing files
-
-**Always blocked** by *role* (filename/type), not directory:
-- `.github/**` — CI / workflow config
-- `*Dockerfile`, `*Dockerfile.*`, `*.dockerfile`, `*.sh` — container builds and shell scripts
-- `*requirements*.txt`, `setup.py`, `setup.cfg`, `pyproject.toml`, `MANIFEST.in`, `*.lock` — dependency / build manifests
-
-The block list takes precedence over the allowlist. Non-`.py` config not on the block list (e.g. `pipelines/*.yaml`) simply isn't allowed either.
-
-**Edit-size caps** (enforced after the Claude session):
-- Each edit to a pre-existing file: ≤50 net lines (additions + deletions)
-- At most 3 new `.py` files per run
-- At least one newly-added function/method/class must be invoked from another changed file (an import alone doesn't count)
-
-Extend the allowlist for your repo via the `guardrails-allowlist` input.
-
-</details>
-
-<details>
-<summary><b>How selection works</b> — four integration shapes + discharge model</summary>
-
-Outrider's selection pass classifies every candidate against your repo using a four-shape taxonomy. A candidate that doesn't fit one of these shapes is a structural mismatch and gets rejected:
-
-- **addition** — paper adds a new module wired into existing code. Most common. Verification: the call site exists and the new module's I/O contract fits.
-- **replacement** — strict drop-in for an existing component with the same I/O contract but better internals (smaller / faster / newer foundation). Verification: I/O contracts are functionally equivalent, not just thematically related.
-- **simplification** — merges two or more existing components into one with the same end-to-end contract. Pipeline collapses. Verification: merged contribution spans the existing boundary contract cleanly.
-- **extension** — proposes a new capability your repo lacks AND that you've signaled openness to (README roadmap, an open `[RFC]` Issue, CONTEXT.md investment pattern). Stricter bar than addition — four gates: pipeline-compatible I/O, explicit team-direction signal, no existing implementation, tier=high + relevance ≥ 0.90. Without ≥1 explicit direction signal in your repo, extension picks are RFC-fishing and get rejected.
-
-Tie-break preference: `simplification > replacement > addition > extension`. Extension is last-resort — picked only when the other three shapes fail AND the four gates pass.
-
-**Discharge model** — the same paper isn't re-recommended once it's already in front of your team. The dedup gate counts:
-
-- **Outrider-opened Issues** (any state, open OR closed) — closing an Issue means "the team has decided," still a discharge signal
-- **Maintainer-opened Issues** (RFCs, discussions) whose body links the paper's arxiv id — a stronger signal than Outrider's own, since you authored the thread
-
-Re-engagement lever: **reopen the Issue** to drop the paper from the discharge set so Outrider can re-recommend it.
-
-</details>
-
-<details>
-<summary><b>How it works</b> — full pipeline</summary>
-
-```
-GitHub cron fires the workflow
-       ↓
-Query engine.remyx.ai for the candidate pool + interest context
-       ↓
-Rate-limit + per-candidate viability gates:
-  - confidence (tier above min-confidence)
-  - PR exists for arxiv?
-  - any prior Issue references arxiv? (Outrider OR maintainer; open OR closed)
-       ↓
-Clone the target repo + detect package / default branch
-       ↓
-Selection pass (Claude agentic, ~5 min budget):
-  Prompt threads in:
-    - candidate brief (with inline "✗ already filed [Outrider/Maintainer]" tags)
-    - "Already in the team's attention" discharge section
-    - 4 integration shapes + tie-break ordering
-    - verification tools: gh code-search, gh api, remyxai search query/info
-  Outputs: chosen_index + integration_shape + selection_reasoning
-       ↓
-External-pick dedup (if out-of-pool / extension candidate) against the same set
-       ↓
-Write the .remyx-recommendation/ spec bundle
-       ↓
-Pre-flight Claude pass: PR or Issue?
-       ↓                              ↓
-     ISSUE                            PR
-       ↓                              ↓
-   open Issue        Invoke Claude Code (implement integration)
-   (impl. diff                        ↓
-    preserved in     Path-allowlist + integration validator
-    body when         (new module must be imported by a modified file)
-    self-review                       ↓
-    routed here)     Stub-density + pytest + test-integration check
-                                      ↓
-                     Self-review pass (downgrade to Issue if orphan;
-                     diff preserved in Issue body for manual review)
-                                      ↓
-                     Commit (bundle scrubbed) + push + open draft PR
-                                      ↓
-                     Inline refinement chain (chain: true, default):
-                       fidelity audit  → Coverage matrix on PR body
-                       convention pass → align to repo conventions
-                       test gate       → lint + tests; drop draft on pass
-```
-
-When `chain: true` (the default), the same run continues into the refinement chain on the PR it just filed — fidelity audit, then (only if the audit ran) convention pass and test gate — so the whole pipeline is one workflow run with no extra workflow files. The chain phases are also invokable individually via `mode: fidelity/convention/test` + `pr-number` for the separate-workflow pattern or to re-run a single phase. Opt out of the inline chain with `chain: false`.
-
-The Remyx engine (commit-history extraction, candidate pool, embedding pre-filter, ranking) runs server-side. This action is a pure consumer.
-
-</details>
-
-## Weekly Discussion summary (opt-in)
-
-A rolling weekly digest of Outrider's work on your repo, posted as a comment
-on a Discussion you designate: run outcomes, the selection pass's verdicts
-(with its rejection reasoning quoted verbatim), refine-query themes, the
-license gate's class distribution, open Outrider Issues with a next-action
-column, and a short "patterns worth attention" section. Makes the action's
-work auditable at a glance — including the runs that deliberately produced
-no PR or Issue.
-
-Setup:
-
-1. **Enable Discussions** on your repo if it isn't already on:
-   *Settings → General → Features → ☑ Discussions*. (Repos — forks
-   especially — have Discussions off by default; the same is true for
-   the Issues tab, which Outrider needs for Issue-route recommendations.
-   When Issues are disabled the run exits cleanly with
-   `skipped_issues_disabled` and a hint to run `gh repo edit <repo>
-   --enable-issues`.)
-2. **Create (or pick) a Discussion** on your repo to host the digests, and
-   note its number from the URL.
-3. **Add a second scheduled job** (weekly cron) that calls the action in
-   `weekly-summary` mode. Note the extra `discussions: write` permission:
-
-   ```yaml
-   name: Outrider weekly summary
-   on:
-     schedule:
-       - cron: '0 15 * * 1'  # Mondays 15:00 UTC
-     workflow_dispatch:
-   jobs:
-     weekly-summary:
-       runs-on: ubuntu-latest
-       permissions:
-         contents: read
-         actions: read        # read the week's run logs
-         issues: read         # list open Outrider Issues
-         discussions: write   # post the digest comment
-       env:
-         REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
-         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-       steps:
-         - uses: remyxai/outrider@v1
-           with:
-             interest-id: 'YOUR-INTEREST-UUID-HERE'
-             mode: weekly-summary
-             weekly-discussion-id: '123'  # your Discussion number
-   ```
-
-The digest posts as `remyx-ai[bot]` when the Remyx GitHub App is installed
-on the repo with Discussions access (if a permission prompt is pending,
-accept it under *Settings → GitHub Apps → remyx-ai*); otherwise it falls
-back to the workflow's `GITHUB_TOKEN` and posts as `github-actions[bot]`.
-
-Cost: one Claude call per week (~$0.10–0.20) to draft the interpretive
-sections; the rest is GitHub API reads. If that call fails, the digest still
-posts with the data tables only. Runs whose logs have aged out of GitHub's
-retention window are listed as "details unavailable" rather than silently
-dropped.
+- **[Configuration reference](docs/configuration.md)** — full inputs, outputs, status codes
+- **[Customization](docs/customization.md)** — how to tailor Outrider to your repo + signals it reads
+- **[Architecture](docs/architecture.md)** — selection taxonomy, pipeline, refinement chain
+- **[Guardrails](docs/guardrails.md)** — what the agent can and can't modify
+- **[Weekly summary mode](docs/weekly-summary.md)** — opt-in rolling digest comments
 
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,146 @@
+---
+type: architecture_overview
+description: Selection taxonomy, gating logic, and the full Outrider pipeline.
+tags: [outrider, architecture, selection-pass, refinement-chain]
+---
+
+# Architecture
+
+How Outrider decides what to recommend, what to scaffold, and how to refine.
+
+
+## 1. Selection — four integration shapes
+
+The selection pass classifies every candidate against your repo using a four-shape taxonomy. A candidate that doesn't fit one of these shapes is a structural mismatch and gets rejected.
+
+| Shape | Definition | Verification gate |
+|---|---|---|
+| **addition** | Paper adds a new module wired into existing code. Most common. | Call site exists and the new module's I/O contract fits. |
+| **replacement** | Strict drop-in for an existing component with the same I/O contract but better internals (smaller / faster / newer foundation). | I/O contracts are functionally equivalent, not just thematically related. |
+| **simplification** | Merges two or more existing components into one with the same end-to-end contract. Pipeline collapses. | Merged contribution spans the existing boundary contract cleanly. |
+| **extension** | Proposes a new capability your repo lacks AND that you've signaled openness to (README roadmap, an open `[RFC]` Issue, CONTEXT.md investment pattern). | Four gates: pipeline-compatible I/O, explicit team-direction signal, no existing implementation, tier=high + relevance ≥ 0.90. Without ≥1 direction signal, extension picks are RFC-fishing and get rejected. |
+
+**Tie-break preference**: `simplification > replacement > addition > extension`. Extension is last-resort — picked only when the other three shapes fail AND the four gates pass.
+
+
+## 2. Discharge model — avoiding duplicate work
+
+The same paper isn't re-recommended once it's already in front of your team. The dedup gate counts:
+
+- **Outrider-opened Issues** (any state, open OR closed) — closing an Issue means "the team has decided," still a discharge signal.
+- **Maintainer-opened Issues** (RFCs, discussions) whose body links the paper's arxiv id — a stronger signal than Outrider's own, since you authored the thread.
+
+**Re-engagement lever**: reopen the Issue to drop the paper from the discharge set so Outrider can re-recommend it.
+
+
+## 3. Pipeline — full flow
+
+```
+GitHub cron fires the workflow
+       ↓
+Query engine.remyx.ai for the candidate pool + interest context
+       ↓
+Per-candidate viability gates:
+  - confidence (tier above min-confidence)
+  - PR exists for arxiv?
+  - any prior Issue references arxiv? (Outrider OR maintainer; open OR closed)
+  - cadence guard (rate-limit-days)
+       ↓
+Clone the target repo + detect package / default branch
+       ↓
+Selection pass (Claude agentic, ~5 min):
+  Inputs:
+    - candidate brief (with inline "✗ already filed" tags)
+    - 4 integration shapes + tie-break ordering
+    - verification tools: gh code-search, gh api, remyxai search query/info
+  Outputs:
+    - chosen_index + integration_shape + selection_reasoning
+    - OR: broaden-search via /search/assets if no in-pool fit
+    - OR: skipped_by_selection_verification if every candidate rejected
+       ↓
+External-pick dedup (if out-of-pool / extension candidate)
+       ↓
+Write the .remyx-recommendation/ spec bundle
+       ↓
+Pre-flight Claude pass: PR or Issue?
+       ↓                              ↓
+     ISSUE                            PR
+       ↓                              ↓
+   open Issue        Invoke Claude Code (implement integration)
+                                      ↓
+                     Path-allowlist + integration validator
+                     (new module must be imported by a modified file)
+                                      ↓
+                     Stub-density + pytest + test-integration check
+                                      ↓
+                     Self-review pass (downgrade to Issue if orphan;
+                     diff preserved in Issue body for manual review)
+                                      ↓
+                     Commit (bundle scrubbed) + push + open draft PR
+                                      ↓
+                     Inline refinement chain (chain: true, default):
+                       Phase A — fidelity audit
+                         · reference-anchored (clone + diff) OR
+                         · paper-anchored (arxiv abstract; degraded mode)
+                         → Coverage matrix in step summary
+                       Phase B — convention pass
+                         · extract upstream PR-body shape
+                         · rewrite body (canonical-first folding)
+                         · patch session (non-algorithmic alignment)
+                       Phase C — test gate
+                         · lint + targeted tests on touched files
+                         · drop draft to ready-for-review on pass
+       ↓
+     Issue route also runs an inline pass (v1.6.17):
+       Phase B' — issue convention pass
+         · walk .github/ISSUE_TEMPLATE/*
+         · classify template kinds (filter bug + question)
+         · pick best-fitting template + rewrite Issue body
+         · PATCH issue body
+```
+
+When `chain: true` (the default), the same run continues into the refinement chain on the artifact it just filed. Opt out with `chain: false`.
+
+The Remyx engine (commit-history extraction, candidate pool, embedding pre-filter, ranking) runs server-side. This action is a pure consumer.
+
+
+## 4. Fidelity audit anchors
+
+Phase A audits the diff against a reference. The anchor depends on what's available:
+
+| Mode | Anchor | When it fires |
+|---|---|---|
+| **Reference-anchored** (A1) | Cloned GitHub repo of the paper's reference impl | Reference URL extractable from PR body |
+| **Paper-anchored** (A2, v1.6.16) | arXiv abstract page text | No reference URL, but arxiv id extractable. Lower precision — the audit reports its precision floor via the "Audit anchor" line in the Coverage matrix. |
+
+A2 is the degraded mode. Before v1.6.16, papers without a public reference impl would cause Phase A to skip and cascade the skip to Phases B + C. A2 keeps the chain running.
+
+
+## 5. Issue-route convention pass (v1.6.17)
+
+When recommend mode routes to an Issue rather than a PR, the chain runs a single phase: the Issue-route convention pass.
+
+| Step | Behavior |
+|---|---|
+| **1. Walk templates** | Read `.github/ISSUE_TEMPLATE/*.{md,yml,yaml}`; skip `config.yml`. Accept both legacy markdown frontmatter and modern Issue Forms. |
+| **2. Classify kinds** | Heuristic: `bug` / `feature` / `new_model` / `question` / `other`. Drop bug + question kinds (paper-pitch Issues don't fit). |
+| **3. Pick best-fitting template** | Claude one-shot. If no fit, fall through to scaffolding-collapse-only mode. |
+| **4. Rewrite body** | Same one-shot emits the rewritten body in a delimited format (`===TEMPLATE_ID===` / `===RATIONALE===` / `===UPDATED_BODY===` / `===END===`) to avoid JSON-escape brittleness on long markdown. |
+| **5. PATCH + label** | PATCH issue body via Issues API; apply `outrider:issue-convention-done`. |
+
+Three terminal statuses:
+- `issue_convention_aligned` — template picked + body folded
+- `issue_convention_aligned_no_fitting_template` — templates exist but all bug/question; body still folded with scaffolding collapsed
+- `issue_convention_skipped_no_templates` — no `.github/ISSUE_TEMPLATE/`; body still folded
+
+
+## 6. What's NOT customizable via inputs
+
+These design choices are baked into the action:
+
+- The four integration shapes and their tie-break ordering — changing them changes Outrider's identity.
+- Self-review heuristics (orphan detection, stub density threshold at 50%, integration validator).
+- Phase A audit anchor selection (reference vs paper). Auto-decided based on paper provenance.
+- Body-rewrite folding rules (canonical-first, Discovery context details block, one-line attribution). The prompts are fixed; the LLM's choices vary per repo.
+
+File an Issue on `remyxai/outrider` if something here is blocking you.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,107 @@
+---
+type: configuration_reference
+description: Inputs, outputs, and status codes for the Outrider action.
+tags: [outrider, configuration, reference]
+---
+
+# Configuration reference
+
+Inputs, outputs, and status codes for the Outrider action.
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `interest-id` | *(required)* | Remyx ResearchInterest UUID |
+| `github-token` | `${{ github.token }}` | Override only for cross-repo controller patterns |
+| `min-confidence` | `moderate` | Tier gate: `high` / `moderate` / `low` |
+| `draft-mode` | `always` | `always` / `on_test_failure` / `never` |
+| `rate-limit-days` | `7` | Cadence guard. Any value > 0 enables: skip the run if any **open** Remyx PR or Issue exists on the target. Engagement (merge or close) releases the gate. Set `0` to disable. The numeric value is otherwise ignored — kept as an on/off bit for compatibility with workflow files written for the prior sliding-window semantics. |
+| `guardrails-allowlist` | `''` | Extra path globs Claude Code may modify, **added on top of** the defaults (`*.py`, `.remyx-recommendation/**`, `**/*.md`). Most repos won't need this. |
+| `test-integration-policy` | `strict` | `strict` (demote to Issue if new tests don't import an existing module) / `soft` (open draft PR with warning) / `off` (skip the gate). Use `soft` for layer/component repos where standalone modules are the contribution. |
+| `lookback` | `week` | Candidate pool window: `today` / `week` / `month` |
+| `candidate-pool` | `25` | How many candidates the selection pass picks from |
+| `claude-timeout` | `900` | Wall-clock seconds for the Claude Code implementation step. Bump for very large repos; lower to cap cost. |
+| `pin-arxiv` | `''` | Optional `arxiv_id`. When set and present in the candidate pool, the action implements that exact paper and skips the selection pass — use it for reproducible eval re-runs. Empty = normal selection. |
+| `mode` | `recommend` | `recommend` (classic per-run flow) / `weekly-summary` (post a weekly digest — see [weekly-summary.md](weekly-summary.md)) / `fidelity` / `convention` / `test` / `issue-convention` (standalone chain phases, for re-running a single phase against an existing PR or Issue) |
+| `chain` | `true` | When `true`, `recommend` mode continues into the refinement chain (fidelity audit → convention pass → test gate for PRs, or convention pass alone for Issues) within the same run. Set `false` for cost-sensitive runs. |
+| `pr-number` | `''` | PR number for standalone chain phases (`fidelity` / `convention` / `test`). Empty in `recommend` mode — the inline chain reads it automatically. |
+| `issue-number` | `''` | Issue number for `mode: issue-convention`. Empty in `recommend` mode — the inline chain reads it automatically. |
+| `weekly-discussion-id` | `''` | Discussion number (from its URL) or GraphQL node ID. Only read in `weekly-summary` mode. |
+
+
+## Outputs
+
+| Output | When | Description |
+|---|---|---|
+| `status` | always | Run outcome — see status codes below |
+| `pr_url` | `pr_opened*` | URL of the opened PR |
+| `pr_number` | `pr_opened*` | Number of the opened PR (handed to the inline refinement chain) |
+| `issue_url` | `issue_opened*` | URL of the opened Issue |
+| `issue_number` | `issue_opened*` | Number of the opened Issue (handed to the inline Issue-route pass) |
+| `chain_fidelity_status` / `chain_convention_status` / `chain_test_status` | chain ran (PR route) | Per-phase outcome of the inline refinement chain |
+| `chain_issue_convention_status` | chain ran (Issue route) | Outcome of the Issue-route convention pass |
+| `chain_draft_dropped` | chain ran | `true` if the test gate flipped the draft to ready-for-review |
+| `arxiv` | when a paper was picked | arxiv_id |
+| `tier` | when a paper was picked | `high` / `moderate` / `low` / `noise` |
+| `cost_usd` | always | Claude spend for this run |
+| `input_tokens` / `output_tokens` | always | Token usage |
+| `discussion_comment_url` | `weekly_summary_posted` | URL of the posted weekly digest comment |
+
+
+## Status codes
+
+### Recommend-mode outcomes
+
+| Status | Meaning |
+|---|---|
+| `pr_opened` | PR opened ready-for-review (tests passed, `draft-mode != always`) |
+| `pr_opened_draft` | PR opened as draft |
+| `issue_opened_preflight` | Pre-flight Claude pass routed to Issue before implementation |
+| `issue_opened` | Claude elected Issue-mode (wrote `OPEN_AS_ISSUE.md` instead of code) |
+| `issue_opened_no_integration` | Diff adds code that nothing invokes |
+| `issue_opened_stub_density` | New module is ≥50% stubs (`pass` / `NotImplementedError` / empty bodies) |
+| `issue_opened_no_test_integration` | New tests don't import from any pre-existing module |
+| `issue_opened_self_review` | Self-review judged the new code an orphan, unreachable from production. Body preserves Claude's implementation diff for manual review |
+| `issue_opened_substitution` | Selection identified a replacement / pipeline-simplification / extension candidate; routed to Issue because the swap needs dep changes the PR guardrails block, or there's no existing call site to anchor against |
+| `issue_opened_high_risk` | Diff Risk Score gate routed to a human-review Issue instead of a PR (implementation diff preserved in the Issue body) |
+| `skipped_low_confidence` | Recommendation below `min-confidence` |
+| `skipped_open_artifact` | An open Remyx PR or Issue from a prior run still exists on the target — engagement (merge or close) releases the gate |
+| `skipped_issues_disabled` | The target repo has its Issues tab disabled (default on forks) and the scoped App token can't re-enable it. Enable with `gh repo edit <repo> --enable-issues` and the next run proceeds |
+| `skipped_pr_exists` | Every candidate already has an open PR |
+| `skipped_issue_exists` | Every candidate already has a prior Issue referencing the arxiv id — Outrider-opened OR maintainer-opened, open OR closed. Step summary differentiates "Already in flight" (open) vs "Already addressed" (closed). Reopen the Issue to re-engage |
+| `skipped_external_issue_exists` | Selection pass surfaced an out-of-pool candidate but it's already in the team's attention |
+| `skipped_by_selection_verification` | Selection pass verified every candidate against the repo and rejected all. The `selection_reasoning` payload renders in the step summary explaining why |
+| `skipped_test_failure` | Tests failed AND `draft-mode: never` |
+| `claude_failed` | Claude CLI exited non-zero |
+| `rejected_path_violations` | Claude touched files outside the guardrails allowlist |
+| `error` | Unhandled exception |
+
+### Chain phase statuses (in `chain.*_status` outputs)
+
+| Phase | Status | Meaning |
+|---|---|---|
+| **Fidelity** (PR route) | `fidelity_audited` | Coverage matrix posted; reference-impl anchor |
+|  | `fidelity_audited_needs_judgment` | Coverage matrix posted; ≥1 item flagged for human review |
+|  | `fidelity_audited_paper_anchored` | Coverage matrix posted; paper-abstract anchor (no reference impl available — paper-anchored degraded mode from v1.6.16) |
+|  | `fidelity_audited_paper_anchored_needs_judgment` | Paper-anchored + needs-judgment |
+|  | `fidelity_skipped_no_reference` | No reference URL **and** no arxiv abstract available — chain bails |
+|  | `fidelity_skipped_not_bot` | PR not authored by `remyx-ai[bot]` |
+|  | `fidelity_failed_clone` | Reference clone failed |
+|  | `fidelity_failed_claude` | Audit Claude call failed or returned unparseable JSON |
+| **Convention** (PR route) | `convention_aligned` | Body rewritten + non-algorithmic alignment patches applied |
+|  | `convention_skipped_*` / `convention_failed_*` | See action source for full list |
+| **Test gate** (PR route) | `test_passed` | Lint + tests passed; draft dropped to ready-for-review |
+|  | `test_failed` | Lint or tests failed; `outrider:test-failed` label applied; PR stays draft |
+| **Issue convention** (Issue route, v1.6.17) | `issue_convention_aligned` | Issue body rewritten to picked ISSUE_TEMPLATE shape |
+|  | `issue_convention_aligned_no_fitting_template` | Templates exist but all bug/question kinds (e.g. bug-only repo); body still folded with scaffolding collapsed |
+|  | `issue_convention_skipped_no_templates` | No `.github/ISSUE_TEMPLATE/` directory; body folded with scaffolding collapsed |
+|  | `issue_convention_failed_claude` / `issue_convention_failed_patch` | Claude call or body PATCH failed |
+
+### Weekly summary mode
+
+| Status | Meaning |
+|---|---|
+| `weekly_summary_posted` | Weekly digest comment posted to the configured Discussion |
+| `weekly_summary_skipped_no_discussion_id` | `mode: weekly-summary` ran without a `weekly-discussion-id` |
+| `weekly_summary_failed` | Weekly mode hit an unhandled error (nothing was posted) |

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,0 +1,133 @@
+---
+type: customization_guide
+description: How to tailor what Outrider does on your repo — the knobs you control and the signals it reads.
+tags: [outrider, customization, configuration]
+---
+
+# Customization
+
+How to tailor what Outrider does on your repo — the knobs you control and the signals it reads.
+
+> For the full reference table of every input and output, see [`configuration.md`](configuration.md). This document is the higher-level "what shapes Outrider's behavior" guide.
+
+
+## 1. What you directly control
+
+### Selection bar — `min-confidence`
+
+Outrider tags each candidate paper with a confidence tier (`high` / `moderate` / `low` / `noise`) from its relevance ranking. `min-confidence: moderate` (default) lets moderate+ candidates through; raise to `high` for stricter signal, lower to `low` for higher-volume exploration on quiet repos.
+
+### Pool size & freshness — `lookback`, `candidate-pool`
+
+- `lookback: week` (default) pulls candidates from the past 7 days. Use `today` for daily fresh runs, `month` for slow-cadence repos.
+- `candidate-pool: 25` is how many candidates the selection pass considers. A larger pool widens the window but doesn't change the relevance bar.
+
+### Routing strictness — `test-integration-policy`
+
+- `strict` (default): if new tests don't import a pre-existing module, the run downgrades to Issue. Right for application / pipeline repos.
+- `soft`: open the PR anyway with a warning section. Right for layer / component repos (graph NN, kernels) where new standalone modules ARE the contribution.
+- `off`: skip the gate entirely.
+
+### Draft-state policy — `draft-mode`
+
+- `always` (default): every PR opens as draft. The chain's test gate flips it to ready-for-review on a passing run.
+- `on_test_failure`: tests pass → ready, tests fail → draft.
+- `never`: tests pass → ready, tests fail → run is skipped entirely (no draft PR).
+
+### Reproducibility — `pin-arxiv`
+
+Set to a specific `arxiv_id` and Outrider skips the selection pass entirely, implementing that exact paper. Use for eval re-runs and demos.
+
+### Filesystem reach — `guardrails-allowlist`
+
+Extra path globs Claude Code may touch, **added on top of** the defaults (`*.py`, `.remyx-recommendation/**`, `**/*.md`). Most repos don't need this. See [`guardrails.md`](guardrails.md) for full details on what's allowed and what's always blocked.
+
+### Cadence guard — `rate-limit-days`
+
+Any value > 0: skip the run if any open Remyx PR or Issue is still on the target. The default (`7`) keeps the gate enabled; engagement (merge or close) releases it. Set `0` to disable — useful for batch trials.
+
+
+## 2. What Outrider reads from your repo
+
+The selection pass is **agentic** — Claude has read-only tools and consults multiple sources before picking a candidate. The more signal your repo emits, the more confident (and faster) the selection.
+
+### Codebase structure
+
+- **Module surface** — Outrider clones your repo and walks `*.py` files to identify call sites. The Diff Risk Score gate also reads `git log` to detect critical-path files.
+- **Package layout** — auto-detected from `setup.py` / `pyproject.toml` / top-level `__init__.py` placement.
+
+### Convention signals
+
+- **Recent merged PRs** — Phase B (convention pass) extracts your PR-body template and merge cadence from the last ~30 merged PRs. Re-uses your headings, table shapes, checklist patterns.
+- **`.github/ISSUE_TEMPLATE/`** — Phase B' (Issue-route convention pass) reads markdown frontmatter and Issue Forms (`.md` / `.yml` / `.yaml`), classifies templates by kind (bug / feature / new_model / question / other), and folds Outrider Issues into the best-fitting template. See [REMYX-146 design](architecture.md#issue-route-convention-pass) for the picker logic.
+- **`CONTRIBUTING.md` / `ORIENTATION.md`** — if present, the drafting prompt consults them for lint configs and house style. Defers to your repo's own config (ruff / pre-commit / black / flake8) rather than hardcoding rules.
+
+### Direction signals (for **extension**-shape picks)
+
+The selection pass's strictest shape — proposing a new capability your repo lacks — requires explicit team-direction signals before it'll route any candidate that way:
+
+- **README roadmap section** — a "Coming soon" / "Roadmap" / "Planned" heading
+- **CONTEXT.md investment pattern** — a recurring theme you've been shipping
+- **Open `[RFC]` Issue** — a maintainer-authored thread inviting discussion of a capability
+
+Without ≥1 of these, extension picks get rejected as "RFC-fishing." Add an RFC Issue or a roadmap line if you want Outrider to surface new-capability candidates.
+
+### Discharge signals (to **not** re-recommend papers)
+
+Outrider treats a paper as "discharged" — won't re-recommend it — when:
+
+- **An Outrider-opened Issue exists** for that arxiv id (any state, open OR closed). Closing means "the team has decided."
+- **A maintainer-opened Issue** (RFC, discussion) links the paper's arxiv id in its body — a stronger signal than Outrider's own.
+
+Re-engagement lever: **reopen the Issue** to drop the paper from the discharge set so Outrider can re-recommend it.
+
+
+## 3. What Outrider reads from your Research Interest
+
+The `interest-id` input points at a `ResearchInterest` record in the Remyx engine — this is the primary surface for customizing what Outrider considers relevant.
+
+- **Auto-interest context** — if you used `outrider init --auto-interest` (or `remyxai interests from-repo`), the engine extracts a structured `ExperimentHistory` from your commit log (3-pass extraction: themes, methods, infrastructure). This is the starting context.
+- **Manual edits** — you can edit the interest's context body in the engine.remyx.ai UI to sharpen the framing. Concrete guidance ("we're focused on X but not Y") raises selection precision noticeably.
+- **License preferences** — the interest carries license-class preferences. By default the action accepts `permissive` (Apache-2.0 / MIT / BSD); copyleft and NC licenses are gated.
+
+
+## 4. Verification tools available to the selection pass
+
+When the agent is choosing among candidates, it has these read-only tools at hand:
+
+| Tool | Purpose |
+|---|---|
+| `gh code-search` | Verify a candidate's claimed call site exists in your repo |
+| `gh api` | Read PRs, Issues, README, CONTRIBUTING.md, ISSUE_TEMPLATE directly |
+| `gh-graph` | Walk a module's imports + reverse-imports (custom helper installed by the action) |
+| `remyxai search query` | Broaden-search across the engine's full corpus when no in-pool candidate fits (the "deep research" refine path) |
+| `remyxai search info` | Pull paper text + abstract by arxiv id for verification |
+
+These tools are what make selection "structural fit" rather than keyword match.
+
+
+## 5. Common customization recipes
+
+| Goal | Set this |
+|---|---|
+| Higher-precision picks only | `min-confidence: high` |
+| Allow proposing new capabilities your repo lacks | Add an RFC Issue or roadmap line; raise `min-confidence: high` (extension shape needs tier=high anyway) |
+| Slow down cadence | Lengthen the cron schedule; default `rate-limit-days` already gates stacking |
+| Batch trial mode (no cadence skipping) | `rate-limit-days: '0'` |
+| Save cost on routine runs | `chain: false` (skip the refinement chain; ~$3-4 → ~$1-2 per run) |
+| Eval re-run on a specific paper | `pin-arxiv: <arxiv_id>` |
+| Layer/component repo (new modules ARE the contribution) | `test-integration-policy: soft` |
+| Touch non-Python config (e.g. `pipelines/*.yaml`) | `guardrails-allowlist: 'pipelines/**/*.yaml'` |
+| Quiet repo with little arxiv-relevant activity | `lookback: month`, `min-confidence: low` |
+
+
+## 6. What you can't (currently) customize
+
+These are baked into the action and not exposed as inputs — intentional design choices:
+
+- **The four integration shapes** (addition / replacement / simplification / extension) and their tie-break ordering. Changing these would change Outrider's identity.
+- **Self-review heuristics** (orphan detection, stub density threshold at 50%, integration validator). Tunable in source but not via inputs.
+- **Phase A audit anchor selection** (reference-anchored vs paper-anchored). Auto-decided based on whether the paper has a reference repo URL.
+- **Body-rewrite folding rules** (canonical-first, Discovery context details block, one-line attribution). The convention pass's prompt is fixed; the LLM's choices vary per repo.
+
+If something in this list is blocking you, file an Issue on `remyxai/outrider` — we'll consider exposing it.

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -1,0 +1,41 @@
+---
+type: guardrails_spec
+description: Path allowlist, block list, and edit-size caps the Outrider agent operates under.
+tags: [outrider, guardrails, security]
+---
+
+# Guardrails
+
+What Claude Code can and can't modify when Outrider drafts a PR.
+
+
+## Allowed paths (defaults)
+
+- `*.py` — any Python source, anywhere in the repo
+- `.remyx-recommendation/**` — the spec bundle (scrubbed before commit)
+- `**/*.md` — Markdown anywhere (README, CHANGELOG, docs/, ADR notes); the 50-line edit cap still applies to existing files
+
+Extend the allowlist for your repo via the `guardrails-allowlist` input.
+
+
+## Always blocked (by role, not directory)
+
+- `.github/**` — CI / workflow config
+- `*Dockerfile`, `*Dockerfile.*`, `*.dockerfile`, `*.sh` — container builds and shell scripts
+- `*requirements*.txt`, `setup.py`, `setup.cfg`, `pyproject.toml`, `MANIFEST.in`, `*.lock` — dependency / build manifests
+
+The block list takes precedence over the allowlist. Non-`.py` config not on the block list (e.g. `pipelines/*.yaml`) simply isn't allowed either.
+
+
+## Edit-size caps (enforced after the Claude session)
+
+- Each edit to a pre-existing file: ≤50 net lines (additions + deletions)
+- At most 3 new `.py` files per run
+- At least one newly-added function/method/class must be invoked from another changed file (an import alone doesn't count)
+
+
+## What enforcement looks like
+
+If Claude touches a path outside the allowlist or violates an edit cap, the run terminates with `rejected_path_violations` rather than opening a malformed PR. The validation runs after the Claude session and before any git push, so violations are caught locally — nothing reaches your repo.
+
+The integration validator (one of the edit-size caps) is also what catches the "added code that nothing invokes" failure mode that downgrades to `issue_opened_no_integration`. That's the same gate as self-review's orphan check, but earlier in the pipeline.

--- a/docs/weekly-summary.md
+++ b/docs/weekly-summary.md
@@ -1,0 +1,72 @@
+---
+type: weekly_summary_guide
+description: Opt-in weekly-summary mode setup — post a rolling digest of Outrider's work as a Discussion comment.
+tags: [outrider, weekly-summary, opt-in]
+---
+
+# Weekly Discussion summary (opt-in)
+
+A rolling weekly digest of Outrider's work on your repo, posted as a comment on a Discussion you designate.
+
+## What goes in the digest
+
+- Run outcomes for the past 7 days
+- The selection pass's verdicts, with its rejection reasoning quoted verbatim
+- Refine-query themes (what topics Outrider broaden-searched on)
+- The license gate's class distribution
+- Open Outrider Issues with a next-action column
+- A short "patterns worth attention" section
+
+Makes the action's work auditable at a glance — including the runs that deliberately produced no PR or Issue.
+
+
+## Setup
+
+### 1. Enable Discussions on your repo
+
+*Settings → General → Features → ☑ Discussions*. Forks especially have Discussions off by default. The same is true for the Issues tab, which Outrider needs for Issue-route recommendations — when Issues are disabled the run exits cleanly with `skipped_issues_disabled` and a hint to run `gh repo edit <repo> --enable-issues`.
+
+### 2. Create (or pick) a Discussion to host the digests
+
+Note its number from the URL.
+
+### 3. Add a second scheduled job (weekly cron)
+
+The weekly job calls the action in `weekly-summary` mode. Note the extra `discussions: write` permission:
+
+```yaml
+name: Outrider weekly summary
+on:
+  schedule:
+    - cron: '0 15 * * 1'  # Mondays 15:00 UTC
+  workflow_dispatch:
+jobs:
+  weekly-summary:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read        # read the week's run logs
+      issues: read         # list open Outrider Issues
+      discussions: write   # post the digest comment
+    env:
+      REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: remyxai/outrider@v1
+        with:
+          interest-id: 'YOUR-INTEREST-UUID-HERE'
+          mode: weekly-summary
+          weekly-discussion-id: '123'  # your Discussion number
+```
+
+
+## Authoring identity
+
+The digest posts as `remyx-ai[bot]` when the Remyx GitHub App is installed on the repo with Discussions access — if a permission prompt is pending, accept it under *Settings → GitHub Apps → remyx-ai*. Otherwise it falls back to the workflow's `GITHUB_TOKEN` and posts as `github-actions[bot]`.
+
+
+## Cost
+
+One Claude call per week (~$0.10–0.20) to draft the interpretive sections; the rest is GitHub API reads. If that call fails, the digest still posts with the data tables only.
+
+Runs whose logs have aged out of GitHub's retention window are listed as "details unavailable" rather than silently dropped.


### PR DESCRIPTION
## What

Slim the README from **318 → 95 lines** by moving reference content into `docs/`. Pure relocation — no content removed.

## Why

The README had drifted to a comprehensive single-page reference. Visitors scrolling for "what does this do for me" were hitting walls of detail (15 inputs, 12 outputs, 25+ status codes, full pipeline diagram, selection taxonomy, weekly-summary setup) before reaching the value prop.

## What moves where

| Source content | Destination |
|---|---|
| Inputs / Outputs / Status codes | `docs/configuration.md` |
| Knobs + signals Outrider reads | `docs/customization.md` (new) |
| How selection works + pipeline diagram | `docs/architecture.md` |
| Path allowlist + block list + edit caps | `docs/guardrails.md` |
| Weekly Discussion summary setup | `docs/weekly-summary.md` |
| Demo GIF | Removed (visual predates v1.6.15's body rewrite) |

All new docs carry OKF frontmatter matching the existing `CONTEXT.md` + bundle-template convention.

## What stays in README

Lead (2 sentences) → workflow snippet → What you get (4 bullets) → Quickstart (CLI one-liner; manual install in `<details>`) → Costs (1 paragraph) → Examples (2 links) → Documentation (links to docs/) → License.

## Examples section

New section adds two recent artifacts as concrete demos:
- **OpenRLHF PR #6** — CFPO regularizer; full inline chain ran; canonical-first body
- **NeMo-Curator Issue #5** — FinerWeb-10BT; paper-anchored audit; self-review-routed

## Updated status table

Now covers v1.6.16's `fidelity_audited_paper_anchored*` and v1.6.17's `issue_convention_*` outcomes that were missing from the prior table.

## Repo metadata (applied separately, already live)

- Description: trimmed 185 → 120 chars to fit the sidebar without truncation
- Homepage: set to https://engine.remyx.ai
- Topics: +5 (`pull-request-automation`, `agentic-ai`, `code-review-automation`, `paper-to-code`, `ai-research`)

## Validation

- `python -m pytest tests/` → 680/680 pass (existing OKF + invocation-frontmatter tests still green)
- All internal cross-links resolved