### PR TITLE
Measurement-based guards + selection-time grounding

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -7225,11 +7225,14 @@ def process_target(target: Target) -> dict:
                 result["selection_rejected"] = _enrich_selection_rejected(
                     selection.get("rejected") or [], viable
                 )
-                # Substitution routing — replacement / simplification
-                # recommendations need dep changes the PR guardrails block
-                # (requirements.txt, factory wiring, often test fixtures).
-                # Open as an Issue with the contract analysis instead of a
-                # half-built PR.
+                # REMYX-172 experiment: the categorical substitution guard
+                # (`shape in ("replacement", "simplification") → auto-Issue`)
+                # used to fire here. Removed on this branch so replacement /
+                # simplification runs proceed to implementation; the
+                # downstream check_integration validator catches diffs that
+                # actually touch dep files or otherwise violate PR guardrails,
+                # using MEASURED dep-file churn instead of the selection's
+                # shape label as the input.
                 shape = (selection.get("integration_shape") or "addition").lower().strip()
                 result["selection_integration_shape"] = shape
                 result["selection_contract_match"] = (
@@ -7238,57 +7241,6 @@ def process_target(target: Target) -> dict:
                 result["selection_migration_cost"] = (
                     selection.get("migration_cost", "")
                 )
-                if shape in ("replacement", "simplification"):
-                    contract_match = selection.get("contract_match", "")
-                    migration_cost = selection.get("migration_cost", "")
-                    shape_label = (
-                        "drop-in replacement"
-                        if shape == "replacement"
-                        else "pipeline simplification"
-                    )
-                    # Engineering axis as its own section, adjacent to the
-                    # license section.
-                    engineering_section = _render_engineering_section(
-                        integration_shape=shape_label,
-                        contract_match=contract_match or "(none reported)",
-                        migration_cost=migration_cost or "(none reported)",
-                    )
-                    detail = (
-                        f"_Selection reasoning_: {selection.get('reasoning', '')}\n\n"
-                        f"This swap touches dependency files and existing module "
-                        f"boundaries — changes that fall outside Outrider's "
-                        f"auto-PR guardrails. Opening as an Issue so the team "
-                        f"can decide whether to merge the upgrade."
-                    )
-                    _record_verdict_fields(result, rec)
-                    issue_url, issue_number = _open_downgrade_issue(
-                        target, rec,
-                        reason=f"Selection identified a {shape_label} candidate",
-                        detail=detail,
-                        engineering_section=engineering_section,
-                        selection_note=selection.get("reasoning", ""),
-                        selection_rejected=result.get("selection_rejected"),
-                        footer_override=(
-                            f"_Opened by the [Remyx Recommendation]"
-                            f"({CANONICAL_ATTRIBUTION_URL}) orchestrator. "
-                            f"Selection identified a {shape_label} that "
-                            f"touches dependency files / module boundaries "
-                            f"outside the PR guardrails — routed to Issue "
-                            f"so the team can decide on the swap._"
-                        ),
-                    )
-                    result.update({
-                        "paper": rec.paper_title,
-                        "arxiv": rec.arxiv_id,
-                        "tier": rec.tier,
-                        "recommendation_id": rec.recommendation_id or None,
-                        "candidates_considered": len(viable),
-                        "status": "issue_opened_substitution",
-                        "issue_url": issue_url,
-                        "issue_number": issue_number,
-                    })
-                    log.info(f"  ✓ issue_opened_substitution ({shape}): {issue_url}")
-                    return result
             else:
                 rec = _fallback_candidate(viable)
                 result["selection_reasoning"] = (

--- a/src/run.py
+++ b/src/run.py
@@ -3835,6 +3835,88 @@ def _load_environments_md(workdir: Path, max_bytes: int = 4096) -> str:
     return ""
 
 
+# ─── selection reasoning path verification ──────────────────────────────────
+#
+# The selection agent sometimes cites paths in its reasoning that don't
+# exist in the target repo — e.g. grepping `unsloth/` on a fork that only
+# has `studio/`, then concluding "no such code exists." That's a
+# confidently-wrong reasoning failure mode that's hard to catch after the
+# fact from log inspection. Extracting cited paths from the reasoning and
+# checking each against the workdir gives an operator a concrete "0/2
+# cited paths verified" signal in the step summary before trusting the
+# verdict.
+
+_PATH_TOKEN_RE = re.compile(r"[a-zA-Z_][\w./\-]*[\w/]")
+
+_PATH_TOKEN_URL_SUBSTRINGS = (
+    "http://", "https://", "github.com/", "arxiv.org/", "huggingface.co/",
+)
+
+
+def _extract_referenced_paths(text: str) -> list[str]:
+    """Extract candidate filesystem paths mentioned in reasoning prose.
+
+    Matches tokens containing at least one slash and starting with a
+    letter/underscore — the shape of a Python source file (``foo/bar.py``)
+    or a directory reference (``foo/bar/``). Filters out:
+      - single-slash tokens without a `.py` suffix or trailing slash
+        (github-repo shapes like ``org/repo``)
+      - URLs and paper-index references (``github.com/...``,
+        ``arxiv.org/...``, ``huggingface.co/...``)
+
+    Best-effort: may miss references embedded in prose without slashes,
+    may include false positives that the workdir verification then flags
+    as ``not_found``. That's fine — this is a diagnostic signal, not a
+    gate.
+    """
+    if not text:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for match in _PATH_TOKEN_RE.finditer(text):
+        path = match.group(0)
+        if "/" not in path:
+            continue
+        lower = path.lower()
+        if any(host in lower for host in _PATH_TOKEN_URL_SUBSTRINGS):
+            continue
+        # Skip github-repo shape: exactly one slash, no `.py` suffix, no
+        # trailing slash — that's `org/repo`, not a repo-internal path.
+        if path.count("/") == 1 and not path.endswith(".py") and not path.endswith("/"):
+            continue
+        if path in seen:
+            continue
+        seen.add(path)
+        out.append(path)
+    return out
+
+
+def _verify_paths_in_workdir(workdir: Path, paths: list[str]) -> dict:
+    """Split cited paths into ``verified`` (exist in workdir) and
+    ``not_found``. Returns a dict with the two lists and the raw ``cited``
+    input for provenance.
+    """
+    verified: list[str] = []
+    not_found: list[str] = []
+    for path in paths:
+        candidate = workdir / path.rstrip("/")
+        if candidate.exists():
+            verified.append(path)
+        else:
+            not_found.append(path)
+    return {"cited": list(paths), "verified": verified, "not_found": not_found}
+
+
+def _check_selection_paths(workdir: Path, reasoning: str) -> dict:
+    """Extract path claims from a selection-reasoning string and verify
+    each against the workdir. Convenience wrapper around
+    ``_extract_referenced_paths`` + ``_verify_paths_in_workdir``.
+    """
+    return _verify_paths_in_workdir(
+        workdir, _extract_referenced_paths(reasoning)
+    )
+
+
 def write_spec_bundle(
     workdir: Path, target: Target, rec: Recommendation, package: str,
     selection_note: str = "",
@@ -7109,6 +7191,17 @@ def process_target(target: Target) -> dict:
                 result["selection_rejected"] = _enrich_selection_rejected(
                     selection.get("rejected") or [], viable
                 )
+                # Confabulation check: if the reasoning cites paths not
+                # present in the workdir, an operator scanning the step
+                # summary should see the mismatch prominently before
+                # trusting a "rejected all candidates" verdict.
+                path_check = _check_selection_paths(workdir, result["selection_reasoning"])
+                result["selection_reasoning_paths"] = path_check
+                if path_check["cited"] and not path_check["verified"]:
+                    log.warning(
+                        "  ⚠ selection reasoning cites %d path(s) — 0 verified in workdir; possible confabulation",
+                        len(path_check["cited"]),
+                    )
                 if selection.get("under_explored"):
                     log.info("  ✗ skipped (coverage gate: under-explored)")
                 else:
@@ -7308,6 +7401,19 @@ def process_target(target: Target) -> dict:
         })
         _record_verdict_fields(result, rec)
         log.info(f"  ✓ selected: [{rec.tier}] {rec.paper_title}")
+
+        # Confabulation check on selection reasoning (see comment in the
+        # skipped-by-verification branch). Runs while workdir is still
+        # available; step-summary renderer picks it up.
+        selection_reasoning_str = result.get("selection_reasoning") or ""
+        if selection_reasoning_str and not selection_reasoning_str.startswith("("):
+            path_check = _check_selection_paths(workdir, selection_reasoning_str)
+            result["selection_reasoning_paths"] = path_check
+            if path_check["cited"] and not path_check["verified"]:
+                log.warning(
+                    "  ⚠ selection reasoning cites %d path(s) — 0 verified in workdir; possible confabulation",
+                    len(path_check["cited"]),
+                )
 
         # 5. Spec bundle for the chosen candidate. Thread the selection
         # rationale through so pre-flight and the implementer evaluate the
@@ -12113,6 +12219,26 @@ def _write_step_summary(result: dict) -> None:
         )
         lines.append(f"\n{selection_reasoning}\n")
         lines.append("\n</details>\n")
