### PR TITLE
Time-decay the cadence guard via rate-limit-days (REMYX-152)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -130,16 +130,16 @@ inputs:
     default: 'always'
   rate-limit-days:
     description: |
-      Cadence guard: skip the run if an *open* Remyx Recommendation
-      artifact (PR or Issue) from a prior run still exists on the
-      target repo. Engagement (merge or close) signals the channel is
-      clear and the next run can proceed. Per-paper dedup (a separate
-      gate) handles same-recommendation retries — this guard is purely
-      about not stacking unresolved work. Any value > 0 enables the
-      guard; 0 disables it. The numeric value is otherwise ignored
-      (retained as an on/off bit so existing workflow files continue
-      to work unchanged; pre-2026-06 versions interpreted it as a
-      sliding "opened within N days" window).
+      Cadence guard window. Skip the run if the most recently opened
+      Remyx Recommendation artifact (PR or Issue) on the target repo is
+      *younger* than this many days. Older open artifacts age out of the
+      throttle window and stop blocking — real maintainers leave Issues
+      open for weeks without active triage, and the action should resume
+      cadence rather than mute the repo indefinitely. Engagement (merge
+      or close) still clears the gate immediately. Per-paper dedup (a
+      separate gate) handles same-recommendation retries — this guard is
+      purely about not stacking *recent* unresolved work. Set to 0 to
+      disable the guard entirely (useful for batch trials).
     required: false
     default: '7'
   guardrails-allowlist:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -44,7 +44,7 @@ Extra path globs Claude Code may touch, **added on top of** the defaults (`*.py`
 
 ### Cadence guard — `rate-limit-days`
 
-Any value > 0: skip the run if any open Remyx PR or Issue is still on the target. The default (`7`) keeps the gate enabled; engagement (merge or close) releases it. Set `0` to disable — useful for batch trials.
+Time-decayed throttle. Skip a run only if the most recently opened Remyx PR/Issue on the target is *younger* than `rate-limit-days`. The default `7` means "don't pile on within a week of the last artifact"; older open artifacts age out of the window and stop blocking — recognizing that maintainers often leave Issues open for weeks without active triage. Engagement (merge or close) still clears the gate immediately. Set `0` to disable the guard entirely (useful for batch trials); set a higher value (e.g. `30`) for a stricter, slower cadence on busy repos.
 
 
 ## 2. What Outrider reads from your repo

--- a/src/run.py
+++ b/src/run.py
@@ -3231,25 +3231,37 @@ def issue_for_paper(open_issues: list[dict], rec: Recommendation) -> dict | None
     return None
 
 
-def open_remyx_artifact_exists(target: Target) -> bool:
-    """Return True if any **open** Remyx Recommendation PR or Issue exists
-    on the target repo.
+def _most_recent_open_artifact_age_days(target: Target) -> int | None:
+    """Return the age in days of the most recently opened Remyx PR/Issue,
+    or ``None`` if no open Remyx artifact exists on the target.
 
-    The cadence guard's job is to avoid stacking unresolved work on a
-    maintainer who hasn't engaged with the prior recommendation. Once
-    they merge or close it, the channel is clear and the next run can
-    proceed — engagement IS the signal. Per-paper dedup (a separate
-    gate) already prevents the same recommendation from re-surfacing,
-    so the cadence guard doesn't need its own time window.
+    Used by the cadence guard to time-decay throttling: only artifacts
+    opened *within* ``rate_limit_days`` block subsequent runs; older open
+    artifacts have aged out of the throttle window and don't fire the
+    gate. The caller does the threshold comparison so it can also surface
+    the age in run telemetry.
 
-    `target.rate_limit_days > 0` enables this gate; `<= 0` disables it.
-    The numeric value is otherwise ignored — preserved as an on/off bit
-    so existing `outrider.yml` workflows continue to work unchanged.
+    Age is days since ``created_at``, floored. When multiple open
+    artifacts exist, returns the *smallest* age (the most recently
+    opened) — that's the one the throttle cares about ("was something
+    just opened?"). Older co-existing artifacts don't matter for cadence;
+    the per-paper discharge filter handles same-paper retries
+    independently.
     """
-    if target.rate_limit_days <= 0:
-        return False
+    now = dt.datetime.now(dt.timezone.utc)
 
-    # PRs — identified by branch prefix. Only open PRs block.
+    def _age_days(created_iso: str) -> int | None:
+        try:
+            created = dt.datetime.fromisoformat(
+                (created_iso or "").replace("Z", "+00:00")
+            )
+        except (ValueError, TypeError):
+            return None
+        return max(0, int((now - created).total_seconds() // 86400))
+
+    ages: list[int] = []
+
+    # PRs — identified by branch prefix. Only open PRs are returned.
     prs = gh_api(
         "GET", f"/repos/{target.repo}/pulls?state=open&per_page=50"
     ) or []
@@ -3257,8 +3269,11 @@ def open_remyx_artifact_exists(target: Target) -> bool:
         ref = pr.get("head", {}).get("ref", "")
         if not ref.startswith(BRANCH_PREFIX):
             continue
-        log.info(f"  open Remyx PR exists: {pr['html_url']}")
-        return True
+        age = _age_days(pr.get("created_at", ""))
+        if age is None:
+            continue
+        log.info(f"  open Remyx PR exists ({age}d old): {pr['html_url']}")
+        ages.append(age)
 
     # Issues — identified by title prefix or body attribution marker.
     # GitHub's /issues endpoint also returns PRs (they carry a
@@ -3273,10 +3288,35 @@ def open_remyx_artifact_exists(target: Target) -> bool:
         body = it.get("body") or ""
         if not (title.startswith(PR_TITLE_PREFIX) or "Remyx Recommendation" in body):
             continue
-        log.info(f"  open Remyx Issue exists: {it['html_url']}")
-        return True
+        age = _age_days(it.get("created_at", ""))
+        if age is None:
+            continue
+        log.info(f"  open Remyx Issue exists ({age}d old): {it['html_url']}")
+        ages.append(age)
 
-    return False
+    return min(ages) if ages else None
+
+
+def open_remyx_artifact_exists(target: Target) -> bool:
+    """Cadence guard — return True iff a *recent* open Remyx artifact
+    blocks the run.
+
+    Time-decayed: an open Remyx PR/Issue blocks new runs only while it's
+    younger than ``rate_limit_days``. Older open artifacts have aged out
+    of the throttle window and no longer fire the gate — recognizing that
+    real maintainers often leave Issues open for weeks without active
+    triage, and the action should resume cadence rather than mute the
+    repo indefinitely. Engagement (merge or close) clears the gate
+    immediately. Per-paper dedup (a separate gate) handles same-paper
+    retries; this guard is purely about not stacking *recent* unresolved
+    work.
+
+    ``rate_limit_days = 0`` disables the guard entirely.
+    """
+    if target.rate_limit_days <= 0:
+        return False
+    age = _most_recent_open_artifact_age_days(target)
+    return age is not None and age < target.rate_limit_days
 
 
 # ─── Workdir + spec bundle ─────────────────────────────────────────────────
@@ -6373,14 +6413,24 @@ def process_target(target: Target) -> dict:
     result: dict = {"repo": target.repo, "status": "unknown"}
 
     # 1. Cadence guard — cheapest gate, before any candidate work or
-    #    checkout. Skip if any *open* Remyx artifact exists on the
-    #    target. Engagement (merge/close) IS the signal that the
-    #    channel is clear; the guard exists to avoid stacking
-    #    unresolved work, not to enforce a time window. Per-paper
-    #    dedup (further down) handles same-recommendation retries.
-    if open_remyx_artifact_exists(target):
-        result["status"] = "skipped_open_artifact"
-        return result
+    #    checkout. Time-decayed: skip only if the most recently opened
+    #    Remyx artifact on the target is *younger* than rate_limit_days.
+    #    Older open artifacts age out of the throttle window (real
+    #    maintainers leave Issues open for weeks; the action should
+    #    resume cadence rather than mute the repo indefinitely).
+    #    Engagement (merge/close) still clears the gate immediately.
+    #    Per-paper dedup (further down) handles same-recommendation retries.
+    if target.rate_limit_days > 0:
+        age = _most_recent_open_artifact_age_days(target)
+        if age is not None and age < target.rate_limit_days:
+            log.info(
+                f"  cadence guard: most recent open Remyx artifact is "
+                f"{age}d old (< rate_limit_days={target.rate_limit_days}); "
+                f"skipping. Older open artifacts no longer block."
+            )
+            result["status"] = "skipped_open_artifact"
+            result["most_recent_artifact_age_days"] = age
+            return result
 
     # 1b. Issues-disabled pre-flight — GitHub disables the Issues tab on
     #     forks (and some repos) by default; without it, every Issue-route

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,14 +1,23 @@
 """Tests for the cadence guard `open_remyx_artifact_exists`.
 
-The guard's new semantic (2026-06-15): skip a run iff an *open* Remyx
-PR or Issue from a prior run still exists on the target. Engagement
-(merge or close) releases the gate. The prior sliding-window
-("opened within N days") behavior is gone; the `rate_limit_days`
-field on Target is reinterpreted as an on/off bit (>0 enables, <=0
-disables) so existing workflow files continue to work.
+Semantic (2026-06-29, REMYX-152): time-decayed. Skip a run only if
+the most recently opened Remyx PR/Issue on the target is younger than
+``rate_limit_days``. Older open artifacts age out of the throttle
+window and stop blocking — recognizing that real maintainers leave
+Issues open for weeks without active triage, and Outrider should
+resume cadence rather than mute the repo indefinitely.
+
+History:
+- pre-2026-06-15: sliding-window "opened within N days" (numeric).
+- 2026-06-15: simplified to on/off (any open Remyx artifact blocks
+  indefinitely until engagement). Found too restrictive in practice.
+- 2026-06-29 (this revision): restored the sliding window, but now
+  computed against the *most recent* open artifact's age — same on/off
+  escape hatch (`rate_limit_days <= 0` disables).
 
 Run with: pytest tests/ -q
 """
+import datetime as dt
 import sys
 from pathlib import Path
 
@@ -18,14 +27,29 @@ import run  # noqa: E402
 from run import Target  # noqa: E402
 
 
-def _pr(ref: str, html_url: str = "https://github.com/r/x/pull/1") -> dict:
-    return {"head": {"ref": ref}, "html_url": html_url}
+def _iso_days_ago(days: int) -> str:
+    """ISO-8601 timestamp ``days`` ago, GitHub-style ``Z`` suffix."""
+    when = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days)
+    return when.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _pr(ref: str, html_url: str = "https://github.com/r/x/pull/1",
+        created_at: str | None = None) -> dict:
+    return {
+        "head": {"ref": ref},
+        "html_url": html_url,
+        "created_at": created_at or _iso_days_ago(0),
+    }
 
 
 def _issue(title: str = "", body: str = "",
            html_url: str = "https://github.com/r/x/issues/1",
-           is_pr: bool = False) -> dict:
-    out = {"title": title, "body": body, "html_url": html_url}
+           is_pr: bool = False,
+           created_at: str | None = None) -> dict:
+    out = {
+        "title": title, "body": body, "html_url": html_url,
+        "created_at": created_at or _iso_days_ago(0),
+    }
     if is_pr:
         out["pull_request"] = {"url": "..."}
     return out
@@ -41,31 +65,95 @@ def _target(rate_limit_days: int = 7) -> Target:
     )
 
 
-# ─── happy path: gate fires when an open Remyx artifact exists ─────────────
+# ─── happy path: a recent open Remyx artifact fires the gate ─────────────
 
 
-def test_open_remyx_pr_fires_the_gate(monkeypatch):
-    """A Remyx PR (`remyx-recommendation/*` branch) that's open blocks
-    the next run — that's the whole point of the guard."""
+def test_open_remyx_pr_fires_the_gate_when_recent(monkeypatch):
+    """A Remyx PR (`remyx-recommendation/*` branch) opened today blocks
+    the next run — within the throttle window."""
     def fake_gh_api(method, path, body=None):
         if "/pulls?" in path:
-            return [_pr(ref="remyx-recommendation/2606.06460v1")]
+            return [_pr(ref="remyx-recommendation/2606.06460v1",
+                        created_at=_iso_days_ago(0))]
         return []
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
     assert run.open_remyx_artifact_exists(_target()) is True
 
 
-def test_open_remyx_issue_fires_the_gate(monkeypatch):
-    """A Remyx Issue (identified by title prefix or body marker) that's
-    open blocks the next run."""
+def test_open_remyx_issue_fires_the_gate_when_recent(monkeypatch):
+    """A Remyx Issue (identified by title prefix or body marker) opened
+    today blocks the next run."""
     def fake_gh_api(method, path, body=None):
         if "/pulls?" in path:
             return []
         if "/issues?" in path:
-            return [_issue(title="[Remyx Recommendation] foo")]
+            return [_issue(title="[Remyx Recommendation] foo",
+                           created_at=_iso_days_ago(0))]
         return []
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
     assert run.open_remyx_artifact_exists(_target()) is True
+
+
+# ─── time-decay: stale open artifacts no longer block ──────────────────────
+
+
+def test_stale_open_pr_ages_out_of_the_throttle(monkeypatch):
+    """A Remyx PR opened 30 days ago no longer blocks runs under the
+    default 7-day window — the core REMYX-152 fix. Real maintainers
+    leave PRs open for weeks; the action should resume cadence rather
+    than mute the repo indefinitely."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return [_pr(ref="remyx-recommendation/2606.06460v1",
+                        created_at=_iso_days_ago(30))]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target(rate_limit_days=7)) is False
+
+
+def test_stale_open_issue_ages_out_of_the_throttle(monkeypatch):
+    """Same as above, for Issues."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return []
+        if "/issues?" in path:
+            return [_issue(title="[Remyx Recommendation] foo",
+                           created_at=_iso_days_ago(21))]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target(rate_limit_days=7)) is False
+
+
+def test_strict_window_still_blocks_a_recent_artifact(monkeypatch):
+    """A higher `rate_limit_days` value extends the throttle window —
+    `rate-limit-days: 30` still blocks on a 5-day-old open Issue."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return []
+        if "/issues?" in path:
+            return [_issue(title="[Remyx Recommendation] foo",
+                           created_at=_iso_days_ago(5))]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target(rate_limit_days=30)) is True
+
+
+def test_youngest_artifact_drives_the_gate(monkeypatch):
+    """When multiple open Remyx artifacts exist, the *most recent* one
+    drives the throttle decision — older co-existing artifacts don't
+    matter for cadence purposes. The per-paper discharge filter handles
+    same-paper retries independently."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return [
+                _pr(ref="remyx-recommendation/old",
+                    created_at=_iso_days_ago(30)),  # aged out
+                _pr(ref="remyx-recommendation/new",
+                    created_at=_iso_days_ago(2)),   # within window
+            ]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run.open_remyx_artifact_exists(_target(rate_limit_days=7)) is True
 
 
 # ─── engagement releases the gate ──────────────────────────────────────────
