### PR TITLE
pin-method bypasses the discharge filter (REMYX-153)

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -6614,6 +6614,14 @@ def process_target(target: Target) -> dict:
     # don't waste budget re-deriving it" regardless of who opened the
     # Issue.
     open_issues = _all_discharge_issues(target)
+    # Pin-method / pin-arxiv = user explicitly named the paper; their
+    # intent overrides the discharge throttle (which is otherwise a
+    # "don't keep re-recommending what Outrider already pitched" guard
+    # for the normal selection flow). Without this override, A/B-style
+    # re-runs, demo re-takes, and "improve the prior artifact" workflows
+    # would always skip with skipped_issue_exists. PR-collision check
+    # below stays active — that's a real safety property.
+    pin_override = bool(target.pin_method or target.pin_arxiv)
     viable: list[Recommendation] = []
     dropped_low_conf = 0
     dropped_pr_exists = 0
@@ -6626,10 +6634,11 @@ def process_target(target: Target) -> dict:
         if existing_pr_for(target, c_branch):
             dropped_pr_exists += 1
             continue
-        prior_issue = issue_for_paper(open_issues, c)
-        if prior_issue:
-            dropped_issue_exists += 1
-            continue
+        if not pin_override:
+            prior_issue = issue_for_paper(open_issues, c)
+            if prior_issue:
+                dropped_issue_exists += 1
+                continue
         viable.append(c)
 
     if not viable:

--- a/tests/test_pin_method.py
+++ b/tests/test_pin_method.py
@@ -141,3 +141,64 @@ def test_main_exits_when_both_pin_inputs_set(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         run.main()
     assert exc.value.code == 2
+
+
+# ─── pin-method bypasses the discharge filter ─────────────────────────────
+
+
+def test_pin_method_bypasses_discharge_filter(monkeypatch):
+    """When pin_method names a paper that already has a prior Outrider
+    Issue, the run still proceeds — user intent overrides the discharge
+    throttle. Without this, A/B re-runs on the same paper always skip.
+    """
+    monkeypatch.setenv("TARGET_REPO", "owner/name")
+    monkeypatch.setenv(
+        "INPUT_INTEREST_ID", "00000000-0000-0000-0000-000000000000"
+    )
+    monkeypatch.setenv("INPUT_PIN_METHOD", "2410.20305v2")
+
+    # Resolve the pin to a synthetic asset
+    asset = {
+        "arxiv_id": "2410.20305v2",
+        "title": "DPO Prefix Sharing",
+        "abstract": "...",
+    }
+    monkeypatch.setattr(run, "_resolve_pin_method", lambda q: asset)
+
+    # Prior open Issue for the same arxiv id — would normally discharge
+    prior = {
+        "title": "[Remyx Recommendation] DPO Prefix Sharing",
+        "body": "https://arxiv.org/abs/2410.20305",
+        "html_url": "https://github.com/owner/name/issues/1",
+        "number": 1,
+        "state": "open",
+    }
+    monkeypatch.setattr(run, "_all_discharge_issues", lambda t: [prior])
+
+    # Stub everything downstream of viable so the test only verifies
+    # the gate decision.
+    monkeypatch.setattr(run, "gh_api", lambda *a, **kw:
+                        {"has_issues": True} if "/repos/" in a[1] and "?" not in a[1]
+                        else [])
+    monkeypatch.setattr(run, "_candidate_enrichment", lambda v: [])
+    monkeypatch.setattr(run, "_pool_composition", lambda c: (0, 0))
+    monkeypatch.setattr(run, "open_remyx_artifact_exists", lambda t: False)
+    monkeypatch.setattr(run, "_license_class_counts", lambda c: {})
+
+    captured = {}
+
+    def fake_prepare_workdir(target):
+        # By the time we reach prepare_workdir, the discharge gate has
+        # already passed — that's what we're verifying.
+        captured["reached_workdir"] = True
+        raise RuntimeError("test stops here")
+
+    monkeypatch.setattr(run, "prepare_workdir", fake_prepare_workdir)
+
+    target = run.build_target_from_env()
+    # We expect process_target to reach prepare_workdir (proving the
+    # discharge gate passed) and then raise our sentinel — the
+    # alternative would be an early skip on skipped_issue_exists.
+    with pytest.raises(RuntimeError, match="test stops here"):
+        run.process_target(target)
+    assert captured.get("reached_workdir") is True


### PR DESCRIPTION
## Summary

When the user explicitly names a paper via `pin-method` (or `pin-arxiv`), their intent overrides the discharge throttle. The discharge filter is right for the normal selection flow ("don't keep re-recommending what Outrider has already pitched"), but wrong as a default for explicit pin-method use.

Three workflows that always skipped before:
- Re-implementing on the same paper after a low-quality first artifact
- A/B comparing model backends (pin same paper, dispatch Anthropic vs z.ai/GLM)
- Demo re-runs

Implementation: ~5 LOC change to gate the `issue_for_paper` check with `if not pin_override` (pin_method or pin_arxiv set). The PR-collision check stays active — that's a real safety property. Existing per-paper-discharge tests for the normal selection flow are unaffected.

## Test plan

- [x] `pytest tests/` — 709 pass (1 new in `test_pin_method.py`)
- [ ] Smoke: re-trigger pin-method on a fork with an existing Outrider Issue for the pinned paper; confirm it produces a new artifact instead of `skipped_issue_exists`