### PR TITLE
Self-review call inherits claude-timeout ceiling

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -5179,6 +5179,12 @@ def self_review_diff(
     Never raises and never blocks: a failure here just means the PR
     won't get the self-review section. The integration / stub-density
     checks are the load-bearing gates.
+
+    ``timeout_s`` defaults to 180 for direct callers (kept for backwards
+    compatibility with tests and ad-hoc invocations); the production call
+    site in ``process_target`` passes ``target.claude_timeout_s`` so a
+    customer who bumped ``claude-timeout`` (large monorepo / slower
+    backend) gets the same headroom on self-review as on implementation.
     """
     try:
         diff_proc = subprocess.run(
@@ -7468,7 +7474,11 @@ def process_target(target: Target) -> dict:
         # new code is an orphan (unreachable from any production path), it
         # routes to Issue. This is a REACHABILITY check, not a triviality
         # one — stub density (§3) already covers "the code is too thin".
-        review = self_review_diff(workdir)
+        # Shares the implementation call's ceiling (same rationale as
+        # preflight above): a customer who bumped claude-timeout for a
+        # large monorepo or a slower non-Anthropic backend should get the
+        # same headroom on review without learning about a separate knob.
+        review = self_review_diff(workdir, timeout_s=target.claude_timeout_s)
         result["self_review"] = review or {}
         if review and review.get("is_orphan") is True:
             log.warning(

--- a/tests/test_self_review_timeout.py
+++ b/tests/test_self_review_timeout.py
@@ -1,0 +1,88 @@
+"""Tests for the self-review-call timeout configurability.
+
+The implementation-call timeout (`claude-timeout`, default 900s) now
+also governs the self-review pass over the produced diff. Customers
+who bumped the timeout for a large monorepo or a slower non-default
+backend get the same headroom on review without needing to know about
+a separate knob — completing the per-stage consolidation started in
+v1.6.28-30 (preflight + audit + selection).
+
+These tests verify the timeout parameter is honored end-to-end through
+`self_review_diff` — that the underlying `_run_claude_oneshot` call
+receives whatever timeout the caller passed.
+
+Run with: pytest tests/test_self_review_timeout.py -q
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# ─── self_review_diff passes timeout through to _run_claude_oneshot ──
+
+
+def _fake_workdir(tmp_path, monkeypatch):
+    """Self-review reads `git diff HEAD` from the workdir. Stub the
+    subprocess call so the function reaches its agent call without
+    needing a real git repo."""
+    class _Proc:
+        stdout = "diff --git a/x b/x\n+++ b/x\n+new line\n"
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _Proc(),
+    )
+    return tmp_path
+
+
+def test_self_review_passes_default_timeout(monkeypatch, tmp_path):
+    """Direct callers (tests, ad-hoc) that don't pass a timeout get
+    the documented 180s default — kept for backwards compatibility."""
+    captured = {}
+
+    def fake_oneshot(workdir, prompt, timeout_s):
+        captured["timeout_s"] = timeout_s
+        return (False, "")  # forces None return; we just care about timeout
+
+    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+
+    run.self_review_diff(_fake_workdir(tmp_path, monkeypatch))
+    assert captured["timeout_s"] == 180
+
+
+def test_self_review_honors_custom_timeout(monkeypatch, tmp_path):
+    """When the caller passes a larger ceiling (mirroring what
+    process_target does with target.claude_timeout_s), it flows
+    through to the agent call unchanged."""
+    captured = {}
+
+    def fake_oneshot(workdir, prompt, timeout_s):
+        captured["timeout_s"] = timeout_s
+        return (False, "")
+
+    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+
+    run.self_review_diff(
+        _fake_workdir(tmp_path, monkeypatch), timeout_s=1500,
+    )
+    assert captured["timeout_s"] == 1500
+
+
+def test_self_review_short_timeout_for_tight_budgets(monkeypatch, tmp_path):
+    """A customer capping cost can pass a small timeout; the value
+    flows through verbatim (the CLI rejects sub-60s at the boundary,
+    but the action itself doesn't second-guess what it receives)."""
+    captured = {}
+
+    def fake_oneshot(workdir, prompt, timeout_s):
+        captured["timeout_s"] = timeout_s
+        return (False, "")
+
+    monkeypatch.setattr(run, "_run_claude_oneshot", fake_oneshot)
+
+    run.self_review_diff(
+        _fake_workdir(tmp_path, monkeypatch), timeout_s=90,
+    )
+    assert captured["timeout_s"] == 90


### PR DESCRIPTION
## Summary

- `self_review_diff` call site in `process_target` now passes `target.claude_timeout_s` so the `claude-timeout` workflow input governs the self-review pass alongside preflight, audit, selection, and implementation.
- Completes the per-stage timeout consolidation started in v1.6.28 (preflight) / v1.6.29 (audit) / v1.6.30 (selection). After this PR, `claude-timeout` is the single budget knob across every Claude-Code stage in the chain.
- Adds `tests/test_self_review_timeout.py` mirroring the v1.6.28 preflight-timeout test pattern (default 180s, custom large, custom small).

## Why this matters

Self-review is the stage that detects orphan code (new code not reachable from any production path) and downgrades a drafted PR back to Issue. When it hits its 180s ceiling on a heavy diff, the chain ships the PR **without** the safety-net check — so a PR that should have been demoted to Issue ships as a draft PR.

Surfaced while running a paired Outrider bench across providers: GLM-5.2's longer/noisier diffs were the canary case (per-stage logs showed self-review hit the ceiling on PR-route runs), but the bug affects any sufficiently large diff on any backend.

## Tests

- `pytest tests/test_self_review_timeout.py -q` — 3 new tests pass (default, custom large, custom small)
- `pytest tests/test_preflight_timeout.py -q` — regression check on the v1.6.28 sibling, 3/3 pass

## Suggested release

v1.6.31. One-line behavior change with backwards-compatible default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)