+
+    # Confabulation signal: if selection reasoning cited paths, show which
+    # ones the workdir actually contains. A "0 of N verified" line is a
+    # concrete flag that the reasoning may be hallucinated — an operator
+    # sees it in the step-summary panel before trusting the verdict.
+    path_check = result.get("selection_reasoning_paths") or {}
+    cited = path_check.get("cited") or []
+    if cited:
+        verified = path_check.get("verified") or []
+        not_found = path_check.get("not_found") or []
+        icon = "✓" if verified and not not_found else ("⚠️" if not verified else "•")
+        lines.append(
+            f"**Paths cited in selection reasoning**: {icon} {len(verified)} of "
+            f"{len(cited)} verified in the workdir\n"
+        )
+        if verified:
+            lines.append("- verified: " + ", ".join(f"`{p}`" for p in verified))
+        if not_found:
+            lines.append("- ⚠️ not found: " + ", ".join(f"`{p}`" for p in not_found))
+        lines.append("")
 
     if reasoning:
         # Collapse long reasoning into a <details> so the cost line

--- a/src/run.py
+++ b/src/run.py
@@ -5530,6 +5530,7 @@ def _render_self_review_section(review: dict) -> str:
     scoped_out = review.get("scoped_out") or review.get("stubbed") or []
     call_site = review.get("call_site") or "(unspecified)"
     summary = (review.get("honest_summary") or "").strip()
