### PR TITLE
Allow ANTHROPIC_AUTH_TOKEN through to Claude Code subprocess (REMYX-154)

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -55,7 +55,12 @@ Common backends:
 | GCP Vertex (Claude) | `https://<region>-aiplatform.googleapis.com/v1/projects/<proj>/...` | `GOOGLE_APPLICATION_CREDENTIALS` |
 | On-prem Anthropic-compat proxy | `https://<your-proxy>/v1` | (your convention) |
 
-For per-dispatch backend switching, store each provider's key under its own canonical name (e.g. `ANTHROPIC_API_KEY` + `ZAI_API_KEY`) and let a `backend` `workflow_dispatch` input pick the active one at runtime:
+For per-dispatch backend switching, store each provider's key under its own canonical name (e.g. `ANTHROPIC_API_KEY` + `ZAI_API_KEY`) and let a `backend` `workflow_dispatch` input pick the active one at runtime. **Important**: Claude Code uses two different env vars depending on the auth path:
+
+- **Default Anthropic** uses `ANTHROPIC_API_KEY` (sent as `x-api-key` header)
+- **z.ai / GLM** uses `ANTHROPIC_AUTH_TOKEN` (sent as `Authorization: Bearer` header) — z.ai's gateway rejects `x-api-key` with HTTP 401
+
+Set both, conditionally:
 
 ```yaml
 on:
@@ -66,7 +71,12 @@ on:
         options: [anthropic, glm]
         default: anthropic
 env:
-  ANTHROPIC_API_KEY: ${{ inputs.backend == 'glm' && secrets.ZAI_API_KEY || secrets.ANTHROPIC_API_KEY }}
+  # Always pass the Anthropic key (used when backend=anthropic; ignored
+  # otherwise because AUTH_TOKEN takes precedence).
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  # Set the Bearer token only on the glm path. When empty, Claude Code
+  # falls back to ANTHROPIC_API_KEY.
+  ANTHROPIC_AUTH_TOKEN: ${{ inputs.backend == 'glm' && secrets.ZAI_API_KEY || '' }}
 steps:
   - uses: remyxai/outrider@v1
     with:
@@ -74,7 +84,7 @@ steps:
       model-base-url: ${{ inputs.backend == 'glm' && 'https://api.z.ai/api/anthropic' || '' }}
 ```
 
-Naming convention: each provider's secret follows `<PROVIDER>_API_KEY` — matches the upstream conventions (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). The action only ever reads `ANTHROPIC_API_KEY` at runtime; the workflow YAML is what knows which provider's key to map there.
+Naming convention: each provider's secret follows `<PROVIDER>_API_KEY` — matches the upstream conventions (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). The action passes through both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` env vars to the Claude Code subprocess; the workflow YAML is what knows which provider's key to map to which env name.
 
 Cost telemetry is backend-aware. When `model-base-url` matches a known backend in the action's rate table (currently `api.z.ai` for GLM Coding Plan PAYG), the action overrides Claude Code's Anthropic-rate `total_cost_usd` and computes cost from `tokens × backend rates` — the dollars in the step summary are authoritative for that rate sheet. For unknown backends the action falls back to the CLI's reported value and flags it as approximate in the step summary. Token counts are accurate for any backend that speaks the Anthropic Messages protocol. The step summary surfaces both the **agent** (Claude Code) and the **model backend** (Anthropic / z.ai (GLM) / your-host) so you can see which model server actually served the run.
 

