### PR TITLE
Fallback selection: use license_compat as tiebreaker when relevance ties

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -4972,6 +4972,24 @@ def _apply_coverage_gate(
     return data
 
 
+def _fallback_candidate(viable: list[Recommendation]) -> Recommendation:
+    """Pick the fallback candidate when agentic selection is unavailable.
+
+    Called when the selection call 429s, times out, or returns unparseable
+    output. The broad pool from `/papers/recommended` isn't guaranteed to
+    be in descending-relevance order at index 0 — the engine occasionally
+    seeds the list with diversity picks — so `viable[0]` blindly on
+    fallback can land the *lowest*-relevance candidate.
+
+    Highest relevance wins; ties broken by `license_compat`. A permissive
+    candidate with a code link (compat=1.00) should beat a no-code-link
+    candidate (compat=0.30) when both are equally relevant. Without the
+    tiebreaker the winner is order-of-arrival luck (max() returns the
+    first element at the max value).
+    """
+    return max(viable, key=lambda c: (c.relevance_score, c.license_compat))
+
+
 def select_recommendation(
     workdir: Path, package: str, candidates: list[Recommendation],
     target: "Target | None" = None,
@@ -7272,14 +7290,7 @@ def process_target(target: Target) -> dict:
                     log.info(f"  ✓ issue_opened_substitution ({shape}): {issue_url}")
                     return result
             else:
-                # The broad pool from `/papers/recommended` isn't guaranteed
-                # to be in descending-relevance order at index 0 — the
-                # engine occasionally seeds the list with diversity picks.
-                # Selecting `viable[0]` blindly on fallback can land the
-                # *lowest*-relevance candidate in the pool. Pick the actual
-                # highest-relevance candidate so a fallback at least gives
-                # the maintainer the engine's strongest signal.
-                rec = max(viable, key=lambda c: c.relevance_score)
+                rec = _fallback_candidate(viable)
                 result["selection_reasoning"] = (
                     "(selection pass unavailable — used highest-relevance "
                     "candidate as fallback)"

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -166,6 +166,66 @@ def test_select_unparseable_output_falls_back(tmp_path, monkeypatch):
     assert run.select_recommendation(tmp_path, "pkg", [geo, count]) is None
 
 
+# ─── _fallback_candidate: license_compat as tiebreaker (REMYX-169) ────────
+
+
+def _cand(title: str, relevance: float, license_compat: float) -> "run.Recommendation":
+    """Minimal Recommendation for fallback-tiebreaker tests."""
+    rec = run._paper_to_recommendation(
+        {"title": title, "resource_id": f"9999.{hash(title) & 0xFFFF:04x}v1",
+         "relevance_score": relevance},
+        fallback_interest_name="fb", interest_context="", experiment_history="",
+    )
+    rec.license_compat = license_compat
+    return rec
+
+
+def test_fallback_picks_highest_relevance():
+    """Baseline behavior: highest-relevance candidate wins regardless of
+    list order."""
+    low = _cand("Low", 0.60, license_compat=1.00)
+    high = _cand("High", 0.95, license_compat=0.30)
+    # `high` last in list — old `viable[0]` bug would pick `low`. max() picks
+    # `high` by relevance.
+    assert run._fallback_candidate([low, high]) is high
+
+
+def test_fallback_breaks_relevance_ties_by_license_compat():
+    """When two candidates share the top relevance, prefer the one with
+    higher license_compat (permissive+code-link > no-code-link)."""
+    no_code = _cand("No code link", 0.99, license_compat=0.30)
+    permissive = _cand("Apache-2.0 with gh source", 0.99, license_compat=1.00)
+    # Order the no-code-link candidate FIRST — old max() would pick it by
+    # order-of-arrival luck. With the fix, permissive wins on tiebreaker.
+    assert run._fallback_candidate([no_code, permissive]) is permissive
+    # And symmetric — order shouldn't matter.
+    assert run._fallback_candidate([permissive, no_code]) is permissive
+
+
+def test_fallback_tiebreak_does_not_override_relevance():
+    """A slightly higher relevance beats a lower relevance even if the
+    lower has better license_compat — license_compat is TIEBREAK only."""
+    lower_relevance_permissive = _cand("perm", 0.98, license_compat=1.00)
+    higher_relevance_no_code = _cand("no code", 0.99, license_compat=0.30)
+    assert (
+        run._fallback_candidate(
+            [lower_relevance_permissive, higher_relevance_no_code]
+        )
+        is higher_relevance_no_code
+    )
+
+
+def test_fallback_all_equal_falls_back_to_list_order():
+    """When both relevance and license_compat tie, list order is fine —
+    the candidates are genuinely equivalent by the ranking we care about."""
+    a = _cand("a", 0.99, license_compat=1.00)
+    b = _cand("b", 0.99, license_compat=1.00)
+    # Whichever appears first wins — that's max()'s documented behavior on
+    # ties, and we're OK with it once the license tiebreak is settled.
+    assert run._fallback_candidate([a, b]) is a
+    assert run._fallback_candidate([b, a]) is b
+
+
 def test_select_unparseable_initial_then_clean_retry(tmp_path, monkeypatch):
     """The model finishes reasoning out loud on the first attempt; the
     format-only retry then emits the JSON. Should succeed (preserving


### PR DESCRIPTION
When the agentic selection call fails (429, timeout, unparseable output), Outrider falls back to picking the highest-relevance candidate. Ties on relevance were previously broken by list position — `max(viable, key=lambda c: c.relevance_score)` returns the first element at the max value.

## Fires in the wild

2026-06-30 GLM C-arm study batch, unsloth run 28492317315: selection call 429'd, fallback picked "Compositional Skill Routing for LLM Agents" (relevance 0.99, `license=(none)`, `compat=0.30`) over a permissive alternative at the same relevance. Winner was determined by candidate-pool order, not by license compatibility.

## Change

- Extract fallback into `_fallback_candidate(viable)` so it's directly testable
- Add `license_compat` as secondary sort key: `max(viable, key=lambda c: (c.relevance_score, c.license_compat))`
- Highest relevance still wins; ties break toward higher license compatibility (permissive+code-link over no-code-link)

## Tests

`tests/test_selection.py` adds 4 tests:
- Highest-relevance candidate wins regardless of list order (baseline)
- Relevance-tied → higher license_compat wins (both orderings)
- Tiebreaker doesn't override a real relevance difference
- All-equal → list order (documented `max()` behavior)

Full suite: 771 passed.

## Non-goals

- Not changing the primary agentic-selection path
- Not adding further tiebreakers (tier is correlated with relevance)
- Not calibrating `license_compat` values

Fixes REMYX-169.