+    is_orphan = review.get("is_orphan") is True
 
     def _bullets(items: list) -> str:
         if not items:
@@ -5547,6 +5548,16 @@ def _render_self_review_section(review: dict) -> str:
         "**Intentionally out of scope** (not needed for this contribution):",
         _bullets(scoped_out),
     ]
+    if is_orphan:
+        parts += [
+            "",
+            "> ⚠ **Self-review flagged this as orphan-shaped.** The coding "
+            "agent concluded that no pre-existing entry point invokes the "
+            "new code (at most its own tests). If this is a library API "
+            "addition meant to be imported by external callers, that's by "
+            "design; if this is application code, the wiring may be "
+            "incomplete — review before merging.",
+        ]
     if summary:
         parts += ["", f"_{summary}_"]
     parts.append("")
@@ -7614,46 +7625,20 @@ def process_target(target: Target) -> dict:
         review = self_review_diff(workdir, timeout_s=target.claude_timeout_s)
         result["self_review"] = review or {}
         if review and review.get("is_orphan") is True:
+            # Surface the classification but don't veto the PR here — the
+            # measurement-based gates upstream (path allowlist,
+            # check_integration invocation check, tests-touch-existing-
+            # modules) already caught orphan scaffolding on real diff
+            # evidence; if the run got this far, those passed. The
+            # self-review verdict rides along in the PR body so the
+            # maintainer sees the orphan framing prominently and can
+            # close a scaffold-shaped PR fast, without the pipeline
+            # single-handedly downgrading a legitimate library API
+            # addition on a boolean flag.
             log.warning(
-                "  ✗ self-review: new code is unreachable from any "
-                "production path (orphan); downgrading to Issue"
+                "  ⚠ self-review flagged is_orphan=True — surfaced in the "
+                "PR body; upstream measurement-based gates already passed"
             )
