### PR TITLE
Coding-agent prompt: guidance on auto-format scope

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -544,6 +544,32 @@ behavior, prefer rewriting the surface expression to avoid the lint
 warning rather than adding ``# noqa`` — explicit suppression should be
 rare and signaled, not the cleanup path.
 
+# Auto-format scope
+
+When you invoke an auto-formatter (``ruff format``, ``black``, ``isort``,
+``prettier``, etc.), it will reformat every line in scope — not just the
+lines you semantically modified. The resulting diff carries cosmetic
+whitespace / line-join / blank-line changes on lines you never touched,
+which dilutes the semantic change and makes review harder.
+
+Prefer **diff-scoped formatting**. For Python, that means ``darker``
+(pipx-installable, wraps ``black``/``ruff format``/``isort`` and only
+applies formatting to lines that differ from HEAD)::
+
+    pipx install darker
+    darker --revision HEAD <files-you-modified>
+
+For other languages the tooling is uneven — ``prettier`` and ``rustfmt``
+don't have native line-range flags. In those cases, prefer *no
+auto-format* over full-file reformat: small formatting drift in a diff
+is fine; format churn on unrelated lines is not.
+
+If you can't scope the formatter to your changes, skip auto-format
+entirely and hand-format only the lines you modified. A diff that shows
+the semantic change without cosmetic noise is more takeover-friendly
+than one that's uniformly formatted at the cost of a much larger review
+surface.
+
 # Honesty rules
 
 - If the public surface of your new module is dominated by `TODO`,


### PR DESCRIPTION
Adds a section to the INVOCATION.md brief telling the coding agent to prefer diff-scoped auto-formatting (e.g. `darker` for Python) over whole-file formatter runs, and to skip auto-format entirely when diff-scoped tooling isn't available.

## Motivating case

hermes-agent Issue #5 (Memori) embedded a draft diff where `agent/conversation_compression.py` was substantially reformatted (multi-line collapses, blank-line adds, function-call line-splitting) alongside the actual Memori integration lines. The format churn diluted the semantic change.

## Why prompt-only (not orchestrator post-processing)

Considered but rejected: auto-run `darker --revision HEAD` in the orchestrator after implementation completes.

- Overrides agent intent universally — if the agent made a deliberate whitespace choice, post-processing would revert it silently
- Wasted work on runs where the diff was already clean
- Language-limited (Python-only via darker)
- Symptom-patches; the agent-side habit is the actual thing to change

Prompt guidance is agent-side, generalizes across languages, and root-cause-shaped.

## Follow-up telemetry

REMYX-176 leaves the door open to add a diagnostic that measures "lines touched with no semantic change" per run. If prompt guidance doesn't reduce churn frequency across the next 20-30 runs, we can escalate to orchestrator post-processing at that point with real data justifying the intervention.

## Test plan

- `pytest tests/` — 788 passed (no behavior change; prompt string update only)

Closes REMYX-176.