### PR TITLE
Add pin-method input — implement a user-specified method

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -203,6 +203,15 @@ inputs:
       use it for reproducible eval re-runs. Empty = normal selection.
     required: false
     default: ''
+  pin-method:
+    description: |
+      Optional method/technique query (e.g. "knowledge distillation", "MoE
+      expert routing"). When set, Outrider runs the engine's search to find
+      the top arxiv paper for the query and implements it — bypassing the
+      selection pass and the interest's candidate pool entirely. Empty =
+      normal selection. Mutually exclusive with pin-arxiv.
+    required: false
+    default: ''
 
 outputs:
   status:
@@ -211,8 +220,8 @@ outputs:
       "skipped_low_confidence" | "skipped_open_artifact" |
       "skipped_issues_disabled" | "skipped_pr_exists" |
       "skipped_issue_exists" | "skipped_test_failure" | "claude_failed" |
-      "rejected_path_violations" | "aborted_secret_in_payload" |
-      "error". In weekly-summary mode:
+      "skipped_no_method_match" | "rejected_path_violations" |
+      "aborted_secret_in_payload" | "error". In weekly-summary mode:
       "weekly_summary_posted" | "weekly_summary_skipped_no_discussion_id" |
       "weekly_summary_failed".
     value: ${{ steps.recommend.outputs.status }}
@@ -310,6 +319,7 @@ runs:
         INPUT_TEST_INTEGRATION_POLICY: ${{ inputs.test-integration-policy }}
         INPUT_CLAUDE_TIMEOUT: ${{ inputs.claude-timeout }}
         INPUT_PIN_ARXIV: ${{ inputs.pin-arxiv }}
+        INPUT_PIN_METHOD: ${{ inputs.pin-method }}
         # PR number to audit in fidelity mode (set from the workflow's
         # pull_request event payload; empty in recommend / weekly-summary).
         INPUT_PR_NUMBER: ${{ inputs.pr-number }}

--- a/src/run.py
+++ b/src/run.py
@@ -1181,6 +1181,12 @@ class Target:
     # LLM selection pass) so eval re-runs are reproducible. Empty = normal
     # selection.
     pin_arxiv: str = ""
+    # Optional: free-text method/technique query. When set, the recommend
+    # phase resolves it to the top arxiv hit via /search/assets, builds a
+    # single-item viable pool from that asset, and pins to it — bypassing
+    # both the interest's candidate pool and the selection pass. Mutually
+    # exclusive with pin_arxiv (validated in build_target_from_env).
+    pin_method: str = ""
     # Inline refinement chain: when True (default), recommend mode continues
     # sequentially into fidelity audit → convention pass → test gate on the
     # just-opened PR, so the chain runs by default without the customer
@@ -2334,6 +2340,28 @@ def _remyx_get_asset(arxiv_id: str) -> dict | None:
     if isinstance(resp, dict) and (resp.get("arxiv_id") or resp.get("title")):
         return resp
     return None
+
+
+_PIN_METHOD_ARXIV_RE = re.compile(r"^\d{4}\.\d{4,5}(v\d+)?$")
+
+
+def _resolve_pin_method(query: str) -> dict | None:
+    """Resolve a pin-method query to a single /search/assets envelope dict.
+
+    Detects whether the input is a literal arxiv_id (post-2007 form
+    ``NNNN.NNNN[N][vN]``) and short-circuits to direct asset lookup via
+    ``_remyx_get_asset`` — both faster and immune to keyword-search
+    retrieval gaps. Otherwise treats it as a free-text method query and
+    returns the top hit from ``_remyx_search_assets``. Returns ``None``
+    when nothing matches.
+    """
+    q = (query or "").strip()
+    if not q:
+        return None
+    if _PIN_METHOD_ARXIV_RE.match(q):
+        return _remyx_get_asset(q)
+    assets = _remyx_search_assets(q, max_results=1)
+    return assets[0] if assets else None
 
 
 def _asset_to_recommendation(
@@ -6379,7 +6407,45 @@ def process_target(target: Target) -> dict:
     #    past week). The old flow took only papers[0], wasting the
     #    lookback; we keep the whole pool so the selection pass can pick
     #    the most implementable candidate.
-    candidates = query_remyx_candidates(target)
+    #
+    #    Pin-method short-circuit: when the user passes a method query
+    #    (or a literal arxiv_id) via `pin-method`, resolve it to a single
+    #    /search/assets envelope and use that asset as the sole
+    #    candidate — bypassing both the interest's recommendation pool
+    #    and the LLM selection pass. The downstream pin_arxiv check at
+    #    §4 then picks this candidate naturally (no extra plumbing).
+    if target.pin_method:
+        asset = _resolve_pin_method(target.pin_method)
+        if asset is None:
+            log.info(f"  ✗ skipped_no_method_match: pin-method "
+                     f"{target.pin_method!r} resolved to no asset")
+            result["status"] = "skipped_no_method_match"
+            result["pin_method"] = target.pin_method
+            return result
+        rec = _asset_to_recommendation(
+            asset, refine_query=f"pin-method:{target.pin_method}",
+            fallback_interest_name="(pin-method)",
+            interest_context="",
+            experiment_history="",
+        )
+        log.info(
+            f"  → pin-method {target.pin_method!r} resolved to "
+            f"{rec.arxiv_id} ({rec.paper_title[:60]}…)"
+        )
+        candidates = [rec]
+        result["pin_method"] = target.pin_method
+        result["pin_method_resolution"] = {
+            "query": target.pin_method,
+            "arxiv_id": rec.arxiv_id,
+            "title": rec.paper_title,
+        }
+        # Reduce pin-method to pin_arxiv so the existing pinning logic at
+        # §4 selects this candidate without a parallel code path. The
+        # original pin_method string is preserved in result["pin_method"]
+        # for the step summary.
+        target.pin_arxiv = rec.arxiv_id
+    else:
+        candidates = query_remyx_candidates(target)
     result["candidates_returned"] = len(candidates)
     # Pool-composition + license-distribution telemetry.
     # Post-dedup counts (query_remyx_candidates coalesces families before
@@ -6480,9 +6546,18 @@ def process_target(target: Target) -> dict:
                             f"pool; falling back to the selection pass")
         if pinned_idx is not None:
             rec = viable[pinned_idx]
-            result["selection_reasoning"] = (
-                f"(pinned via pin-arxiv={target.pin_arxiv})"
-            )
+            # pin-method reduces to pin-arxiv internally (see §2); surface
+            # the original user-facing source in the reasoning so step
+            # summaries / telemetry are honest about which input drove the pin.
+            if target.pin_method:
+                result["selection_reasoning"] = (
+                    f"(pinned via pin-method={target.pin_method!r} → "
+                    f"{target.pin_arxiv})"
+                )
+            else:
+                result["selection_reasoning"] = (
+                    f"(pinned via pin-arxiv={target.pin_arxiv})"
+                )
             log.info(f"  ✓ pinned candidate [{pinned_idx}] {rec.paper_title[:50]}…")
         else:
             selection = select_recommendation(
@@ -7372,6 +7447,7 @@ def build_target_from_env() -> Target:
         test_integration_policy=test_integration_policy,
         claude_timeout_s=claude_timeout_s,
         pin_arxiv=_optional_env("INPUT_PIN_ARXIV", ""),
+        pin_method=_optional_env("INPUT_PIN_METHOD", ""),
         chain_enabled=chain_enabled,
         notes="",
     )
@@ -11828,6 +11904,12 @@ def main():
         sys.exit(2)
 
     target = build_target_from_env()
+    if target.pin_arxiv and target.pin_method:
+        log.error(
+            "pin-arxiv and pin-method are mutually exclusive; set one or "
+            "the other, not both."
+        )
+        sys.exit(2)
     log.info(f"=== {target.repo} ===")
     log.info(f"  interest_id={target.interest_id}")
     if mode == "weekly-summary":

--- a/tests/test_pin_method.py
+++ b/tests/test_pin_method.py
@@ -1,0 +1,143 @@
+"""Tests for the pin-method input — REMYX-148.
+
+Covers the pure logic of pin-method resolution:
+
+  - arxiv_id-shaped query → direct asset lookup (bypasses keyword search)
+  - free-text query → keyword search → top-1 hit
+  - empty / no-match → ``None`` (the caller surfaces ``skipped_no_method_match``)
+  - the recommend-phase short-circuit reduces pin-method to pin-arxiv so
+    the existing pinning logic at §4 selects the asset
+  - pin-method + pin-arxiv set together exits with code 2 (mutex)
+
+The Remyx /search/assets fetch is the only network I/O involved;
+both the keyword-search and the direct-asset endpoints are
+monkey-patched.
+
+Run with: pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# ─── _resolve_pin_method ──────────────────────────────────────────────────
+
+
+def test_pin_method_arxiv_id_uses_direct_lookup(monkeypatch):
+    """A query that matches the arxiv_id shape skips the keyword search
+    and goes straight to ``_remyx_get_asset`` — both faster and immune
+    to keyword-retrieval gaps.
+    """
+    asset = {"arxiv_id": "2410.20305v2", "title": "Some Paper"}
+    calls = {"get_asset": 0, "search_assets": 0}
+
+    def fake_get_asset(arxiv_id):
+        calls["get_asset"] += 1
+        assert arxiv_id == "2410.20305v2"
+        return asset
+
+    def fake_search(query, max_results=5, use_llm=True):
+        calls["search_assets"] += 1
+        return []
+
+    monkeypatch.setattr(run, "_remyx_get_asset", fake_get_asset)
+    monkeypatch.setattr(run, "_remyx_search_assets", fake_search)
+
+    result = run._resolve_pin_method("2410.20305v2")
+    assert result == asset
+    assert calls["get_asset"] == 1
+    assert calls["search_assets"] == 0
+
+
+def test_pin_method_arxiv_id_without_version_also_matches(monkeypatch):
+    asset = {"arxiv_id": "2410.20305", "title": "Some Paper"}
+
+    def fake_get_asset(arxiv_id):
+        assert arxiv_id == "2410.20305"
+        return asset
+
+    monkeypatch.setattr(run, "_remyx_get_asset", fake_get_asset)
+    monkeypatch.setattr(run, "_remyx_search_assets",
+                        lambda *a, **kw: pytest.fail("must not call search"))
+
+    assert run._resolve_pin_method("2410.20305") == asset
+
+
+def test_pin_method_freetext_uses_keyword_search(monkeypatch):
+    """A non-arxiv query hits ``_remyx_search_assets`` and returns the
+    top-1 envelope."""
+    hits = [
+        {"arxiv_id": "2402.01234", "title": "A Distillation Paper"},
+        {"arxiv_id": "2402.05678", "title": "Another Paper"},
+    ]
+
+    def fake_search(query, max_results=5, use_llm=True):
+        assert query == "knowledge distillation"
+        assert max_results == 1
+        return hits
+
+    monkeypatch.setattr(run, "_remyx_search_assets", fake_search)
+    monkeypatch.setattr(run, "_remyx_get_asset",
+                        lambda *a, **kw: pytest.fail("must not call get"))
+
+    result = run._resolve_pin_method("knowledge distillation")
+    assert result == hits[0]
+
+
+def test_pin_method_freetext_no_hits_returns_none(monkeypatch):
+    monkeypatch.setattr(run, "_remyx_search_assets",
+                        lambda *a, **kw: [])
+    assert run._resolve_pin_method("some obscure unknown method") is None
+
+
+def test_pin_method_arxiv_id_not_found_returns_none(monkeypatch):
+    """``_remyx_get_asset`` returns None on 404 — pin-method propagates that."""
+    monkeypatch.setattr(run, "_remyx_get_asset", lambda *a, **kw: None)
+    assert run._resolve_pin_method("9999.99999v1") is None
+
+
+def test_pin_method_empty_query_returns_none(monkeypatch):
+    monkeypatch.setattr(run, "_remyx_get_asset",
+                        lambda *a, **kw: pytest.fail("must not call"))
+    monkeypatch.setattr(run, "_remyx_search_assets",
+                        lambda *a, **kw: pytest.fail("must not call"))
+    assert run._resolve_pin_method("") is None
+    assert run._resolve_pin_method("   ") is None
+
+
+# ─── Target.pin_method env wiring ─────────────────────────────────────────
+
+
+def test_target_picks_up_pin_method_env(monkeypatch):
+    monkeypatch.setenv("TARGET_REPO", "owner/name")
+    monkeypatch.setenv("INPUT_INTEREST_ID", "00000000-0000-0000-0000-000000000000")
+    monkeypatch.setenv("INPUT_PIN_METHOD", "knowledge distillation")
+    target = run.build_target_from_env()
+    assert target.pin_method == "knowledge distillation"
+    assert target.pin_arxiv == ""
+
+
+def test_target_pin_arxiv_and_pin_method_both_default_empty(monkeypatch):
+    monkeypatch.setenv("TARGET_REPO", "owner/name")
+    monkeypatch.setenv("INPUT_INTEREST_ID", "00000000-0000-0000-0000-000000000000")
+    target = run.build_target_from_env()
+    assert target.pin_method == ""
+    assert target.pin_arxiv == ""
+
+
+# ─── main() mutex check ───────────────────────────────────────────────────
+
+
+def test_main_exits_when_both_pin_inputs_set(monkeypatch):
+    monkeypatch.setenv("TARGET_REPO", "owner/name")
+    monkeypatch.setenv("INPUT_INTEREST_ID", "00000000-0000-0000-0000-000000000000")
+    monkeypatch.setenv("INPUT_PIN_ARXIV", "2410.20305v2")
+    monkeypatch.setenv("INPUT_PIN_METHOD", "knowledge distillation")
+    with pytest.raises(SystemExit) as exc:
+        run.main()
+    assert exc.value.code == 2


### PR DESCRIPTION
## Summary

- Adds a `pin-method` action input that accepts either a free-text method query (e.g. \"knowledge distillation\") or a literal arxiv_id, and pins Outrider to the resolved paper — bypassing both the interest's candidate pool and the LLM selection pass.
- arxiv_id-shaped inputs go through `_remyx_get_asset` (direct asset lookup), free-text inputs go through `_remyx_search_assets` top-1. This makes `pin-method` a strict superset of `pin-arxiv`: it also works on arxiv_ids that aren't in the candidate pool.
- `pin-method` + `pin-arxiv` are mutually exclusive; setting both exits with code 2.
- New `skipped_no_method_match` status when nothing resolves.

## Test plan

- [x] `pytest tests/` — 9 new tests in `test_pin_method.py`, all 689 existing tests pass
- [ ] Trial dispatch on a target fork with `pin-method: "knowledge distillation"` to confirm the resolution chain renders in the step summary
- [ ] Trial dispatch with `pin-method: "<arxiv_id>"` where the id is *not* in the interest's pool, confirm direct asset lookup pins the right paper