-            summary = review.get("honest_summary") or ""
-            # Promote the self-review summary out of italics into a
-            # proper sub-heading — it's the most informative part of
-            # the body and worth a glance, not a footnote.
-            detail_body = (
-                "On a second pass over the diff, the coding agent "
-                "concluded that no pre-existing entry point or module "
-                "invokes the new code — at most its own tests call it. "
-                "That's an orphan: the product never exercises it. "
-                "(This is about reachability, not whether the code is "
-                "trivial — stub density is judged separately.)\n"
-            )
-            if summary:
-                detail_body += (
-                    f"\n### Self-review summary\n\n{summary}\n"
-                )
-            issue_url, issue_number = _open_downgrade_issue(
-                target, rec,
-                reason="Self-review judged the new code an orphan (no production call path)",
-                detail=detail_body,
-                implementation_diff=_capture_implementation_diff(workdir),
-                tldr=summary[:240] if summary else "",
-                selection_note=result.get("selection_reasoning", ""),
-                selection_rejected=result.get("selection_rejected"),
-                footer_override=(
-                    f"_Opened by the [Remyx Recommendation]"
-                    f"({CANONICAL_ATTRIBUTION_URL}) orchestrator. "
-                    f"Self-review caught that the new code is wired into "
-                    f"a flag no production caller sets — routed to Issue "
-                    f"so the team can decide whether to enable it._"
-                ),
-            )
-            result["status"] = "issue_opened_self_review"
-            result["issue_url"] = issue_url
-            result["issue_number"] = issue_number
-            return result
         review_section = _render_self_review_section(review) if review else ""
 
         # 10. Draft determination. "unvalidated" (tests couldn't run in CI,

--- a/src/run.py
+++ b/src/run.py
@@ -1068,10 +1068,21 @@ Markdown fences, no prose before or after. Schema:
                      deliberate boundaries, not as what you 'failed' to do.>"
 }
 