@@ -90,14 +178,14 @@ def test_only_merged_or_closed_prs_do_not_fire(monkeypatch):
         "gate must query only open PRs, not state=all"
 
 
-# ─── on/off bit ────────────────────────────────────────────────────────────
+# ─── on/off escape hatch ───────────────────────────────────────────────────
 
 
 def test_rate_limit_days_zero_disables_the_gate(monkeypatch):
     """`rate-limit-days: 0` in the workflow input disables the gate
-    entirely — the guard returns False even if a Remyx PR is open."""
+    entirely — the guard returns False even if a Remyx PR is open. No
+    API calls are made (cheap-circuit)."""
     def fake_gh_api(method, path, body=None):
-        # Should never be reached when the gate is disabled.
         raise AssertionError("gate must not call gh_api when disabled")
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
     assert run.open_remyx_artifact_exists(_target(rate_limit_days=0)) is False
@@ -146,3 +234,32 @@ def test_issues_endpoint_returns_prs_which_are_filtered(monkeypatch):
     monkeypatch.setattr(run, "gh_api", fake_gh_api)
     # The PR-like Issue is filtered; no Remyx artifact reported.
     assert run.open_remyx_artifact_exists(_target()) is False
+
+
+# ─── age helper ────────────────────────────────────────────────────────────
+
+
+def test_age_helper_returns_smallest_age(monkeypatch):
+    """`_most_recent_open_artifact_age_days` returns the smallest age
+    when multiple open Remyx artifacts exist — that's the artifact the
+    throttle cares about."""
+    def fake_gh_api(method, path, body=None):
+        if "/pulls?" in path:
+            return [
+                _pr(ref="remyx-recommendation/old",
+                    created_at=_iso_days_ago(30)),
+                _pr(ref="remyx-recommendation/new",
+                    created_at=_iso_days_ago(2)),
+            ]
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run._most_recent_open_artifact_age_days(_target()) == 2
+
+
+def test_age_helper_returns_none_when_no_artifacts(monkeypatch):
+    """When no open Remyx artifact exists, the helper returns None
+    (signal for the caller to not fire the gate at all)."""
+    def fake_gh_api(method, path, body=None):
+        return []
+    monkeypatch.setattr(run, "gh_api", fake_gh_api)
+    assert run._most_recent_open_artifact_age_days(_target()) is None


### PR DESCRIPTION
## Summary

The cadence guard was binary on/off: any open Remyx PR/Issue blocked every subsequent run indefinitely until merged or closed. Maintainers leave Issues open for weeks without active triage, which silently muted repos. Hit on `remyxai/outrider` itself — every scheduled run since Issue #64 opened produced 0 artifacts for $0 cost.

This PR restores the sliding-window semantic: skip only if the most recently opened Remyx artifact is younger than `rate_limit_days`. Older open artifacts age out of the throttle window and stop blocking. Engagement still clears the gate immediately. `rate_limit_days=0` still disables the guard entirely (existing batch-trial escape hatch unchanged).

`rate-limit-days`'s numeric value is once again meaningful — it's the throttle-window length in days. Default `7` means "don't pile on within a week"; a higher value yields a stricter, slower cadence.

## Implementation

- New `_most_recent_open_artifact_age_days(target) -> int | None` helper: returns the smallest age (in days, floored) of any open Remyx PR/Issue, or `None` when none exist
- `open_remyx_artifact_exists(target) -> bool` is now a thin wrapper that compares the age against `rate_limit_days`
- The age is surfaced in `result["most_recent_artifact_age_days"]` when the gate fires, so run telemetry shows why
- Docs in `customization.md` updated to describe the time-decay semantic

## Test plan

- [x] `pytest tests/` — 695 pass (13 in `test_rate_limit.py`, 6 new tests covering time-decay scenarios: stale-PR ages out, stale-Issue ages out, strict-window still blocks, youngest-artifact drives the gate, helper-returns-smallest-age, helper-returns-none-when-empty)
- [x] Existing fixtures updated to set `created_at` (default = today, preserving prior tests' "fires when recent" expectation)
- [ ] Smoke: trigger a run on `remyxai/outrider` after merge — Issue #64 (open for several days) should no longer block

## Backward compatibility

- `rate-limit-days: 0` → guard disabled (unchanged)
- `rate-limit-days: 7` (default) → throttle window = 7 days (was: throttle indefinitely on any open artifact)
- Workflows that explicitly set higher values now get *stricter* throttling, not the previous on/off bit. Doc updated accordingly.