### PR TITLE
Integration validator: bump existing-file cap when spillover-to-new-module

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -93,6 +93,8 @@ Workflow step (see [`cocoindex-code`](https://github.com/cocoindex-io/cocoindex-
 
 The agent's brief will now include a section describing the skill, so it knows to reach for `ccc` when the task calls for it.
 
+See [`examples/workflows/with-cocoindex.yml`](../examples/workflows/with-cocoindex.yml) for the full copy-pasteable workflow.
+
 ## What Outrider does with the file
 
 1. Reads it from the first location found in the search order

--- a/examples/workflows/with-cocoindex.yml
+++ b/examples/workflows/with-cocoindex.yml
@@ -1,0 +1,75 @@
+name: Outrider (with cocoindex-code AST search)
+
+# Copy-pasteable workflow that installs cocoindex-code as a Claude Code
+# skill and describes its availability via ENVIRONMENTS.md so the Outrider
+# agent knows to reach for it during selection and implementation.
+#
+# See docs/environments.md for the full ENVIRONMENTS.md convention.
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'  # Mondays 14:00 UTC; pick any cadence
+  workflow_dispatch:
+    inputs:
+      pin-method:
+        description: 'Optional arxiv_id or method query to implement directly.'
+        required: false
+        default: ''
+      claude-timeout:
+        description: 'Wall-clock seconds for Claude Code (preflight + implementation).'
+        required: false
+        default: '900'
+
+jobs:
+  recommend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    env:
+      REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cocoindex-code as a Claude Code skill
+        run: |
+          git clone --depth 1 https://github.com/cocoindex-io/cocoindex-code /tmp/cocoindex-code
+          pipx install 'cocoindex-code[full]'
+          mkdir -p ~/.claude/skills/
+          ln -sfn /tmp/cocoindex-code ~/.claude/skills/cocoindex-code
+
+      - name: Describe environment to Outrider (ENVIRONMENTS.md)
+        run: |
+          cat > "$GITHUB_WORKSPACE/ENVIRONMENTS.md" <<'EOF'
+          ---
+          type: Workflow Environment
+          title: cocoindex-code AST search available
+          description: cocoindex-code AST-based semantic code search is pre-installed as a Claude Code skill.
+          resource: https://github.com/cocoindex-io/cocoindex-code
+          tags: [outrider, environment, cocoindex-code, ast-search]
+          timestamp: 2026-07-01T00:00:00Z
+          ---
+
+          # Environment: cocoindex-code AST search
+
+          ## Available tools
+
+          - **`ccc` CLI** (AST-based semantic code search across the cloned repo).
+            Prefer over reading entire large files when locating functions,
+            classes, or specific code patterns. Multi-language via tree-sitter.
+
+          ## Suggested use during implementation
+
+          - For "find the function that does X" queries, invoke the semantic-search
+            skill rather than Read/Grep on speculation.
+          - For files > 500 LOC where you only need one function, prefer AST search
+            + targeted Read over reading the whole file.
+          EOF
+
+      - uses: remyxai/outrider@v1
+        with:
+          interest-id: 'YOUR-INTEREST-UUID-HERE'
+          pin-method: ${{ inputs.pin-method }}
+          claude-timeout: ${{ inputs.claude-timeout }}

--- a/src/run.py
+++ b/src/run.py
@@ -135,6 +135,19 @@ DEFAULT_ALLOWLIST_GLOBS = [
 # module under the cover of "integration".
 MAX_LINES_PER_EXISTING_FILE = 50
 
+# Higher cap that applies to purely-additive edits (deleted == 0) when the
+# run also creates a substantial new module. The shape being unblocked is
+# "small wrapper edit at the existing API surface + bulk implementation in
+# a new module" — the surgical pattern we want to encourage. The `deleted
+# == 0` gate ensures rewrites of existing modules still hit the tighter
+# cap (that's the case the original threshold exists to catch).
+MAX_LINES_PER_EXISTING_FILE_WITH_SPILLOVER = 100
+
+# Minimum size of the concurrent new-module spillover that unlocks the
+# higher cap. Trivial new files (a two-line stub next to a 90-line edit to
+# an existing file) don't count as real spillover.
+MIN_SPILLOVER_LINES = 100
+
 # Cap on number of newly-created .py files in the target package. A
 # real integration adds one module, sometimes two; anything beyond
 # that is scaffold-shaped.
@@ -5722,6 +5735,21 @@ def check_integration(
         if p.startswith(pkg_prefix) and p.endswith(".py") and _file_is_new(workdir, p)
     ]
 
+    # Total lines added across new package modules. A concurrent new module
+    # of meaningful size signals that any edit to an existing file is likely
+    # a wrapper/registration (imports + declaration + docstring), not the
+    # actual logic. In that case we raise the existing-file limit to
+    # unblock the "small wrapper + spillover to a new module" pattern.
+    # (New files are untracked here — git diff --numstat sees nothing for
+    # them, so read directly.)
+    def _new_file_lines(p: str) -> int:
+        try:
+            return sum(1 for _ in (workdir / p).open("r", encoding="utf-8", errors="ignore"))
+        except OSError:
+            return 0
+    new_pkg_lines = sum(_new_file_lines(p) for p in new_pkg_files)
+    has_spillover = new_pkg_lines >= MIN_SPILLOVER_LINES
+
     violations: list[str] = []
 
     if len(new_pkg_files) > MAX_NEW_PACKAGE_FILES:
@@ -5734,10 +5762,18 @@ def check_integration(
         if _file_is_new(workdir, p):
             continue
         added, deleted = _diff_line_changes(workdir, p)
-        if added + deleted > MAX_LINES_PER_EXISTING_FILE:
+        # Purely-additive edit alongside a substantial new module = the
+        # surgical wrapper pattern. Higher cap. In-place edits (deleted > 0)
+        # always stay at the tighter cap — those are the rewrites this
+        # threshold exists to catch.
+        if deleted == 0 and has_spillover:
+            limit = MAX_LINES_PER_EXISTING_FILE_WITH_SPILLOVER
+        else:
+            limit = MAX_LINES_PER_EXISTING_FILE
+        if added + deleted > limit:
             violations.append(
                 f"oversized edit to existing file {p}: +{added}/-{deleted} "
-                f"> {MAX_LINES_PER_EXISTING_FILE}"
+                f"> {limit}"
             )
 
     # Invocation check. Every newly-added callable, keyed by the file that

--- a/tests/test_integration_gates.py
+++ b/tests/test_integration_gates.py
@@ -169,6 +169,89 @@ def test_pure_edit_with_no_new_callable_is_not_gated():
     assert ok
 
 
+# ── 2b. surgical wrapper + spillover to a new module ──────────────────────
+#
+# The "small wrapper edit at an existing file + bulk implementation in a
+# new module" pattern is the surgical shape we want to encourage. Without
+# the spillover-aware limit, an additive wrapper edit that exceeds 50
+# lines would flip a legitimately good diff to Issue. But rewrites of
+# existing files (deleted > 0) should still trip the tighter cap — that's
+# the case the threshold exists for.
+
+
+def _oversize_wrapper_edit(bp: Path, n_lines: int) -> None:
+    """Append n_lines of purely-additive wrapper code to an existing file."""
+    body = "".join(
+        f"    def wrapper_fn_{i}(self, x):\n        return x\n"
+        for i in range(n_lines // 2)
+    )
+    bp.write_text(bp.read_text() + body)
+
+
+def test_additive_wrapper_with_spillover_passes_higher_cap():
+    """+55/-0 to an existing file + a substantial new module = allowed."""
+    wd = _base_repo()
+    bp = wd / "vqasynth" / "benchmarks.py"
+    # 55 additive lines — over the 50-line base cap.
+    bp.write_text(
+        bp.read_text()
+        + "    def calibrated_score(self, x):\n        from vqasynth.newcap import compute\n"
+        + "        return compute(x)\n"
+        + "".join(f"    # padding line {i}\n" for i in range(52))
+    )
+    # Substantial new module (>MIN_SPILLOVER_LINES = 100) — the actual logic.
+    (wd / "vqasynth" / "newcap.py").write_text(
+        "def compute(x):\n    return x\n"
+        + "".join(f"# implementation detail {i}\n" for i in range(120))
+    )
+    (wd / "tests" / "test_new.py").write_text(
+        "from vqasynth.benchmarks import BenchmarkRunner\n"
+        "def test_c():\n    BenchmarkRunner().calibrated_score(1)\n"
+    )
+    ok, violations = run.check_integration(wd, TGT, "vqasynth")
+    assert ok, f"expected pass, got violations: {violations}"
+
+
+def test_inplace_oversized_edit_still_blocked_even_with_spillover():
+    """An in-place rewrite (deleted > 0) gets the tight cap even with spillover."""
+    wd = _base_repo()
+    bp = wd / "vqasynth" / "benchmarks.py"
+    # Replace the existing "return x" body with a longer implementation.
+    # git diff will report deleted > 0 because "return x" line is gone.
+    bp.write_text(
+        "class BenchmarkRunner:\n"
+        "    def score(self, x):\n"
+        + "".join(f"        line_{i} = {i}\n" for i in range(55))
+        + "        return sum([line_0, line_1, line_2])\n"
+    )
+    # Add a large new module too — but spillover only helps additive edits.
+    (wd / "vqasynth" / "newcap.py").write_text(
+        "def compute(x):\n    return x\n"
+        + "".join(f"# line {i}\n" for i in range(120))
+    )
+    (wd / "tests" / "test_x.py").write_text(
+        "from vqasynth.newcap import compute\ndef test_c():\n    compute(1)\n"
+    )
+    ok, violations = run.check_integration(wd, TGT, "vqasynth")
+    # An in-place rewrite ignores the spillover bonus.
+    assert not ok
+    assert any("oversized edit to existing file" in v for v in violations)
+
+
+def test_additive_edit_without_spillover_still_capped():
+    """+55/-0 with no substantial new module = still gets the tight cap."""
+    wd = _base_repo()
+    bp = wd / "vqasynth" / "benchmarks.py"
+    bp.write_text(
+        bp.read_text()
+        + "    def added(self, x):\n        return x\n"
+        + "".join(f"    # padding {i}\n" for i in range(55))
+    )
+    ok, violations = run.check_integration(wd, TGT, "vqasynth")
+    assert not ok
+    assert any("oversized edit to existing file" in v for v in violations)
+
+
 # ── 3. changed_files sees files in brand-new directories ───────────────────
 
 def test_changed_files_expands_new_directory():


### PR DESCRIPTION
The +50-line cap on edits-to-existing-files blocks the surgical wrapper pattern — a small additive edit at the existing API surface + bulk implementation in a new module — which is the shape the refinement family is trying to encourage.

## Change

- When the run adds a substantial new package module (>=100 lines) **and** the edit to the existing file is purely additive (`deleted == 0`), raise the cap to 100 lines.
- In-place edits (`deleted > 0`) always keep the tighter 50-line cap — that's the rewrite case the threshold exists for.

## Also included

- `examples/workflows/with-cocoindex.yml` — copy-pasteable workflow that pairs the ENVIRONMENTS.md convention (shipped in v1.6.32) with cocoindex-code as a Claude Code skill.

## Tests

`tests/test_integration_gates.py` adds:
- Additive wrapper + spillover to a new module — passes (was blocked)
- In-place rewrite + spillover — still blocked (deleted > 0 keeps the tight cap)
- Additive edit without spillover — still capped at 50

Full suite: 767 passed.

## Motivating case

atropos + RiVER cocoindex re-run produced +55/-0 to `atroposlib/utils/advantages.py` + a ~150-line new module + tests — a clean surgical shape — and got downgraded to Issue by the flat 50-line cap. With this change, that diff would ship as a PR.

Fixes remyxai/remyx#449 (REMYX-167).