-Be ruthless about reachability. If the only thing that calls your new code
-is a test you added (or nothing at all), set is_orphan=true — the product
-never exercises it. If a pre-existing entry point (a pipeline/stage driver,
-a CLI, an existing module) now invokes your new code, set is_orphan=false.
+Be ruthless about reachability, but distinguish LIBRARY-shape API additions
+from APPLICATION-shape orphan scaffolding. In a library — one that ships a
+Python package for external users to import — a new public class/function
+exported from a package `__init__.py` IS the API surface; external callers,
+not internal library code, are the consumers. That is NOT orphan (set
+is_orphan=false and note the library-API framing in honest_summary). In an
+application repo (a CLI / service / pipeline), an addition that no pre-
+existing entry point invokes is a real orphan (is_orphan=true).
+
+Use the available tools to verify repo shape before deciding — signals of
+library-shape include `pyproject.toml` with `[project]` + `packages`,
+`setup.py` with `packages=`, or a `src/<pkg>/` layout; signals of application-
+shape include a top-level `cli.py` / `main.py` / `server.py` without a
+package declaration. When in doubt, quote the specific file evidence in
+honest_summary so a reviewer can audit the reasoning.
 Separately, list under scoped_out the parts of the paper you deliberately
 left for later (e.g. a trainer/model the repo can't host) — you are not
 required to reproduce the paper's full method, only to deliver its result.

--- a/src/run.py
+++ b/src/run.py
@@ -713,7 +713,7 @@ iteratively. For your most promising candidate(s):
     extends (`gh issue list --repo <repo> --state open --search "..."`
     or `gh issue view <n> --repo <repo>` for specific Issues).
 
-**Four legitimate integration shapes — classify each candidate you
+__ENVIRONMENT_HINT__**Four legitimate integration shapes — classify each candidate you
 consider.** A candidate that does NOT fit one of these four shapes is
 a structural mismatch and should be rejected.
 
@@ -3827,6 +3827,7 @@ def _load_environments_md(workdir: Path, max_bytes: int = 4096) -> str:
 def write_spec_bundle(
     workdir: Path, target: Target, rec: Recommendation, package: str,
     selection_note: str = "",
+    env_body: str | None = None,
 ) -> None:
     """Write the .remyx-recommendation/ bundle that Claude Code reads as its brief.
 
@@ -3894,7 +3895,10 @@ def write_spec_bundle(
     # servers, or other agent-usable tooling attached to this run.
     # Only written when non-empty; the invocation's file list refs it
     # only when it's present.
-    environment_body = _load_environments_md(workdir)
+    # Accept a pre-loaded env_body when the caller has already loaded it —
+    # the selection pass injects the same body upstream, so avoid a second
+    # load. None means "not pre-loaded, load now."
+    environment_body = env_body if env_body is not None else _load_environments_md(workdir)
     environment_file_ref = ""
     if environment_body:
         (bundle / "ENVIRONMENT.md").write_text(_ENVIRONMENT_MD_TEMPLATE.format(
@@ -4990,11 +4994,31 @@ def _fallback_candidate(viable: list[Recommendation]) -> Recommendation:
     return max(viable, key=lambda c: (c.relevance_score, c.license_compat))
 
 
+def _render_environment_hint(env_body: str) -> str:
+    """Render the workflow-attached tooling hint block for the selection prompt.
+
+    Injecting ENVIRONMENTS.md at selection time means the selection agent
+    can leverage workflow-authored tools (AST search skills, MCP servers,
+    custom search) while VERIFYING candidates — the load-bearing grounding
+    stage. Empty env_body yields empty string so behavior is unchanged for
+    runs without an ENVIRONMENTS.md.
+    """
+    if not env_body.strip():
+        return ""
+    return (
+        "**Workflow-attached tooling available for verification** "
+        "(from ENVIRONMENTS.md; prefer these over generic search when the "
+        "described tool fits the task):\n\n"
+        f"{env_body}\n\n"
+    )
+
+
 def select_recommendation(
     workdir: Path, package: str, candidates: list[Recommendation],
     target: "Target | None" = None,
     timeout_s: int | None = None,
     discharged_issues: list[dict] | None = None,
+    env_body: str = "",
 ) -> dict | None:
     """Claude pass that picks the most implementable candidate from the
     lookback pool, given the target repo's module layout.
@@ -5030,6 +5054,7 @@ def select_recommendation(
             _render_candidate_brief(candidates, discharged=discharged_index),
         )
         .replace("__LAYOUT__", layout)
+        .replace("__ENVIRONMENT_HINT__", _render_environment_hint(env_body))
     )
     # Bound the agentic flow — selection is verification, not a full
     # implementation session. 25 turns covers a few `gh code-search` +
@@ -6992,6 +7017,11 @@ def process_target(target: Target) -> dict:
     try:
         package = detect_package_name(workdir)
         default_branch = detect_default_branch(workdir)
+        # Load ENVIRONMENTS.md once, early, so the selection pass sees
+        # workflow-attached tooling before it verifies candidates. Thread
+        # the body through to both selection and write_spec_bundle to
+        # avoid a second load.
+        env_body = _load_environments_md(workdir)
         log.info(f"  detected package: {package}  default branch: {default_branch}")
 
         pinned_idx = None
@@ -7022,6 +7052,7 @@ def process_target(target: Target) -> dict:
             selection = select_recommendation(
                 workdir, package, viable, target=target,
                 discharged_issues=open_issues,
+                env_body=env_body,
             )
             # Attach exploration-coverage telemetry once, before the branch
             # handling — every downstream path returns this same `result`, so
@@ -7225,14 +7256,13 @@ def process_target(target: Target) -> dict:
                 result["selection_rejected"] = _enrich_selection_rejected(
                     selection.get("rejected") or [], viable
                 )
