### PR TITLE
Add ENVIRONMENTS.md convention for workflow-provided tool hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Sett
 - **[Architecture](docs/architecture.md)** — selection taxonomy, pipeline, refinement chain
 - **[Guardrails](docs/guardrails.md)** — what the agent can and can't modify
 - **[Model backends](docs/backends.md)** — route at any Anthropic-Messages-compatible backend (z.ai's GLM, Bedrock, Vertex, on-prem); auth-header matrix; per-dispatch backend-switching workflow template
+- **[Environments](docs/environments.md)** — describe workflow-attached tooling (Claude Code skills, MCP servers, custom search) via `ENVIRONMENTS.md` so the agent knows to reach for it
 - **[Weekly summary mode](docs/weekly-summary.md)** — opt-in rolling digest comments
 
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,114 @@
+---
+type: Workflow Environment Convention
+title: ENVIRONMENTS.md — workflow-provided tool hints
+description: How to describe workflow-attached tooling (skills, MCP servers, custom search) so the Outrider agent knows to reach for it.
+resource: https://github.com/remyxai/outrider/blob/main/docs/environments.md
+tags: [outrider, environments, workflow, tool-hints, skills]
+timestamp: 2026-07-01T02:30:00Z
+---
+
+# ENVIRONMENTS.md — workflow-provided tool hints
+
+Attach a `ENVIRONMENTS.md` file at your workflow's workspace root (or repo root) to tell the Outrider agent about tooling you've installed for this run — Claude Code skills, MCP servers, custom code-search CLIs, private lint plugins, anything the agent would benefit from knowing exists.
+
+Outrider reads it, strips the OKF/YAML frontmatter, and injects the body into the agent's brief alongside SPEC.md / PAPER.md / GUARDRAILS.md. If no file is present, behavior is unchanged.
+
+## Motivation
+
+Outrider spawns Claude Code with a small set of default tools (Read, Grep, Glob, Bash, edit_file). Workflow authors often want to attach *more*:
+
+- An AST-based semantic code search (e.g. [`cocoindex-code`](https://github.com/cocoindex-io/cocoindex-code)) for large modules where whole-file reads are wasteful
+- MCP servers for private data sources (internal docs, org-specific search)
+- Custom lint / type / security scanners that produce agent-usable output
+- Any skill discoverable via `~/.claude/skills/`
+
+Discoverability alone is not enough — even a correctly-installed skill won't get used if the agent's brief doesn't mention it exists. `ENVIRONMENTS.md` is that mention.
+
+## File location
+
+Outrider looks in this order (first hit wins):
+
+1. `$GITHUB_WORKSPACE/ENVIRONMENTS.md`
+2. `$GITHUB_WORKSPACE/ENVIRONMENT.md` (singular, if you prefer the `CONTRIBUTING.md` naming)
+3. `<workdir>/ENVIRONMENTS.md`
+4. `<workdir>/ENVIRONMENT.md`
+
+Content over 4 KB is truncated with a marker; keep the description terse.
+
+## File shape
+
+`ENVIRONMENTS.md` follows the same [OKF frontmatter convention](https://github.com/openknowledge-network/openknowledge) as Outrider's other docs. The frontmatter is machine-readable metadata (dropped before the agent sees the body); the markdown body is what gets injected.
+
+```markdown
+---
+type: Workflow Environment
+title: <descriptive name of this workflow's environment>
+description: <one-line summary of tools/context this workflow provides>
+resource: <URL to the workflow file or docs>
+tags: [outrider, environment, <tool-specific>]
+timestamp: <ISO 8601 datetime>
+---
+
+# <Title>
+
+<Markdown body — described tools, expected usage patterns, invocation notes>
+```
+
+## Example — attaching AST-based semantic code search
+
+Workflow step (see [`cocoindex-code`](https://github.com/cocoindex-io/cocoindex-code) for install specifics):
+
+```yaml
+- name: Install cocoindex-code as Claude Code skill
+  run: |
+    git clone --depth 1 https://github.com/cocoindex-io/cocoindex-code /tmp/cocoindex-code
+    pipx install 'cocoindex-code[full]'
+    mkdir -p ~/.claude/skills/
+    ln -sfn /tmp/cocoindex-code ~/.claude/skills/cocoindex-code
+
+- name: Describe environment to Outrider
+  run: |
+    cat > ENVIRONMENTS.md <<'EOF'
+    ---
+    type: Workflow Environment
+    title: cocoindex-code AST search available
+    description: cocoindex-code AST-based semantic code search is pre-installed as a Claude Code skill.
+    resource: https://github.com/remyxai/outrider/blob/main/docs/environments.md
+    tags: [outrider, environment, cocoindex-code, ast-search]
+    timestamp: 2026-07-01T00:00:00Z
+    ---
+
+    # Environment: cocoindex-code AST search
+
+    ## Available tools
+
+    - **`ccc` CLI** (AST-based semantic code search across the cloned repo). Prefer over reading entire large files when locating functions, classes, or specific code patterns. Multi-language (tree-sitter based).
+
+    ## Suggested use during implementation
+
+    - For "find the function that does X" queries, invoke the semantic-search skill rather than Read/Grep on speculation.
+    - For files >500 LOC where you only need one function, prefer AST search + targeted Read over reading the whole file.
+    EOF
+```
+
+The agent's brief will now include a section describing the skill, so it knows to reach for `ccc` when the task calls for it.
+
+## What Outrider does with the file
+
+1. Reads it from the first location found in the search order
+2. Strips any YAML frontmatter (the agent doesn't need the metadata)
+3. Caps size at 4 KB with a truncation marker
+4. Writes the body to `.remyx-recommendation/ENVIRONMENT.md` in the bundle Claude Code reads
+5. Updates the agent's file-reading order to include it after ORIENTATION.md
+
+If the file is absent, missing frontmatter body, or empty, no bundle entry is written and the agent's brief is unchanged.
+
+## When not to use ENVIRONMENTS.md
+
+- **Auth secrets or connection strings** — those belong in Actions secrets, not a markdown file. The frontmatter and body are not confidential.
+- **Runtime configuration** the workflow already sets via environment variables — Outrider doesn't parse `ENVIRONMENTS.md` for structured config.
+- **Documentation that lives with your target repo's contributor guide** — use `ORIENTATION.md` (already auto-detected from `CONTRIBUTING.md` / repo docs), not `ENVIRONMENTS.md`.
+
+## Naming
+
+`ENVIRONMENTS.md` (plural) is the primary spelling, since a workflow may attach multiple tools' worth of environment. `ENVIRONMENT.md` (singular) is a supported fallback for consistency with `CONTRIBUTING.md` / `LICENSE.md` conventions. Both work; pick one.

--- a/src/run.py
+++ b/src/run.py
@@ -257,6 +257,31 @@ arxiv: https://arxiv.org/abs/{arxiv_id}
 {paper_abstract}
 """
 
+_ENVIRONMENT_MD_TEMPLATE = """\
+---
+type: workflow_environment
+description: Workflow-provided tooling available in this environment.
+---
+
+# Tooling available in this environment
+
+The following capabilities were attached to this run by the workflow
+author (via an ENVIRONMENTS.md or ENVIRONMENT.md at the workflow
+workspace or repo root). Prefer these over generic Read / Grep / Glob
+when the described tool fits the task better.
+
+{environment_body}
+"""
+
+
+_ENVIRONMENT_FILE_REF_TEMPLATE = """\
+  6. .remyx-recommendation/ENVIRONMENT.md  — workflow-provided tooling
+                                              hints (available tools +
+                                              suggested usage patterns
+                                              for this run's environment)
+"""
+
+
 _CONTEXT_MD_TEMPLATE = """\
 ---
 type: team_history
@@ -370,6 +395,7 @@ Read these files in order:
                                               + tests near the planned call
                                               site. Use these patterns
                                               without re-exploring them.
+{environment_file_ref}
 
 SPEC.md names a PROPOSED CALL SITE under "How this maps onto your repo"
 (the file + function the selection pass judged most implementable). Start
@@ -3734,6 +3760,57 @@ def _collect_repo_orientation(workdir: Path, target: Target, package: str) -> st
     return _ORIENTATION_MD_TEMPLATE.format(**blocks)
 
 
+def _load_environments_md(workdir: Path, max_bytes: int = 4096) -> str:
+    """Load a workflow-authored ENVIRONMENTS.md (or ENVIRONMENT.md), strip
+    OKF/YAML frontmatter, cap size. Returns the markdown body or "" if no
+    such file is present.
+
+    Search order (first hit wins):
+      1. $GITHUB_WORKSPACE/ENVIRONMENTS.md
+      2. $GITHUB_WORKSPACE/ENVIRONMENT.md
+      3. <workdir>/ENVIRONMENTS.md
+      4. <workdir>/ENVIRONMENT.md
+
+    The file is a workflow-authored surface: the workflow author writes it
+    to describe what tooling they attached to this run (skills, MCP
+    servers, custom search, private lint plugins, etc.). Outrider strips
+    the YAML frontmatter (the agent only needs the body) and caps size
+    to avoid a runaway prompt injection.
+    """
+    import re
+    candidates: list[Path] = []
+    ws = os.environ.get("GITHUB_WORKSPACE", "")
+    if ws:
+        candidates.append(Path(ws) / "ENVIRONMENTS.md")
+        candidates.append(Path(ws) / "ENVIRONMENT.md")
+    candidates.append(workdir / "ENVIRONMENTS.md")
+    candidates.append(workdir / "ENVIRONMENT.md")
+
+    for p in candidates:
+        try:
+            if not p.is_file():
+                continue
+            raw = p.read_text(errors="replace")
+        except OSError:
+            continue
+        m = re.match(r"^---\r?\n.*?\r?\n---\r?\n(.*)$", raw, flags=re.DOTALL)
+        body = (m.group(1) if m else raw).strip()
+        if not body:
+            continue
+        encoded = body.encode("utf-8")
+        truncated = False
+        if len(encoded) > max_bytes:
+            body = encoded[:max_bytes].decode("utf-8", errors="ignore").rstrip()
+            body += "\n\n... (truncated at {} bytes)".format(max_bytes)
+            truncated = True
+        log.info(
+            "  ✓ workflow environment loaded: %s (%d bytes%s)",
+            p, len(body.encode("utf-8")), " truncated" if truncated else "",
+        )
+        return body
+    return ""
+
+
 def write_spec_bundle(
     workdir: Path, target: Target, rec: Recommendation, package: str,
     selection_note: str = "",
@@ -3798,10 +3875,25 @@ def write_spec_bundle(
         blocked="\n".join(ALWAYS_BLOCKED),
     ))
 
+    # ENVIRONMENT.md — workflow-authored tooling hints picked up from
+    # $GITHUB_WORKSPACE (or workdir) if the workflow author left an
+    # ENVIRONMENTS.md / ENVIRONMENT.md file describing skills, MCP
+    # servers, or other agent-usable tooling attached to this run.
+    # Only written when non-empty; the invocation's file list refs it
+    # only when it's present.
+    environment_body = _load_environments_md(workdir)
+    environment_file_ref = ""
+    if environment_body:
+        (bundle / "ENVIRONMENT.md").write_text(_ENVIRONMENT_MD_TEMPLATE.format(
+            environment_body=environment_body,
+        ))
+        environment_file_ref = _ENVIRONMENT_FILE_REF_TEMPLATE
+
     (bundle / "INVOCATION.md").write_text(_INVOCATION_MD_TEMPLATE.format(
         package=package,
         attribution_url=CANONICAL_ATTRIBUTION_URL,
         issue_fallback_filename=ISSUE_FALLBACK_FILENAME,
+        environment_file_ref=environment_file_ref,
     ))
 
     # ORIENTATION.md — target repo's contributor guides, PR template, recent

--- a/tests/test_environments_md.py
+++ b/tests/test_environments_md.py
@@ -1,0 +1,114 @@
+"""Tests for the workflow-authored ENVIRONMENTS.md convention.
+
+The workflow author can leave an ENVIRONMENTS.md (or ENVIRONMENT.md) file
+at the workflow workspace root (`$GITHUB_WORKSPACE`) or the target
+workdir. Outrider reads it, strips OKF/YAML frontmatter, caps size, and
+writes the body into the recommendation bundle as ENVIRONMENT.md so the
+agent sees workflow-attached tooling as first-class context alongside
+SPEC/PAPER/CONTEXT/GUARDRAILS.
+
+Run with: pytest tests/test_environments_md.py -q
+"""
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# ─── _load_environments_md: file lookup, frontmatter stripping, size cap ──
+
+
+def test_returns_empty_when_no_file(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    assert run._load_environments_md(tmp_path) == ""
+
+
+def test_reads_environments_md_from_workdir(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    (tmp_path / "ENVIRONMENTS.md").write_text(
+        "# my env\n\nccc is available for AST search."
+    )
+    body = run._load_environments_md(tmp_path)
+    assert "# my env" in body
+    assert "ccc is available" in body
+
+
+def test_strips_okf_yaml_frontmatter(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    (tmp_path / "ENVIRONMENTS.md").write_text(textwrap.dedent("""\
+        ---
+        type: Workflow Environment
+        title: cocoindex available
+        description: cocoindex-code AST search installed
+        resource: https://example.com/workflow.yml
+        tags: [outrider, cocoindex]
+        timestamp: 2026-07-01T02:00:00Z
+        ---
+
+        # Tooling
+
+        AST search via `ccc`. Prefer over Read for large modules.
+        """))
+    body = run._load_environments_md(tmp_path)
+    # Frontmatter (metadata the agent doesn't need) is stripped
+    assert "type: Workflow Environment" not in body
+    assert "timestamp:" not in body
+    # Markdown body is preserved
+    assert "# Tooling" in body
+    assert "AST search via `ccc`" in body
+
+
+def test_no_frontmatter_body_still_returned(tmp_path, monkeypatch):
+    """Files without frontmatter are returned as-is; the convention is
+    encouraged but not required."""
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    (tmp_path / "ENVIRONMENTS.md").write_text("plain content, no frontmatter\n")
+    assert run._load_environments_md(tmp_path) == "plain content, no frontmatter"
+
+
+def test_size_cap_truncates_over_max(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    big = "x" * 8000
+    (tmp_path / "ENVIRONMENTS.md").write_text(big)
+    body = run._load_environments_md(tmp_path, max_bytes=1024)
+    assert len(body.encode("utf-8")) <= 1024 + len("\n\n... (truncated at 1024 bytes)")
+    assert "truncated" in body
+
+
+def test_singular_environment_md_also_works(tmp_path, monkeypatch):
+    """ENVIRONMENT.md (singular) is a fallback for the same convention;
+    matches CONTRIBUTING.md / LICENSE.md naming."""
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    (tmp_path / "ENVIRONMENT.md").write_text("singular works too")
+    assert run._load_environments_md(tmp_path) == "singular works too"
+
+
+def test_workspace_takes_precedence_over_workdir(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "ENVIRONMENTS.md").write_text("from workspace")
+    (tmp_path / "ENVIRONMENTS.md").write_text("from workdir")
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+    body = run._load_environments_md(tmp_path)
+    assert body == "from workspace"
+
+
+def test_plural_takes_precedence_over_singular(tmp_path, monkeypatch):
+    """When both are present, ENVIRONMENTS.md (the primary spelling)
+    wins over ENVIRONMENT.md."""
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    (tmp_path / "ENVIRONMENTS.md").write_text("plural")
+    (tmp_path / "ENVIRONMENT.md").write_text("singular")
+    assert run._load_environments_md(tmp_path) == "plural"
+
+
+def test_empty_body_after_frontmatter_returns_empty(tmp_path, monkeypatch):
+    """A file that's all frontmatter and no body doesn't produce a bundle
+    entry — treat it as if the workflow didn't provide any environment
+    hints."""
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    (tmp_path / "ENVIRONMENTS.md").write_text("---\ntype: x\n---\n\n\n")
+    assert run._load_environments_md(tmp_path) == ""


### PR DESCRIPTION
## Summary

- Adds a workflow-authored `ENVIRONMENTS.md` (or `ENVIRONMENT.md`) convention: workflows can describe agent-usable tooling they've attached to a run (skills, MCP servers, custom search) and Outrider injects the body into the agent's brief.
- Loader (`_load_environments_md`) searches `$GITHUB_WORKSPACE` first, then workdir, strips OKF/YAML frontmatter, caps at 4 KB.
- New bundle entry `.remyx-recommendation/ENVIRONMENT.md` written only when non-empty; matching entry in the invocation's file-reading order appears only when the file is written.
- Backwards-compatible: when no file is provided, behavior is unchanged.

## Why

Discoverability alone is not enough. A Claude Code skill correctly symlinked into `~/.claude/skills/` still won't be used if the agent's brief doesn't mention it exists. `ENVIRONMENTS.md` is the workflow-author's seam for adding that mention — without a code change to Outrider per new tool.

## Tests

- `pytest tests/test_environments_md.py -q` — 9 new tests (default no-file, workdir/workspace lookup, frontmatter strip, singular fallback, size-cap, precedence, empty-body edge cases)
- Regression: `test_preflight_timeout.py` + `test_self_review_timeout.py` — 6/6 pass

## Docs

New `docs/environments.md` describes the convention and includes a worked example attaching `cocoindex-code` AST-based semantic code search. README's Documentation section links to it.

## Suggested release

v1.6.32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)