### PR TITLE
HF Hub checkpoint preflight for architecture-add Issues (REMYX-178)

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -2152,6 +2152,130 @@ def _verify_repo_matches_paper(
     return hits >= 2
 
 
+_ARCHITECTURE_ADD_PATTERNS = (
+    r"\bnew\s+\w*\s*(?:transformer|model|backbone|architecture)\b",
+    r"\b(?:attention|linear-attention|gla)\s+processor\b",
+    r"\bnew\s+\w*\s*(?:tuner|adapter)\b",
+    r"\bmodel\s+class\s+with\s+no\s+weights\b",
+    r"\bmodel/pipeline/scheduler\s+description\b",
+    r"\barchitectural\s+sibling\b",
+    r"\bregister\w*\s+.*(?:model|processor)\b",
+)
+
+
+def _is_architecture_add_shape(body: str) -> bool:
+    """Return True when the Issue body reads as an architecture-add artifact.
+
+    Architecture-add shape means the paper proposes a new model class,
+    backbone, attention processor, or tuner that would require multi-file
+    registration and — if intended as a runnable capability — a pretrained
+    checkpoint. These are the Issues where "does a checkpoint exist?" is a
+    load-bearing question the reader wants answered.
+    """
+    if not body:
+        return False
+    for pat in _ARCHITECTURE_ADD_PATTERNS:
+        if re.search(pat, body, re.IGNORECASE):
+            return True
+    return False
+
+
+_HF_PAPER_CACHE: dict[str, dict] = {}
+
+
+def _fetch_hf_paper_linkage(arxiv_id: str, timeout_s: int = 5) -> dict | None:
+    """Fetch a paper's canonical HF Hub linkage envelope, or ``None``.
+
+    Uses ``GET /api/papers/{arxiv_id}`` — HF Hub's paper index endpoint,
+    which returns ``linkedModels`` / ``linkedDatasets`` / ``linkedSpaces``
+    populated by HF's own crawler + model-card frontmatter (`arxiv:` tag)
+    + manual paper-page curation. This is the authoritative "does this
+    paper have a public checkpoint" answer — no author heuristics, no
+    substring matching.
+
+    Returns:
+    - ``{"title": str, "linked_models": [...], "linked_datasets": [...],
+       "linked_spaces": [...]}`` when the paper is indexed on HF
+      (regardless of whether it has any linked artifacts).
+    - ``None`` when the paper is not indexed on HF (title comes back
+      null) or on any network failure. Caller should treat ``None`` as
+      "no signal" — don't confuse it with "definitely no checkpoint".
+
+    Never raises. Cached per arxiv_id within a run.
+    """
+    if not arxiv_id:
+        return None
+    key = arxiv_id.strip().lower().replace("v", " ").split()[0]
+    if key in _HF_PAPER_CACHE:
+        return _HF_PAPER_CACHE[key]
+
+    url = f"https://huggingface.co/api/papers/{key}"
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "outrider-hf-paper-linkage",
+                "Accept": "application/json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            data = json.loads(resp.read())
+    except Exception as e:
+        log.debug(f"  HF paper linkage for {key!r} failed: {e}")
+        _HF_PAPER_CACHE[key] = None
+        return None
+
+    if not isinstance(data, dict) or not data.get("title"):
+        # HF returned an envelope but this arxiv id isn't indexed on
+        # huggingface.co/papers — no signal, not "no checkpoint".
+        _HF_PAPER_CACHE[key] = None
+        return None
+
+    parsed = {
+        "title": data.get("title", ""),
+        "linked_models": data.get("linkedModels") or [],
+        "linked_datasets": data.get("linkedDatasets") or [],
+        "linked_spaces": data.get("linkedSpaces") or [],
+    }
+    _HF_PAPER_CACHE[key] = parsed
+    return parsed
+
+
+def _format_hf_checkpoint_section(linkage: dict | None) -> str:
+    """Render an Issue-body block reporting HF Hub checkpoint availability.
+
+    Called only for architecture-add-shaped Issues. Consumes the output
+    of ``_fetch_hf_paper_linkage``:
+
+    - ``None`` → paper is not indexed on huggingface.co/papers, so we
+      have no authoritative signal. Return an empty string (no section).
+      Better to omit than to hallucinate a false "not found" claim.
+    - ``linkage`` with populated ``linked_models`` → list them (green).
+    - ``linkage`` with empty ``linked_models`` → paper IS indexed and
+      genuinely has no linked checkpoint (yellow).
+    """
+    if linkage is None:
+        return ""
+    models = linkage.get("linked_models", [])
+    if models:
+        items = "\n".join(
+            f"- [`{m.get('id', '')}`](https://huggingface.co/{m.get('id', '')})"
+            for m in models if isinstance(m, dict) and m.get("id")
+        )
+        return (
+            "\n**Hub checkpoint availability** 🟢 "
+            f"{len(models)} public checkpoint(s) linked to this paper on "
+            "Hugging Face Hub (checked via `/api/papers/{arxiv_id}` at run "
+            f"time):\n\n{items}\n"
+        )
+    return (
+        "\n**Hub checkpoint availability** 🟡 "
+        "This paper is indexed on huggingface.co/papers but has no linked "
+        "checkpoint. If a checkpoint is later published and linked to the "
+        "paper page, reopen this Issue to have Outrider revisit.\n"
+    )
+
+
 def _gather_arxiv_html_candidate_slugs(arxiv_id: str, paper_title: str) -> list[str]:
     """Collect github repo slugs from arxiv HTML + one-hop project pages.
 
@@ -7779,6 +7903,13 @@ def process_target(target: Target) -> dict:
                 f"{preflight.get('reasoning', '(no reasoning provided)')}\n\n"
                 f"{issue_body_inner}"
             )
+            # REMYX-178: architecture-add Issues gain an HF Hub checkpoint
+            # availability block, replacing "Is a checkpoint forthcoming?" as
+            # an open question with a run-time-checked fact — sourced from
+            # HF's canonical arxiv-paper linkage index, not a heuristic.
+            if _is_architecture_add_shape(issue_body_inner):
+                linkage = _fetch_hf_paper_linkage(rec.arxiv_id)
+                preflight_detail += _format_hf_checkpoint_section(linkage)
             issue_url, issue_number = _open_downgrade_issue(
                 target, rec,
                 reason="Pre-flight routed to Issue before implementation",
@@ -7834,6 +7965,13 @@ def process_target(target: Target) -> dict:
                      f"({ISSUE_FALLBACK_FILENAME} present); opening Issue")
             issue_title_inner, issue_body_inner = parse_issue_fallback_file(issue_file)
             issue_title = f"{PR_TITLE_PREFIX} {issue_title_inner}"
+            # REMYX-178: architecture-add Issues gain a checkpoint-availability
+            # block sourced from HF's arxiv-paper linkage index, replacing the
+            # "Is a checkpoint forthcoming?" question with a resolved fact.
+            checkpoint_block = ""
+            if _is_architecture_add_shape(issue_body_inner):
+                linkage = _fetch_hf_paper_linkage(rec.arxiv_id)
+                checkpoint_block = _format_hf_checkpoint_section(linkage)
             issue_body = (
                 f"**Recommended paper**: "
                 f"[{rec.paper_title}](https://arxiv.org/abs/{rec.arxiv_id})\n"
@@ -7841,6 +7979,7 @@ def process_target(target: Target) -> dict:
                 f"(Remyx relevance {rec.relevance_score:.2f})\n"
                 f"**Research interest**: {rec.interest_name or '(unnamed)'}\n"
                 f"{_render_license_section(rec)}"
+                f"{checkpoint_block}"
                 f"\n---\n\n"
                 f"{issue_body_inner}"
             )

--- a/tests/test_hf_hub_preflight.py
+++ b/tests/test_hf_hub_preflight.py
@@ -1,0 +1,187 @@
+"""Tests for the HF Hub checkpoint-availability preflight (REMYX-178).
+
+The preflight uses HF Hub's canonical arxiv-paper linkage API
+(``GET /api/papers/{arxiv_id}``) rather than heuristic author/name
+matching, so we have three signals to test:
+- paper indexed + linked models present → 🟢 list them
+- paper indexed + no linked models      → 🟡 declare absence
+- paper NOT indexed on HF               → no signal, emit nothing
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# --- _is_architecture_add_shape ---------------------------------------------
+
+def test_arch_shape_matches_new_transformer_model():
+    body = (
+        "A faithful, registered DiG would mean a new DiGTransformer2DModel "
+        "mirroring DiTTransformer2DModel."
+    )
+    assert run._is_architecture_add_shape(body) is True
+
+
+def test_arch_shape_matches_attention_processor():
+    body = "A new GLA attention processor alongside SanaLinearAttnProcessor2_0."
+    assert run._is_architecture_add_shape(body) is True
+
+
+def test_arch_shape_matches_new_tuner():
+    body = "Add a new PEFT tuner implementing AdaMoLE."
+    assert run._is_architecture_add_shape(body) is True
+
+
+def test_arch_shape_matches_model_class_no_weights():
+    body = "A model class with no weights and no pipeline that instantiates it."
+    assert run._is_architecture_add_shape(body) is True
+
+
+def test_arch_shape_matches_hf_diffusers_template():
+    body = "**Model/Pipeline/Scheduler description**\n\nDiG (Diffusion..."
+    assert run._is_architecture_add_shape(body) is True
+
+
+def test_arch_shape_rejects_pure_algorithm_improvement():
+    body = (
+        "Add GD²PO advantage estimator behind --algo.advantage.estimator "
+        "gd2po. Extends the existing dispatch."
+    )
+    assert run._is_architecture_add_shape(body) is False
+
+
+def test_arch_shape_rejects_dataset_or_benchmark_add():
+    body = "Add a new benchmark that evaluates existing models on X."
+    assert run._is_architecture_add_shape(body) is False
+
+
+def test_arch_shape_rejects_empty_body():
+    assert run._is_architecture_add_shape("") is False
+
+
+# --- _fetch_hf_paper_linkage ------------------------------------------------
+
+def _fake_resp(payload):
+    class Resp:
+        def __init__(self, data): self._data = data
+        def read(self): return json.dumps(self._data).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+    return Resp(payload)
+
+
+def test_paper_linkage_indexed_with_linked_models():
+    run._HF_PAPER_CACHE.clear()
+    payload = {
+        "title": "SomePaper: Doing Something",
+        "linkedModels": [
+            {"id": "org/somepaper-checkpoint", "downloads": 42},
+            {"id": "org/somepaper-large"},
+        ],
+        "linkedDatasets": [],
+        "linkedSpaces": [],
+    }
+    with patch.object(run.urllib.request, "urlopen", return_value=_fake_resp(payload)):
+        got = run._fetch_hf_paper_linkage("2405.18428")
+    assert got is not None
+    assert got["title"] == "SomePaper: Doing Something"
+    assert len(got["linked_models"]) == 2
+
+
+def test_paper_linkage_indexed_but_no_linked_models():
+    """This is the DiG case — paper indexed on HF, but no checkpoint linked."""
+    run._HF_PAPER_CACHE.clear()
+    payload = {
+        "title": "DiG: Scalable and Efficient Diffusion Models with Gated Linear Attention",
+        "linkedModels": [],
+        "linkedDatasets": [],
+        "linkedSpaces": [],
+    }
+    with patch.object(run.urllib.request, "urlopen", return_value=_fake_resp(payload)):
+        got = run._fetch_hf_paper_linkage("2405.18428")
+    assert got is not None
+    assert got["title"].startswith("DiG")
+    assert got["linked_models"] == []
+
+
+def test_paper_linkage_not_indexed_returns_none():
+    """HF returns title=null when the paper isn't on huggingface.co/papers."""
+    run._HF_PAPER_CACHE.clear()
+    payload = {"title": None, "linkedModels": [], "linkedDatasets": []}
+    with patch.object(run.urllib.request, "urlopen", return_value=_fake_resp(payload)):
+        got = run._fetch_hf_paper_linkage("2606.99999")
+    assert got is None
+
+
+def test_paper_linkage_network_failure_returns_none():
+    run._HF_PAPER_CACHE.clear()
+    with patch.object(run.urllib.request, "urlopen", side_effect=OSError("dns")):
+        assert run._fetch_hf_paper_linkage("2405.18428") is None
+
+
+def test_paper_linkage_caches_per_arxiv_id():
+    run._HF_PAPER_CACHE.clear()
+    payload = {"title": "X", "linkedModels": []}
+    calls = [0]
+    def counting(*a, **kw):
+        calls[0] += 1
+        return _fake_resp(payload)
+    with patch.object(run.urllib.request, "urlopen", side_effect=counting):
+        run._fetch_hf_paper_linkage("2405.18428")
+        run._fetch_hf_paper_linkage("2405.18428")
+        run._fetch_hf_paper_linkage("2405.18428v2")  # version stripped in cache key
+    assert calls[0] == 1
+
+
+def test_paper_linkage_empty_arxiv_id_returns_none():
+    assert run._fetch_hf_paper_linkage("") is None
+
+
+# --- _format_hf_checkpoint_section ------------------------------------------
+
+def test_format_section_omits_entirely_when_linkage_is_none():
+    """No-signal case: paper isn't indexed on HF, so we say nothing.
+    Emitting a false 'not found' would be worse than staying silent."""
+    assert run._format_hf_checkpoint_section(None) == ""
+
+
+def test_format_section_lists_linked_models_when_present():
+    linkage = {
+        "title": "X",
+        "linked_models": [
+            {"id": "hustvl/DiG-XL-2-256"},
+            {"id": "hustvl/DiG-S-2"},
+        ],
+    }
+    out = run._format_hf_checkpoint_section(linkage)
+    assert "🟢" in out
+    assert "hustvl/DiG-XL-2-256" in out
+    assert "hustvl/DiG-S-2" in out
+    assert "huggingface.co/hustvl/DiG-XL-2-256" in out
+    assert "2 public checkpoint" in out
+
+
+def test_format_section_declares_absence_when_paper_indexed_no_models():
+    linkage = {"title": "DiG: ...", "linked_models": []}
+    out = run._format_hf_checkpoint_section(linkage)
+    assert "🟡" in out
+    assert "indexed on huggingface.co/papers" in out
+    assert "no linked" in out
+
+
+def test_format_section_skips_models_without_id():
+    linkage = {
+        "title": "X",
+        "linked_models": [{"id": "org/valid"}, {"no_id": True}, "not_a_dict"],
+    }
+    out = run._format_hf_checkpoint_section(linkage)
+    assert "org/valid" in out
+    assert "no_id" not in out


### PR DESCRIPTION
Architecture-add Issues (new model class / backbone / attention processor / tuner) gain a "Hub checkpoint availability" block resolved at run time. Fixes the DiG#13 pattern where "Is a DiG checkpoint forthcoming on the Hub?" was asked but never investigated — Outrider now answers it before the maintainer has to.

## Design (in response to review)

**Not a heuristic.** First draft used author-name matching (`github.com/hustvl/DiG` → `?author=hustvl` on HF + substring filter) which is overfit and brittle. Rewritten to use HF's canonical arxiv-linkage endpoint:

```
GET https://huggingface.co/api/papers/{arxiv_id}
→ {title, linkedModels, linkedDatasets, linkedSpaces, ...}
```

This is HF's own paper→repo index, populated by model-card `arxiv:` frontmatter tags + curated paper pages. Same source the [huggingface.co/papers](https://huggingface.co/papers) UI shows.

## Three-state signal

| Case | HF response | Rendered |
|---|---|---|
| Paper indexed + linked models present | `title != null`, `linkedModels` populated | 🟢 list them with links |
| Paper indexed + no linked models | `title != null`, `linkedModels: []` | 🟡 declare absence explicitly |
| Paper not indexed on HF | `title: null` | *(silent — no section)* |

The silent case is deliberate: emitting a false "not found" claim when HF simply hasn't indexed the paper would be worse than saying nothing. Better to omit than to hallucinate signal.

## Firing conditions

Enrichment only runs when the Issue body reads as architecture-add shape (regex-detected via keywords like `new * transformer/model/backbone`, `attention processor`, `new * tuner`, `Model/Pipeline/Scheduler description`, `architectural sibling`). Pure algorithm-improvement Issues (like OpenRLHF's GD²PO) don't fire — checkpoint availability isn't a load-bearing question for those.

## Test plan

- `pytest tests/test_hf_hub_preflight.py` — 18 new tests covering the three-state signal, cache, arch-shape detection, empty-body / bad-url guards
- `pytest tests/` — 814 total (796 previous + 18 new), all passing

## Motivating example

Under this change, DiG#13's body would gain:

> **Hub checkpoint availability** 🟡 This paper is indexed on huggingface.co/papers but has no linked checkpoint. If a checkpoint is later published and linked to the paper page, reopen this Issue to have Outrider revisit.

And its "open question 1" ("Is a DiG checkpoint forthcoming on the Hub?") becomes redundant — the maintainer can drop it from their reply.