-                # REMYX-172 experiment: the categorical substitution guard
-                # (`shape in ("replacement", "simplification") → auto-Issue`)
-                # used to fire here. Removed on this branch so replacement /
-                # simplification runs proceed to implementation; the
-                # downstream check_integration validator catches diffs that
-                # actually touch dep files or otherwise violate PR guardrails,
-                # using MEASURED dep-file churn instead of the selection's
-                # shape label as the input.
+                # The former substitution guard fired here on
+                # `shape in ("replacement", "simplification")` and short-
+                # circuited to Issue. Removed: the workflow's path allowlist
+                # (`DEFAULT_ALLOWLIST_GLOBS`) already blocks dep files, and
+                # `check_integration()` measures oversized existing-file
+                # edits and orphan additions on the actual diff — replacing
+                # the shape label with measured evidence.
                 shape = (selection.get("integration_shape") or "addition").lower().strip()
                 result["selection_integration_shape"] = shape
                 result["selection_contract_match"] = (
@@ -7264,6 +7294,7 @@ def process_target(target: Target) -> dict:
         write_spec_bundle(
             workdir, target, rec, package,
             selection_note=result.get("selection_reasoning", ""),
+            env_body=env_body,
         )
 
         # 5.5. Pre-flight Issue routing (§6). Cheap Claude pass that

--- a/tests/test_integration_gates.py
+++ b/tests/test_integration_gates.py
@@ -306,9 +306,29 @@ def test_self_review_renders_value_first():
     assert "Delivers (from the paper)" in md
     assert "Intentionally out of scope" in md
     assert "Stubbed" not in md and "left out" not in md
+    # Orphan flag should not appear when is_orphan is absent or false.
+    assert "orphan-shaped" not in md
     # Legacy keys still render via the fallback.
     md2 = run._render_self_review_section({"implemented": ["x"], "stubbed": ["y"]})
     assert "- x" in md2 and "- y" in md2
+
+
+def test_self_review_surfaces_orphan_flag_when_set():
+    """When is_orphan is true the PR body carries a prominent warning so
+    the maintainer sees the verdict without the pipeline downgrading the
+    PR to an Issue on a boolean flag."""
+    md = run._render_self_review_section({
+        "delivered": ["EncoderHallucinationDetector metric"],
+        "scoped_out": ["training and eval sweep"],
+        "call_site": "opik.evaluation.metrics",
+        "is_orphan": True,
+        "honest_summary": "Library API addition — external callers only.",
+    })
+    assert "orphan-shaped" in md
+    assert "review before merging" in md
+    # Still shows the value-first sections above the warning.
+    assert "What this PR delivers" in md
+    assert "EncoderHallucinationDetector" in md
 
 
 def test_detect_default_branch():

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -80,6 +80,63 @@ def test_select_single_candidate_short_circuits(tmp_path):
     assert run.select_recommendation(tmp_path, "pkg", [geo]) is None
 
 
+# ─── _render_environment_hint: selection-time ENVIRONMENTS.md injection ──
+
+
+def test_environment_hint_empty_when_no_env_body():
+    """Runs without an ENVIRONMENTS.md attached — hint block is empty so
+    the selection prompt is unchanged."""
+    assert run._render_environment_hint("") == ""
+    assert run._render_environment_hint("   \n\n  ") == ""
+
+
+def test_environment_hint_wraps_env_body_when_present():
+    """When ENVIRONMENTS.md is attached, the hint block introduces the
+    workflow-attached tooling and includes the body."""
+    body = "AST search via `ccc` is pre-installed. Prefer over Read on files >500 LOC."
+    hint = run._render_environment_hint(body)
+    assert "Workflow-attached tooling" in hint
+    assert "ENVIRONMENTS.md" in hint
+    assert "AST search via `ccc`" in hint
+
+
+def test_select_prompt_substitutes_environment_hint(tmp_path, monkeypatch):
+    """The selection prompt gets the env body substituted at the
+    __ENVIRONMENT_HINT__ placeholder, so the selection agent sees
+    workflow-attached tooling before it verifies candidates."""
+    geo, count = _make_candidates()
+    captured_prompt = {}
+
+    def _fake_stream(wd, prompt, t, **kw):
+        captured_prompt["text"] = prompt
+        return (True, '{"chosen_index": 0, "reasoning": "x", "rejected": []}', [])
+
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", _fake_stream)
+    run.select_recommendation(
+        tmp_path, "pkg", [geo, count],
+        env_body="AST search via `ccc` is pre-installed.",
+    )
+    assert "__ENVIRONMENT_HINT__" not in captured_prompt["text"], "placeholder not substituted"
+    assert "AST search via `ccc`" in captured_prompt["text"]
+    assert "Workflow-attached tooling" in captured_prompt["text"]
+
+
+def test_select_prompt_without_env_body_has_no_hint_block(tmp_path, monkeypatch):
+    """Backwards-compat: runs with no env_body render the prompt without
+    the hint section, no dangling placeholder."""
+    geo, count = _make_candidates()
+    captured_prompt = {}
+
+    def _fake_stream(wd, prompt, t, **kw):
+        captured_prompt["text"] = prompt
+        return (True, '{"chosen_index": 0, "reasoning": "x", "rejected": []}', [])
+
+    monkeypatch.setattr(run, "_run_claude_oneshot_streaming", _fake_stream)
+    run.select_recommendation(tmp_path, "pkg", [geo, count])
+    assert "__ENVIRONMENT_HINT__" not in captured_prompt["text"]
+    assert "Workflow-attached tooling" not in captured_prompt["text"]
+
+
 def test_select_parses_chosen_index(tmp_path, monkeypatch):
     geo, count = _make_candidates()
     # The selection pass runs in streaming mode so it can parse the tool

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -121,6 +121,76 @@ def test_select_prompt_substitutes_environment_hint(tmp_path, monkeypatch):
     assert "Workflow-attached tooling" in captured_prompt["text"]
 
 
+# ─── path verification of selection reasoning (confabulation check) ───────
+
+
+def test_extract_referenced_paths_basic():
+    """Paths ending in .py or trailing slash are extracted; single-slash
+    org/repo shapes and URLs are filtered out."""
+    text = (
+        "grep of unsloth/ + unsloth_cli/ for retrieval/MCP/agent = no hits. "
+        "The reference impl at github.com/pilancilab/Riemannian_Preconditioned_LoRA "
+        "and the module at routes/inference.py:_truncate_middle_messages both matter. "
+        "The org/repo shape shouldn't match."
+    )
+    paths = run._extract_referenced_paths(text)
+    assert "unsloth/" in paths
+    assert "unsloth_cli/" in paths
+    assert "routes/inference.py" in paths
+    assert "retrieval/MCP/agent" in paths  # 2+ slashes → looks path-shaped
+    # github.com URL should be filtered
+    assert not any("github.com" in p for p in paths)
+    # single-slash org/repo shape filtered
+    assert "org/repo" not in paths
+
+
+def test_extract_referenced_paths_empty():
+    assert run._extract_referenced_paths("") == []
+    assert run._extract_referenced_paths(None) == []
+
+
+def test_verify_paths_in_workdir_splits_verified_and_not_found(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "foo.py").write_text("")
+    (tmp_path / "existing_dir").mkdir()
+    result = run._verify_paths_in_workdir(
+        tmp_path, ["src/foo.py", "existing_dir/", "made_up/", "nowhere/bar.py"]
+    )
+    assert "src/foo.py" in result["verified"]
+    assert "existing_dir/" in result["verified"]
+    assert "made_up/" in result["not_found"]
+    assert "nowhere/bar.py" in result["not_found"]
+    assert len(result["cited"]) == 4
+
+
+def test_check_selection_paths_catches_confabulation(tmp_path):
+    """The exact reasoning shape that caused today's unsloth-retry misfire:
+    grepped nonexistent directories, concluded 'no such code exists'.
+    Path check flags 0 of 2 verified — an operator can spot this."""
+    # Workdir simulates smellslikeml/unsloth's actual shape (studio/, no unsloth/)
+    (tmp_path / "studio").mkdir()
+    (tmp_path / "studio" / "backend").mkdir()
+    reasoning = "grep of unsloth/ + unsloth_cli/ for X = no hits"
+    check = run._check_selection_paths(tmp_path, reasoning)
+    assert check["cited"] == ["unsloth/", "unsloth_cli/"]
+    assert check["verified"] == []
+    assert set(check["not_found"]) == {"unsloth/", "unsloth_cli/"}
+
+
+def test_check_selection_paths_verifies_real_paths(tmp_path):
+    """The opik-SAFARI shape: reasoning cites a real path, verification
+    finds it — an operator sees the reasoning is grounded."""
+    (tmp_path / "sdks").mkdir()
+    (tmp_path / "sdks" / "python").mkdir()
+    (tmp_path / "sdks" / "python" / "opik").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "suite_evaluators").mkdir()
+    (tmp_path / "suite_evaluators" / "agentic").mkdir()
+    reasoning = "Opik's suite_evaluators/agentic/ evaluator IS SAFARI's architecture"
+    check = run._check_selection_paths(tmp_path, reasoning)
+    assert "suite_evaluators/agentic/" in check["verified"]
+    assert not check["not_found"]
+
+
 def test_select_prompt_without_env_body_has_no_hint_block(tmp_path, monkeypatch):
     """Backwards-compat: runs with no env_body render the prompt without
     the hint section, no dangling placeholder."""


