### PR TITLE
License detection: retry via arxiv HTML on unfavorable buckets

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -1941,6 +1941,106 @@ def _fetch_arxiv_abstract_page_urls(arxiv_id: str) -> tuple[list[str], list[str]
     return gh, hf
 
 
+# arxiv.org/html/<id> is a newer rendered-HTML surface for papers that
+# includes URLs mentioned in the paper body — which the abstract page
+# almost never does. Every rendered page also carries footer refs to
+# `github.com/arXiv/html_feedback` + `github.com/brucemiller/LaTeXML`;
+# these are filtered out as boilerplate.
+_ARXIV_HTML_CACHE: dict[str, list[str]] = {}
+_ARXIV_HTML_NOISE = ("arxiv/html_feedback", "brucemiller/latexml")
+
+
+def _fetch_arxiv_html_urls(arxiv_id: str) -> list[str]:
+    """Fetch ``https://arxiv.org/html/<arxiv_id>`` and return github slugs
+    from the paper body, filtering the standard arxiv footer refs.
+
+    Used as a fallback source for license detection when the primary
+    path (Remyx envelope + abstract-page scrape + GitHub `/license`)
+    doesn't surface a usable SPDX. Never raises.
+    """
+    arxiv_id = (arxiv_id or "").strip()
+    if not arxiv_id:
+        return []
+    if arxiv_id in _ARXIV_HTML_CACHE:
+        return _ARXIV_HTML_CACHE[arxiv_id]
+    try:
+        req = urllib.request.Request(
+            f"https://arxiv.org/html/{arxiv_id}",
+            headers={
+                "User-Agent": "feature-finder-orchestrator",
+                "Accept": "text/html",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        log.debug(f"  arxiv HTML fetch for {arxiv_id} failed: {e}")
+        _ARXIV_HTML_CACHE[arxiv_id] = []
+        return []
+    slugs = [
+        s for s in _extract_github_urls(html)
+        if s.lower() not in _ARXIV_HTML_NOISE
+    ]
+    _ARXIV_HTML_CACHE[arxiv_id] = slugs
+    return slugs
+
+
+def _rank_slugs_by_title_overlap(slugs: list[str], title: str) -> list[str]:
+    """Rank github slugs so the one whose repo name shares the most
+    substrings with the paper title comes first. Handles compound repo
+    names like ``EntityBindingFailures`` where token-splitting fails but
+    substring matching against title words succeeds.
+    """
+    words = [w.lower() for w in re.findall(r"[A-Za-z]{4,}", title)]
+    def _score(slug: str) -> int:
+        name = slug.split("/")[-1].lower()
+        return sum(1 for w in words if w in name)
+    return sorted(slugs, key=lambda s: -_score(s))
+
+
+def _retry_license_via_arxiv_html(candidate: "Recommendation", target_class: str) -> bool:
+    """When the primary license path left ``license_class`` unfavorable
+    (``no-code-link`` / ``unknown`` / ``missing``), try discovering fresh
+    github URLs from arxiv's HTML surface and re-classifying. Returns
+    ``True`` when the retry produced a bucketable result and updated the
+    candidate in place, ``False`` otherwise. Never raises.
+
+    The retry addresses two observed failure modes:
+      - Discovery gaps: the paper's github URL never surfaced from the
+        Remyx envelope or the abstract page, so classification never got
+        a chance to run.
+      - Timing gaps: GitHub's async license classifier hadn't caught up
+        when the primary path ran, returning ``NOASSERTION``. A fresh
+        fetch after some delay usually returns the real SPDX.
+    """
+    unfavorable = ("no-code-link", "unknown", "missing")
+    if candidate.license_class not in unfavorable:
+        return False
+    slugs = _fetch_arxiv_html_urls(candidate.arxiv_id)
+    if not slugs:
+        return False
+    ranked = _rank_slugs_by_title_overlap(slugs, candidate.paper_title or "")
+    for slug in ranked:
+        fresh_spdx = _fetch_repo_license(slug)
+        if not fresh_spdx or fresh_spdx.upper() == "NOASSERTION":
+            continue
+        fresh_class = _classify_license(fresh_spdx)
+        if fresh_class in ("unknown", "missing"):
+            continue
+        candidate.paper_license = fresh_spdx
+        if not candidate.paper_github_url:
+            candidate.paper_github_url = f"https://github.com/{slug}"
+        candidate.license_source = "arxiv_html_retry"
+        candidate.license_class = fresh_class
+        candidate.license_compat = _license_compat_score(fresh_class, target_class)
+        log.info(
+            "  ↻ license retry via arxiv HTML on %s…: %s (%s)",
+            (candidate.paper_title or "")[:50], fresh_spdx, fresh_class,
+        )
+        return True
+    return False
+
+
 # Cached extracted text (title + abstract) per arxiv id. Populated by
 # ``_fetch_arxiv_abstract_text`` for paper-anchored fidelity audits (the
 # Phase A degraded mode used when a paper has no public reference impl).
@@ -3070,6 +3170,10 @@ def _enrich_candidate_licenses(
         else:
             c.license_class = _classify_license(c.paper_license)
         c.license_compat = _license_compat_score(c.license_class, target_class)
+        # Step 6: retry via arxiv HTML when the primary path landed on an
+        # unfavorable bucket. Fires only when the primary path already
+        # ran and gave up — never overrides a successful classification.
+        _retry_license_via_arxiv_html(c, target_class)
 
 
 def query_remyx_recommendation(target: Target) -> Recommendation:

--- a/tests/test_identity_coverage.py
+++ b/tests/test_identity_coverage.py
@@ -337,6 +337,9 @@ def test_enrichment_no_url_anywhere_lands_no_code_link(monkeypatch):
     monkeypatch.setattr(
         run, "_fetch_arxiv_abstract_page_urls", lambda a: ([], []),
     )
+    # Block the arxiv HTML retry (fires on no-code-link) so it doesn't
+    # hit the network during a unit test.
+    monkeypatch.setattr(run, "_fetch_arxiv_html_urls", lambda a: [])
 
     target = Target(repo="example/perm", interest_id="iid")
     rec = Recommendation(

--- a/tests/test_license_gate.py
+++ b/tests/test_license_gate.py
@@ -213,6 +213,11 @@ def test_enrich_candidates_populates_fields_and_compat(monkeypatch):
     monkeypatch.setattr(
         run, "_fetch_arxiv_abstract_page_urls", lambda arxiv_id: ([], []),
     )
+    # Block the arxiv HTML retry (fires on unfavorable buckets) so it
+    # doesn't hit the network during a unit test either.
+    monkeypatch.setattr(
+        run, "_fetch_arxiv_html_urls", lambda arxiv_id: [],
+    )
 
     target = Target(repo="example/target-repo", interest_id="iid")
     candidates = [
@@ -259,6 +264,166 @@ def test_enrich_candidates_populates_fields_and_compat(monkeypatch):
 
     # Target license was fetched exactly once (cached).
     assert calls.count("/repos/example/target-repo/license") == 1
+
+
+# ─── arxiv HTML retry (license fallback discovery) ────────────────────────
+
+
+def test_rank_slugs_by_title_overlap_picks_paper_repo():
+    """Given multiple github refs, the one whose repo name substrings
+    match the paper title ranks first — that's the paper's own repo,
+    not a citation to a competitor."""
+    slugs = ["cloneofsimo/lora", "pilancilab/Riemannian_Preconditioned_LoRA"]
+    ranked = run._rank_slugs_by_title_overlap(
+        slugs, "Riemannian Preconditioned LoRA for Fine-Tuning Foundation Models"
+    )
+    assert ranked[0] == "pilancilab/Riemannian_Preconditioned_LoRA"
+
+
+def test_rank_slugs_by_title_overlap_handles_compound_repo_names():
+    """Compound repo names like `EntityBindingFailures` (no separators)
+    still match via substring against title words."""
+    slugs = ["arxiv/html_feedback", "R-Suresh/EntityBindingFailures"]
+    ranked = run._rank_slugs_by_title_overlap(
+        slugs, "Entity Binding Failures in Tool-Augmented Agents"
+    )
+    assert ranked[0] == "R-Suresh/EntityBindingFailures"
+
+
+def test_retry_via_arxiv_html_skips_favorable_buckets(monkeypatch):
+    """When license_class is already `permissive` (or any non-unfavorable),
+    the retry never runs — never overrides successful classification."""
+    called = {"n": 0}
+    def fake_fetch_urls(arxiv_id):
+        called["n"] += 1
+        return ["should/not/matter"]
+    monkeypatch.setattr(run, "_fetch_arxiv_html_urls", fake_fetch_urls)
+
+    c = Recommendation(
+        paper_title="Foo", arxiv_id="2410.12345", tier="high",
+        z_score=0.0, spec_md="", paper_abstract="", domain_summary="",
+        raw_paper_md="",
+    )
+    c.license_class = "permissive"
+    c.license_compat = 1.0
+    result = run._retry_license_via_arxiv_html(c, target_class="permissive")
+    assert result is False
+    assert called["n"] == 0
+    # Fields unchanged.
+    assert c.license_class == "permissive"
+    assert c.license_compat == 1.0
+
+
+def test_retry_via_arxiv_html_recovers_discovery_gap(monkeypatch):
+    """Candidate with `license_class=no-code-link` gets recovered when
+    arxiv HTML discovers a github URL that returns MIT — exactly the
+    LettuceDetect / EntityBindingFailures failure shape."""
+    monkeypatch.setattr(
+        run, "_fetch_arxiv_html_urls",
+        lambda arxiv_id: ["KRLabsOrg/LettuceDetect"],
+    )
+    monkeypatch.setattr(
+        run, "_fetch_repo_license", lambda slug: "MIT",
+    )
+
+    c = Recommendation(
+        paper_title="LettuceDetect: A Hallucination Detection Framework for RAG",
+        arxiv_id="2502.17125v1", tier="high", z_score=0.0, spec_md="",
+        paper_abstract="", domain_summary="", raw_paper_md="",
+    )
+    c.license_class = "no-code-link"
+    c.license_compat = 0.3
+
+    result = run._retry_license_via_arxiv_html(c, target_class="permissive")
+    assert result is True
+    assert c.paper_license == "MIT"
+    assert c.paper_github_url == "https://github.com/KRLabsOrg/LettuceDetect"
+    assert c.license_class == "permissive"
+    assert c.license_compat == 1.0
+    assert c.license_source == "arxiv_html_retry"
+
+
+def test_retry_via_arxiv_html_recovers_timing_gap(monkeypatch):
+    """Candidate with `license_class=unknown` (URL was known but classifier
+    returned NOASSERTION or similar) gets recovered on retry — the
+    Riemannian LoRA / LightMem2 failure shape."""
+    monkeypatch.setattr(
+        run, "_fetch_arxiv_html_urls",
+        lambda arxiv_id: ["pilancilab/Riemannian_Preconditioned_LoRA"],
+    )
+    monkeypatch.setattr(
+        run, "_fetch_repo_license", lambda slug: "MIT",
+    )
+
+    c = Recommendation(
+        paper_title="Riemannian Preconditioned LoRA for Fine-Tuning Foundation Models",
+        arxiv_id="2402.02347v3", tier="high", z_score=0.0, spec_md="",
+        paper_abstract="", domain_summary="", raw_paper_md="",
+        paper_github_url="https://github.com/pilancilab/Riemannian_Preconditioned_LoRA",
+    )
+    c.paper_license = "NOASSERTION"  # what the primary path landed on
+    c.license_class = "unknown"
+    c.license_compat = 0.0
+
+    result = run._retry_license_via_arxiv_html(c, target_class="permissive")
+    assert result is True
+    assert c.paper_license == "MIT"
+    assert c.license_class == "permissive"
+    # The URL was already set — retry doesn't clobber it.
+    assert c.paper_github_url == "https://github.com/pilancilab/Riemannian_Preconditioned_LoRA"
+
+
+def test_retry_via_arxiv_html_skips_noassertion_from_retry(monkeypatch):
+    """If the retry also finds a URL but that URL's license fetch returns
+    NOASSERTION (GitHub classifier still lagging), keep the original
+    unfavorable class rather than falsely upgrading."""
+    monkeypatch.setattr(
+        run, "_fetch_arxiv_html_urls",
+        lambda arxiv_id: ["some/repo"],
+    )
+    monkeypatch.setattr(
+        run, "_fetch_repo_license", lambda slug: "NOASSERTION",
+    )
+
+    c = Recommendation(
+        paper_title="Foo", arxiv_id="2410.12345", tier="high",
+        z_score=0.0, spec_md="", paper_abstract="", domain_summary="",
+        raw_paper_md="",
+    )
+    c.license_class = "unknown"
+    c.license_compat = 0.0
+
+    result = run._retry_license_via_arxiv_html(c, target_class="permissive")
+    assert result is False
+    assert c.license_class == "unknown"
+
+
+def test_retry_via_arxiv_html_tries_multiple_urls_until_match(monkeypatch):
+    """When ranked URLs are tried in order, the first one that returns a
+    real SPDX wins; NOASSERTION responses skip to the next candidate."""
+    monkeypatch.setattr(
+        run, "_fetch_arxiv_html_urls",
+        lambda arxiv_id: ["some/citation", "real/paper_repo"],
+    )
+    responses = {"some/citation": "NOASSERTION", "real/paper_repo": "MIT"}
+    monkeypatch.setattr(
+        run, "_fetch_repo_license", lambda slug: responses[slug],
+    )
+
+    c = Recommendation(
+        paper_title="paper repo", arxiv_id="2410.12345", tier="high",
+        z_score=0.0, spec_md="", paper_abstract="", domain_summary="",
+        raw_paper_md="",
+    )
+    c.license_class = "no-code-link"
+    c.license_compat = 0.3
+
+    result = run._retry_license_via_arxiv_html(c, target_class="permissive")
+    assert result is True
+    assert c.paper_license == "MIT"
+    # Title-overlap ranking put real/paper_repo first (title "paper repo"
+    # substring-matches "paper_repo" in slug name).
+    assert c.paper_github_url == "https://github.com/real/paper_repo"
 
 
 def test_fetch_repo_license_caches(monkeypatch):


### PR DESCRIPTION
Adds a fallback discovery + re-classification path for candidates that the primary license pipeline landed in unfavorable buckets (`no-code-link`, `unknown`, `missing`).

## Motivating cases

Four repos observed today where the primary path failed but a direct probe via `https://arxiv.org/html/<id>` finds the code URL cleanly:

| Repo | Actual license | Outrider label before | Failure mode |
|---|---|---|---|
| pilancilab/Riemannian_Preconditioned_LoRA | MIT | `unknown` | Timing gap — GitHub async classifier hadn't caught up when the primary path ran |
| KRLabsOrg/LettuceDetect | MIT | `no-code-link` | Discovery gap — URL never surfaced |
| R-Suresh/EntityBindingFailures | MIT | `no-code-link` | Discovery gap |
| zjunlp/LightMem2 | MIT | `unknown` | Timing gap |

Direct `gh api /repos/{owner}/{repo}/license` returns `spdx_id: MIT` for all four now — the classifier logic isn't broken; the primary path just didn't get a clean shot at classification for these candidates.

## Change

- `_fetch_arxiv_html_urls(arxiv_id)` — fetches the arxiv HTML surface (`arxiv.org/html/<id>`), extracts github slugs, filters the arxiv footer noise (`arxiv/html_feedback`, `brucemiller/latexml`)
- `_rank_slugs_by_title_overlap(slugs, title)` — ranks github slugs by substring overlap with paper title words; the paper's own repo beats citations to competitors
- `_retry_license_via_arxiv_html(candidate, target_class)` — fires only on unfavorable buckets, tries each ranked slug, first non-NOASSERTION SPDX wins, updates candidate fields in place
- Wired as step 6 in `_enrich_candidate_licenses` after the primary path completes

Never overrides a successful classification — activates strictly when the pipeline already gave up.

## Tests

`tests/test_license_gate.py` adds 7 tests:
- Title-overlap ranking picks paper repo over citation
- Title-overlap ranking handles compound repo names via substring match
- Retry skips favorable buckets (no override of successful classification)
- Retry recovers discovery gaps (LettuceDetect / EntityBindingFailures shape)
- Retry recovers timing gaps (Riemannian LoRA / LightMem2 shape)
- Retry skips NOASSERTION-from-retry (no false upgrade if GitHub still lagging)
- Retry tries multiple URLs, first real SPDX wins

`tests/test_identity_coverage.py` and the existing `_enrich_candidate_licenses` test are patched to block the new network path so unit tests stay hermetic.

Full suite: 788 passed.

Closes REMYX-171.