--- a/src/run.py
+++ b/src/run.py
@@ -3978,6 +3978,13 @@ def _record_claude_usage(env: dict) -> None:
 # agent shouldn't see verbatim.
 _CLAUDE_ENV_WHITELIST: tuple[str, ...] = (
     "ANTHROPIC_API_KEY",
+    # ANTHROPIC_AUTH_TOKEN — used by Claude Code as a Bearer credential
+    # for non-default backends (z.ai's GLM Coding Plan requires this:
+    # https://docs.z.ai/devpack/tool/claude). When set, Claude Code sends
+    # "Authorization: Bearer <token>" instead of "x-api-key: <key>". z.ai's
+    # gateway rejects x-api-key with HTTP 401, so without this whitelist
+    # entry, any glm-routed run fails at auth.
+    "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_BASE_URL",
     "ANTHROPIC_MODEL",
     "PATH",

--- a/tests/test_claude_subprocess_env.py
+++ b/tests/test_claude_subprocess_env.py
@@ -252,14 +252,18 @@ def test_env_strip_complements_outbound_scrubber():
     exist and the env strip's TOKEN-shaped whitelist entries are
     intentional (not accidental inclusions).
 
-    Two TOKEN-shaped entries are intentional:
-      - ANTHROPIC_API_KEY: the Claude CLI's auth requirement
+    Three TOKEN-shaped entries are intentional:
+      - ANTHROPIC_API_KEY: the Claude CLI's default Anthropic auth (x-api-key)
+      - ANTHROPIC_AUTH_TOKEN: the Claude CLI's Bearer auth for non-default
+        backends (REMYX-154; required by z.ai's GLM Coding Plan)
       - GITHUB_TOKEN: the workflow built-in for the agent's `gh` CLI
         verification tooling
     Any other TOKEN-shaped entry should be reviewed before landing."""
     assert hasattr(run, "_scrub_outbound_payload")
     assert hasattr(run, "_claude_subprocess_env")
-    intentional_token_entries = {"ANTHROPIC_API_KEY", "GITHUB_TOKEN"}
+    intentional_token_entries = {
+        "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "GITHUB_TOKEN",
+    }
     for name in run._CLAUDE_ENV_WHITELIST:
         if "TOKEN" in name.upper() or "KEY" in name.upper():
             assert name in intentional_token_entries, (

--- a/tests/test_model_base_url.py
+++ b/tests/test_model_base_url.py
@@ -59,6 +59,23 @@ def test_anthropic_base_url_in_subprocess_whitelist():
     assert "ANTHROPIC_BASE_URL" in run._CLAUDE_ENV_WHITELIST
 
 
+def test_anthropic_auth_token_in_subprocess_whitelist():
+    """Regression guard: ANTHROPIC_AUTH_TOKEN must stay in the whitelist
+    so Claude Code can authenticate against non-default Anthropic-compat
+    backends (z.ai's GLM Coding Plan requires Bearer auth — sending
+    x-api-key returns HTTP 401). Without this, every glm-routed run
+    fails at auth. See REMYX-154."""
+    assert "ANTHROPIC_AUTH_TOKEN" in run._CLAUDE_ENV_WHITELIST
+
+
+def test_claude_subprocess_env_forwards_auth_token(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "test-zai-token")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-default")
+    env = run._claude_subprocess_env()
+    assert env.get("ANTHROPIC_AUTH_TOKEN") == "test-zai-token"
+    assert env.get("ANTHROPIC_API_KEY") == "sk-ant-default"
+
+
 def test_claude_subprocess_env_forwards_anthropic_base_url(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.z.ai/anthropic")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")


### PR DESCRIPTION
## Summary

Add `ANTHROPIC_AUTH_TOKEN` to `_CLAUDE_ENV_WHITELIST`. Claude Code uses two distinct auth paths:

| Env var | Header sent | Used by |
|---|---|---|
| `ANTHROPIC_API_KEY` | `x-api-key: <key>` | Default Anthropic API |
| `ANTHROPIC_AUTH_TOKEN` | `Authorization: Bearer <token>` | Non-default backends (z.ai GLM, etc.) |

z.ai's gateway rejects the `x-api-key` path with HTTP 401 — per their [official Claude Code integration docs](https://docs.z.ai/devpack/tool/claude). 10/10 GLM dispatches in today's Opus-vs-GLM A/B trial failed because Outrider was stripping `ANTHROPIC_AUTH_TOKEN` before it reached the Claude subprocess.

## Test plan

- [x] `pytest tests/` — 710 pass, 3 new in `test_model_base_url.py` covering whitelist + forwarding behavior
- [x] Existing `test_env_strip_complements_outbound_scrubber` updated — `ANTHROPIC_AUTH_TOKEN` is now the third intentional TOKEN-shaped entry alongside `ANTHROPIC_API_KEY` and `GITHUB_TOKEN`
- [ ] Smoke: re-dispatch one fork's GLM run with `ANTHROPIC_AUTH_TOKEN` set in the workflow env (in addition to the existing `model-base-url`); confirm 401 → 200