### PR DESCRIPTION
Replaces categorical guards on shape-labels with measurement-based decisions and gives selection access to workflow-attached tooling.

## What changes

- **Substitution guard removed.** The `shape in ("replacement", "simplification") → auto-Issue` short-circuit before implementation ran categorically on the selection's label. Now `replacement`/`simplification` runs proceed to implementation; the path allowlist + `check_integration()` catch broken diffs on measured evidence. The external-pick substitution path (out-of-pool candidates) is unchanged.
- **ENVIRONMENTS.md injected into selection.** The loader previously fired only inside `write_spec_bundle` (post-selection). Now it runs early and threads the body through `select_recommendation`'s prompt so the selection agent has workflow-attached tooling (AST-search skills, MCP servers) while verifying candidates. Empty ENVIRONMENTS.md = unchanged behavior.
- **Self-review prompt distinguishes library vs application shape.** Instructs the agent to check `pyproject.toml`/`setup.py`/`src/<pkg>/` signals and classify accordingly — library API adds get `is_orphan=false` when new callables are exported via `__init__.py`.
- **Self-review orphan surfaced, not vetoed.** When `is_orphan=true`, the PR still ships; the classification is rendered as a prominent warning in the body. Upstream measurement-based gates (path allowlist, `check_integration` invocation check, tests-touch-existing-modules) already catch scaffold-shaped diffs on real evidence.
- **Confabulation check on selection reasoning.** Extracts path-like tokens from `selection_reasoning`, verifies each against the workdir, renders `N of M verified` in the step-summary panel. A `0 of N verified` line makes confidently-wrong "I grepped X and found nothing" reasoning (where X doesn't exist) catchable at glance.

## Motivating cases from 2026-07-01

- unsloth C-arm run: `shape=replacement → auto-Issue` on TokenPilot despite selection identifying a clean drop-in call site. Guard-removal path.
- opik LettuceDetect: `issue_opened_self_review` on a legitimate library API addition (`BaseMetric` subclass). Surface-not-veto path.
- unsloth-retry misfire: selection grepped nonexistent `unsloth/` + `unsloth_cli/`, confidently rejected 20 candidates. Confabulation-check path.
- opik SAFARI (this branch): selection cited real `suite_evaluators/agentic/`, run reached PR — [smellslikeml/opik#8](https://github.com/smellslikeml/opik/pull/8) +420/-3 across 5 files. Validates the branch doesn't regress on happy-path runs.

## Testing

- `pytest tests/` — 780 passed
- Live: opik SAFARI (2026-07-01 18:02Z) — full-chain reach-PR on the branch, no regression on happy path
- Live: agents Entity Binding earlier today (also full-chain, different branch — same pipeline behavior)

## Ticket coverage

Closes REMYX-172 fully (all three phases: substitution guard, self-review orphan, orphan-veto removal). Closes REMYX-173 primary scope (env at selection); secondary scope (pin-method lightweight grounding pass) deferred to a follow-up.

Partially addresses REMYX-170 — confabulation-detection surface added; engine-persistence scope (backend work) remains.

## AI assistance

AI-assisted patch. Every changed line reviewed; live tests exercised the primary code paths.