### PR TITLE
Pre-PR fidelity gate + patch stage + coordinated pin-arxiv/search-method rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ remyxai outrider init --repo owner/name --auto-interest
 From then on, the scheduled cron handles it — a draft PR or Issue appears each cycle. Trigger an ad-hoc run on a specific paper without waiting:
 
 ```bash
-remyxai outrider trigger --repo owner/name --pin-method 2410.20305v2
-remyxai outrider trigger --repo owner/name --pin-method "knowledge distillation"
+remyxai outrider trigger --repo owner/name --pin-arxiv 2410.20305v2
+remyxai outrider trigger --repo owner/name --pin-method "riemannian preconditioning LoRA optimizer"
 ```
 
-(Free-text method query or a literal arxiv id; pinning bypasses the candidate-selection pass.)
+`--pin-arxiv` implements the exact arxiv id (bypasses selection). `--pin-method` runs an engine search and implements the top hit — use it for exploratory dispatches when you know the method family but not the specific arxiv id, not for reproducible re-runs.
 
 Requires `REMYXAI_API_KEY` (from [engine.remyx.ai](https://engine.remyx.ai) Settings) and an Anthropic key (`--anthropic-key` or `ANTHROPIC_API_KEY`). See [`remyxai-cli`](https://github.com/remyxai/remyxai-cli) for bulk-install, per-dispatch routing flags, and secret management.
 

--- a/action.yml
+++ b/action.yml
@@ -205,13 +205,15 @@ inputs:
       use it for reproducible eval re-runs. Empty = normal selection.
     required: false
     default: ''
-  pin-method:
+  search-method:
     description: |
-      Optional method/technique query (e.g. "knowledge distillation", "MoE
-      expert routing"). When set, Outrider runs the engine's search to find
-      the top arxiv paper for the query and implements it — bypassing the
-      selection pass and the interest's candidate pool entirely. Empty =
-      normal selection. Mutually exclusive with pin-arxiv.
+      Free-text method/technique query (e.g. "riemannian preconditioning
+      LoRA optimizer"). When set, Outrider runs the engine's search to
+      find the top-hit arxiv paper matching the query and implements it —
+      overriding the interest's ranked pool. Use for exploratory dispatches
+      when you know the method family but not the specific arxiv id. For
+      reproducible re-runs of a known paper, use pin-arxiv instead. Empty
+      = normal selection. Mutually exclusive with pin-arxiv.
     required: false
     default: ''
   model-base-url:
@@ -400,7 +402,7 @@ runs:
         INPUT_TEST_INTEGRATION_POLICY: ${{ inputs.test-integration-policy }}
         INPUT_CLAUDE_TIMEOUT: ${{ inputs.claude-timeout }}
         INPUT_PIN_ARXIV: ${{ inputs.pin-arxiv }}
-        INPUT_PIN_METHOD: ${{ inputs.pin-method }}
+        INPUT_SEARCH_METHOD: ${{ inputs.search-method }}
         INPUT_MODEL_BASE_URL: ${{ inputs.model-base-url }}
         # PR number to audit in fidelity mode (set from the workflow's
         # pull_request event payload; empty in recommend / weekly-summary).

--- a/src/run.py
+++ b/src/run.py
@@ -8502,10 +8502,26 @@ def process_target(target: Target) -> dict:
             if patched:
                 # Append the patch as a second commit on the existing
                 # branch. Can't reuse `commit_and_push` — its safety
-                # guard requires HEAD == origin/main, which no longer
-                # holds after the first commit_and_push moved HEAD to
-                # the feature branch. Direct git ops here.
+                # guard requires HEAD == origin/main.
+                #
+                # Extra step: the first commit_and_push re-authored the
+                # remote branch head via the GitHub API (produces a
+                # bot-verified commit with same tree, different author
+                # metadata). Local HEAD is still at the pre-reauth
+                # commit — a plain push of a local descendant would be
+                # non-fast-forward. `fetch + reset --soft` aligns local
+                # HEAD to the remote's API commit without touching the
+                # working tree (patch changes stay uncommitted); the
+                # subsequent commit is a clean fast-forward.
                 try:
+                    subprocess.run(
+                        ["git", "fetch", "origin", branch],
+                        cwd=workdir, check=True, capture_output=True, text=True,
+                    )
+                    subprocess.run(
+                        ["git", "reset", "--soft", f"origin/{branch}"],
+                        cwd=workdir, check=True, capture_output=True, text=True,
+                    )
                     subprocess.run(
                         ["git", "commit", "-am", "Fidelity remediation"],
                         cwd=workdir, check=True, capture_output=True, text=True,

--- a/src/run.py
+++ b/src/run.py
@@ -8500,11 +8500,27 @@ def process_target(target: Target) -> dict:
                 timeout_s=target.claude_timeout_s,
             )
             if patched:
-                # Re-commit + push the patched branch, then re-run fidelity
-                commit_and_push(
-                    workdir, branch, pr_title, repo=target.repo,
-                    base_branch=default_branch,
-                )
+                # Append the patch as a second commit on the existing
+                # branch. Can't reuse `commit_and_push` — its safety
+                # guard requires HEAD == origin/main, which no longer
+                # holds after the first commit_and_push moved HEAD to
+                # the feature branch. Direct git ops here.
+                try:
+                    subprocess.run(
+                        ["git", "commit", "-am", "Fidelity remediation"],
+                        cwd=workdir, check=True, capture_output=True, text=True,
+                    )
+                    subprocess.run(
+                        ["git", "push", "origin", branch],
+                        cwd=workdir, check=True, capture_output=True, text=True,
+                    )
+                    log.info(f"  ✓ pushed patch commit on {branch}")
+                except subprocess.CalledProcessError as e:
+                    stderr = (e.stderr or "").strip()
+                    log.warning(f"  ⚠ patch commit/push failed: {stderr[-300:]}")
+                    result["status"] = "skipped_fidelity_fabrication"
+                    result["error"] = f"patch commit failed: {stderr[-200:]}"
+                    return result
                 revised_verdict = _run_pre_pr_fidelity_check(
                     rec, target, workdir, pr_title, pr_body,
                     base_branch=default_branch,

--- a/src/run.py
+++ b/src/run.py
@@ -1262,7 +1262,7 @@ class Target:
     # single-item viable pool from that asset, and pins to it — bypassing
     # both the interest's candidate pool and the selection pass. Mutually
     # exclusive with pin_arxiv (validated in build_target_from_env).
-    pin_method: str = ""
+    search_method: str = ""
     # Optional: route the Claude Code subprocess at a non-default base URL.
     # When set, becomes ``ANTHROPIC_BASE_URL`` for every Claude CLI call,
     # which is the Anthropic-Messages-compatible protocol any z.ai/GLM,
@@ -7652,34 +7652,34 @@ def process_target(target: Target) -> dict:
             "arxiv_id": rec.arxiv_id,
             "title": rec.paper_title,
         }
-    elif target.pin_method:
-        asset = _resolve_pin_method(target.pin_method)
+    elif target.search_method:
+        asset = _resolve_pin_method(target.search_method)
         if asset is None:
             log.info(f"  ✗ skipped_no_method_match: pin-method "
-                     f"{target.pin_method!r} resolved to no asset")
+                     f"{target.search_method!r} resolved to no asset")
             result["status"] = "skipped_no_method_match"
-            result["pin_method"] = target.pin_method
+            result["search_method"] = target.search_method
             return result
         rec = _asset_to_recommendation(
-            asset, refine_query=f"pin-method:{target.pin_method}",
+            asset, refine_query=f"search-method:{target.search_method}",
             fallback_interest_name="(pin-method)",
             interest_context="",
             experiment_history="",
         )
         log.info(
-            f"  → pin-method {target.pin_method!r} resolved to "
+            f"  → search-method {target.search_method!r} resolved to "
             f"{rec.arxiv_id} ({rec.paper_title[:60]}…)"
         )
         candidates = [rec]
-        result["pin_method"] = target.pin_method
-        result["pin_method_resolution"] = {
-            "query": target.pin_method,
+        result["search_method"] = target.search_method
+        result["search_method_resolution"] = {
+            "query": target.search_method,
             "arxiv_id": rec.arxiv_id,
             "title": rec.paper_title,
         }
         # Reduce pin-method to pin_arxiv so the existing pinning logic at
         # §4 selects this candidate without a parallel code path. The
-        # original pin_method string is preserved in result["pin_method"]
+        # original search_method string is preserved in result["search_method"]
         # for the step summary.
         target.pin_arxiv = rec.arxiv_id
     else:
@@ -7725,7 +7725,7 @@ def process_target(target: Target) -> dict:
     # re-runs, demo re-takes, and "improve the prior artifact" workflows
     # would always skip with skipped_issue_exists. PR-collision check
     # below stays active — that's a real safety property.
-    pin_override = bool(target.pin_method or target.pin_arxiv)
+    pin_override = bool(target.search_method or target.pin_arxiv)
     viable: list[Recommendation] = []
     dropped_low_conf = 0
     dropped_pr_exists = 0
@@ -7809,9 +7809,9 @@ def process_target(target: Target) -> dict:
             # pin-method reduces to pin-arxiv internally (see §2); surface
             # the original user-facing source in the reasoning so step
             # summaries / telemetry are honest about which input drove the pin.
-            if target.pin_method:
+            if target.search_method:
                 result["selection_reasoning"] = (
-                    f"(pinned via pin-method={target.pin_method!r} → "
+                    f"(pinned via search-method={target.search_method!r} → "
                     f"{target.pin_arxiv})"
                 )
             else:
@@ -8762,7 +8762,7 @@ def build_target_from_env() -> Target:
         test_integration_policy=test_integration_policy,
         claude_timeout_s=claude_timeout_s,
         pin_arxiv=_optional_env("INPUT_PIN_ARXIV", ""),
-        pin_method=_optional_env("INPUT_PIN_METHOD", ""),
+        search_method=_optional_env("INPUT_SEARCH_METHOD", ""),
         model_base_url=_optional_env("INPUT_MODEL_BASE_URL", ""),
         chain_enabled=chain_enabled,
         notes="",
@@ -13391,8 +13391,8 @@ def _post_run_telemetry(result: dict, target: "Target") -> None:
         # up as PR / Issue / preflight-Issue / no-integration.
         "preflight_decision": result.get("preflight_decision"),
         "audit_anchor": result.get("audit_anchor"),
-        "pin_method": result.get("pin_method"),
-        "pin_method_resolution": result.get("pin_method_resolution"),
+        "search_method": result.get("search_method"),
+        "search_method_resolution": result.get("search_method_resolution"),
         "selection_proposed_call_site": (
             (result.get("selection_proposed_call_site") or "")[:512] or None
         ),
@@ -13541,7 +13541,7 @@ def main():
         sys.exit(2)
 
     target = build_target_from_env()
-    if target.pin_arxiv and target.pin_method:
+    if target.pin_arxiv and target.search_method:
         log.error(
             "pin-arxiv and pin-method are mutually exclusive; set one or "
             "the other, not both."

--- a/src/run.py
+++ b/src/run.py
@@ -7767,8 +7767,46 @@ def process_target(target: Target) -> dict:
                 None,
             )
             if pinned_idx is None:
-                log.warning(f"  pin-arxiv {target.pin_arxiv!r} not in viable "
-                            f"pool; falling back to the selection pass")
+                # Pool didn't contain the paper — the ranker's interest-
+                # scoped top-N missed it. But pin-arxiv is an explicit "use
+                # THIS paper" directive; honor the intent by fetching the
+                # paper directly from Remyx's asset endpoint and injecting
+                # it as the sole candidate. Downstream preflight still
+                # validates fit against the codebase (a legitimately
+                # off-domain pin still routes to Issue). REMYX-183.
+                log.info(
+                    f"  pin-arxiv {target.pin_arxiv!r} not in ranker pool "
+                    f"(top-{len(viable)}); fetching directly from Remyx "
+                    f"assets to override the candidate list"
+                )
+                asset = _remyx_get_asset(target.pin_arxiv)
+                if asset is None:
+                    log.error(
+                        f"  ✗ pin-arxiv {target.pin_arxiv!r}: asset lookup "
+                        f"failed (paper not in Remyx catalog); skipping"
+                    )
+                    result["status"] = "skipped_pin_arxiv_not_found"
+                    result["pin_arxiv_requested"] = target.pin_arxiv
+                    return result
+                # Carry the interest metadata from an existing viable candidate
+                # if the pool has one — otherwise empty strings work (the
+                # asset-to-rec mapping degrades gracefully).
+                iname = viable[0].interest_name if viable else ""
+                ictx = viable[0].interest_context if viable else ""
+                ihist = viable[0].experiment_history if viable else ""
+                pinned_rec = _asset_to_recommendation(
+                    asset,
+                    refine_query=f"pin-arxiv override ({target.pin_arxiv})",
+                    fallback_interest_name=iname,
+                    interest_context=ictx,
+                    experiment_history=ihist,
+                )
+                viable = [pinned_rec]
+                pinned_idx = 0
+                log.info(
+                    f"  ✓ pin-arxiv override: injected "
+                    f"{pinned_rec.paper_title[:60]!r} from asset lookup"
+                )
         if pinned_idx is not None:
             rec = viable[pinned_idx]
             # pin-method reduces to pin-arxiv internally (see §2); surface
@@ -10390,7 +10428,11 @@ Fix them by editing the branch's files to match the reference.
 Read the reference codebase (already cloned as `./reference/`) as needed.
 Apply the fixes; changes are staged by the caller.
 """
-    brief_path = workdir / ".remyx-recommendation" / "FIDELITY_REMEDIATION.md"
+    # Write the patch brief to INVOCATION.md — the file `invoke_claude_code`
+    # reads at startup. The original INVOCATION.md was consumed by the earlier
+    # implementation session; overwriting it here is safe because no downstream
+    # reader in the pre-PR flow needs the original content.
+    brief_path = workdir / ".remyx-recommendation" / "INVOCATION.md"
     brief_path.parent.mkdir(exist_ok=True)
     brief_path.write_text(patch_brief)
 

--- a/src/run.py
+++ b/src/run.py
@@ -7625,7 +7625,34 @@ def process_target(target: Target) -> dict:
     #    candidate — bypassing both the interest's recommendation pool
     #    and the LLM selection pass. The downstream pin_arxiv check at
     #    §4 then picks this candidate naturally (no extra plumbing).
-    if target.pin_method:
+    if target.pin_arxiv:
+        # Short-circuit: fetch the pinned paper directly, skip the ranker
+        # pool entirely (bypasses /papers/recommended, refine queries, and
+        # per-candidate license enrichment on the full pool). Explicit
+        # "use THIS paper" intent doesn't need the ranker's opinion.
+        asset = _remyx_get_asset(target.pin_arxiv)
+        if asset is None:
+            log.info(f"  ✗ skipped_pin_arxiv_not_found: pin-arxiv "
+                     f"{target.pin_arxiv!r} not found in Remyx catalog")
+            result["status"] = "skipped_pin_arxiv_not_found"
+            result["pin_arxiv_requested"] = target.pin_arxiv
+            return result
+        rec = _asset_to_recommendation(
+            asset, refine_query=f"pin-arxiv:{target.pin_arxiv}",
+            fallback_interest_name="(pin-arxiv)",
+            interest_context="",
+            experiment_history="",
+        )
+        log.info(
+            f"  → pin-arxiv {target.pin_arxiv!r} resolved to "
+            f"{rec.paper_title[:60]}… (skipped ranker pool)"
+        )
+        candidates = [rec]
+        result["pin_arxiv_resolution"] = {
+            "arxiv_id": rec.arxiv_id,
+            "title": rec.paper_title,
+        }
+    elif target.pin_method:
         asset = _resolve_pin_method(target.pin_method)
         if asset is None:
             log.info(f"  ✗ skipped_no_method_match: pin-method "
@@ -7767,46 +7794,16 @@ def process_target(target: Target) -> dict:
                 None,
             )
             if pinned_idx is None:
-                # Pool didn't contain the paper — the ranker's interest-
-                # scoped top-N missed it. But pin-arxiv is an explicit "use
-                # THIS paper" directive; honor the intent by fetching the
-                # paper directly from Remyx's asset endpoint and injecting
-                # it as the sole candidate. Downstream preflight still
-                # validates fit against the codebase (a legitimately
-                # off-domain pin still routes to Issue). REMYX-183.
-                log.info(
-                    f"  pin-arxiv {target.pin_arxiv!r} not in ranker pool "
-                    f"(top-{len(viable)}); fetching directly from Remyx "
-                    f"assets to override the candidate list"
+                # Defensive: the pin-arxiv fast-path at §2 injects the
+                # pinned paper directly, so this branch is effectively
+                # unreachable. Log + skip if it ever fires.
+                log.error(
+                    f"  ✗ pin-arxiv {target.pin_arxiv!r} unexpectedly "
+                    f"absent from viable pool (fast-path bug?); skipping"
                 )
-                asset = _remyx_get_asset(target.pin_arxiv)
-                if asset is None:
-                    log.error(
-                        f"  ✗ pin-arxiv {target.pin_arxiv!r}: asset lookup "
-                        f"failed (paper not in Remyx catalog); skipping"
-                    )
-                    result["status"] = "skipped_pin_arxiv_not_found"
-                    result["pin_arxiv_requested"] = target.pin_arxiv
-                    return result
-                # Carry the interest metadata from an existing viable candidate
-                # if the pool has one — otherwise empty strings work (the
-                # asset-to-rec mapping degrades gracefully).
-                iname = viable[0].interest_name if viable else ""
-                ictx = viable[0].interest_context if viable else ""
-                ihist = viable[0].experiment_history if viable else ""
-                pinned_rec = _asset_to_recommendation(
-                    asset,
-                    refine_query=f"pin-arxiv override ({target.pin_arxiv})",
-                    fallback_interest_name=iname,
-                    interest_context=ictx,
-                    experiment_history=ihist,
-                )
-                viable = [pinned_rec]
-                pinned_idx = 0
-                log.info(
-                    f"  ✓ pin-arxiv override: injected "
-                    f"{pinned_rec.paper_title[:60]!r} from asset lookup"
-                )
+                result["status"] = "skipped_pin_arxiv_not_found"
+                result["pin_arxiv_requested"] = target.pin_arxiv
+                return result
         if pinned_idx is not None:
             rec = viable[pinned_idx]
             # pin-method reduces to pin-arxiv internally (see §2); surface

--- a/src/run.py
+++ b/src/run.py
@@ -8438,6 +8438,65 @@ def process_target(target: Target) -> dict:
         commit_and_push(
             workdir, branch, pr_title, repo=target.repo, base_branch=default_branch
         )
+
+        # REMYX-186: Pre-PR fidelity gate.
+        # Run fidelity on the local branch BEFORE opening the PR. If
+        # substantive deviations from the reference are found, either
+        # patch the branch (REMYX-185, scoped-down single-attempt) or
+        # skip publication entirely. Fabricated artifacts never become
+        # public.
+        prepub_verdict = _run_pre_pr_fidelity_check(
+            rec, target, workdir, pr_title, pr_body, base_branch=default_branch,
+        )
+        result["prepub_fidelity"] = {
+            "status": prepub_verdict.get("status"),
+            "items_count": prepub_verdict.get("items_count", 0),
+            "needs_judgment": prepub_verdict.get("needs_judgment", False),
+        }
+        if prepub_verdict.get("coverage_section"):
+            _append_to_step_summary(prepub_verdict["coverage_section"])
+
+        if prepub_verdict.get("needs_judgment"):
+            log.info("  → pre-PR fidelity flagged fabrication; attempting one patch")
+            patched = _attempt_pre_pr_fidelity_patch(
+                workdir,
+                prepub_verdict["matrix"],
+                prepub_verdict.get("reference_url", ""),
+                timeout_s=target.claude_timeout_s,
+            )
+            if patched:
+                # Re-commit + push the patched branch, then re-run fidelity
+                commit_and_push(
+                    workdir, branch, pr_title, repo=target.repo,
+                    base_branch=default_branch,
+                )
+                revised_verdict = _run_pre_pr_fidelity_check(
+                    rec, target, workdir, pr_title, pr_body,
+                    base_branch=default_branch,
+                )
+                result["prepub_fidelity_after_patch"] = {
+                    "status": revised_verdict.get("status"),
+                    "items_count": revised_verdict.get("items_count", 0),
+                    "needs_judgment": revised_verdict.get("needs_judgment", False),
+                }
+                if revised_verdict.get("coverage_section"):
+                    _append_to_step_summary(revised_verdict["coverage_section"])
+                if revised_verdict.get("needs_judgment"):
+                    result["status"] = "skipped_fidelity_fabrication_after_patch"
+                    log.info(
+                        f"  ✗ {result['status']}: fidelity still flags "
+                        f"{revised_verdict['items_count']} items after patch"
+                    )
+                    return result
+                log.info("  ✓ patch resolved fidelity findings — continuing to PR")
+            else:
+                result["status"] = "skipped_fidelity_fabrication"
+                log.info(
+                    f"  ✗ {result['status']}: patch attempt failed or no edits; "
+                    "no PR opened"
+                )
+                return result
+
         pr_url, pr_number = open_pr(
             target, branch, pr_title, pr_body, draft=draft, base=default_branch
         )
@@ -10165,6 +10224,201 @@ Return ONLY a valid JSON object (no prose before or after):
   ]
 }}
 """
+
+
+def _local_git_diff(workdir: "Path", base_branch: str = "main") -> str:
+    """Return the diff of committed changes on the current branch vs base.
+
+    Called pre-PR-publication so fidelity can audit local branch changes
+    without fetching from GitHub. ``workdir`` is the clone that
+    ``commit_and_push`` just built on. Returns ``""`` on any git failure —
+    caller decides how to degrade.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--no-color", f"{base_branch}..HEAD"],
+            cwd=str(workdir), capture_output=True, text=True, timeout=30,
+        )
+        return result.stdout if result.returncode == 0 else ""
+    except (subprocess.SubprocessError, OSError) as e:
+        log.debug(f"  local git diff failed: {e}")
+        return ""
+
+
+def _run_pre_pr_fidelity_check(
+    rec: "Recommendation",
+    target: "Target",
+    workdir: "Path",
+    pr_title: str,
+    pr_body: str,
+    base_branch: str = "main",
+) -> dict:
+    """Run the fidelity audit on the local branch, before opening a PR.
+
+    Mirrors ``run_fidelity_mode`` but takes local inputs (title/body/diff
+    from what's about to be posted) instead of fetching from a PR that
+    doesn't exist yet. Returns a verdict dict with ``needs_judgment``,
+    ``items_count``, ``coverage_section``, ``status``, ``matrix``.
+
+    Only reference-anchored mode is supported here — the paper-anchored
+    degraded mode adds complexity that isn't needed for the primary
+    (fidelity-catches-fabrication) use case. When no reference URL is
+    available, returns ``needs_judgment=False`` and lets the flow
+    proceed (equivalent to the old post-PR skip behavior).
+    """
+    verdict = {
+        "needs_judgment": False,
+        "items_count": 0,
+        "coverage_section": "",
+        "status": "pre_pr_fidelity_skipped_no_reference",
+        "matrix": None,
+    }
+    _, reference_url = _extract_reference_url_from_pr_body(pr_body, target.repo)
+    if not reference_url:
+        log.info("  → pre-PR fidelity: no reference URL, skipping")
+        return verdict
+    verdict["reference_url"] = reference_url
+
+    fid_workdir = Path(tempfile.mkdtemp(prefix="outrider-prepub-fidelity-"))
+    log.info(f"  → pre-PR fidelity workdir: {fid_workdir}")
+    ok, ref_dir, err = _clone_reference_repo(reference_url, fid_workdir)
+    if not ok:
+        verdict["status"] = "pre_pr_fidelity_failed_clone"
+        verdict["error"] = err
+        log.warning(f"  ⚠ pre-PR fidelity clone failed: {err}")
+        return verdict
+
+    diff = _local_git_diff(workdir, base_branch)
+    if not diff:
+        verdict["status"] = "pre_pr_fidelity_failed_no_diff"
+        log.warning("  ⚠ pre-PR fidelity: local git diff empty; skipping")
+        return verdict
+
+    prompt = _build_fidelity_audit_prompt(
+        pr_title=pr_title,
+        pr_body=pr_body,
+        pr_diff=diff,
+        arxiv_id=rec.arxiv_id,
+        reference_url=reference_url,
+        reference_root=ref_dir,
+    )
+    log.info(f"  → pre-PR fidelity Claude one-shot (timeout={target.claude_timeout_s}s)")
+    ok, raw = _run_claude_oneshot(
+        fid_workdir, prompt, target.claude_timeout_s, max_turns=20,
+    )
+    if not ok:
+        verdict["status"] = "pre_pr_fidelity_failed_claude"
+        verdict["error"] = f"Claude non-zero: {raw[-500:]}"
+        log.warning(f"  ⚠ pre-PR fidelity Claude failed")
+        return verdict
+
+    matrix = _extract_json_object(raw)
+    if not matrix or "items" not in matrix:
+        verdict["status"] = "pre_pr_fidelity_failed_claude"
+        verdict["error"] = f"unparseable JSON: {raw[-500:]}"
+        log.warning("  ⚠ pre-PR fidelity: unparseable JSON")
+        return verdict
+
+    coverage_section = _render_coverage_matrix(matrix, audit_anchor="reference")
+    needs_judgment = bool(matrix.get("needs_judgment", False))
+
+    verdict.update({
+        "needs_judgment": needs_judgment,
+        "items_count": len(matrix.get("items", [])),
+        "coverage_section": coverage_section,
+        "matrix": matrix,
+        "status": (
+            "pre_pr_fidelity_needs_judgment" if needs_judgment
+            else "pre_pr_fidelity_clean"
+        ),
+    })
+    log.info(
+        f"  ✓ pre-PR fidelity: {verdict['items_count']} items, "
+        f"needs_judgment={needs_judgment}"
+    )
+    return verdict
+
+
+def _attempt_pre_pr_fidelity_patch(
+    workdir: "Path",
+    coverage_matrix: dict,
+    reference_url: str,
+    timeout_s: int = 900,
+) -> bool:
+    """Invoke Claude Code with fidelity findings to patch the local branch.
+
+    Bounded single-attempt remediation: Claude gets the coverage matrix
+    of flagged deviations + the reference-repo URL as context and edits
+    the branch's files to resolve them. Caller re-runs fidelity after.
+
+    Returns ``True`` if Claude exited cleanly AND touched files in the
+    workdir (so re-fidelity is worth running). ``False`` on Claude
+    failure or no edits — caller should skip publication.
+    """
+    if not coverage_matrix or not coverage_matrix.get("items"):
+        return False
+    flagged = [
+        it for it in coverage_matrix["items"]
+        if isinstance(it, dict) and "deviation" in str(it.get("status", "")).lower()
+    ]
+    if not flagged:
+        return False
+
+    # Compose a Claude Code prompt file that Claude reads on startup.
+    findings_md = "\n".join(
+        f"- **{it.get('name', '(unnamed)')}** ({it.get('status', '')}): "
+        f"{it.get('rationale', '')[:400]}"
+        for it in flagged
+    )
+    patch_brief = f"""# Fidelity remediation brief
+
+Fidelity audit against the reference implementation ({reference_url})
+flagged {len(flagged)} substantive deviations in the current branch.
+Fix them by editing the branch's files to match the reference.
+
+**Constraints**:
+- Match the reference's algorithm, defaults, and mechanism — do not invent
+- If the paper claim in the PR body is wrong, correct it — reference is
+  ground truth
+- Do not add new scope (no unrelated features, no drive-by refactors)
+- Keep the diff surface small — the goal is to resolve these findings,
+  not rewrite the module
+
+**Flagged items**:
+{findings_md}
+
+Read the reference codebase (already cloned as `./reference/`) as needed.
+Apply the fixes; changes are staged by the caller.
+"""
+    brief_path = workdir / ".remyx-recommendation" / "FIDELITY_REMEDIATION.md"
+    brief_path.parent.mkdir(exist_ok=True)
+    brief_path.write_text(patch_brief)
+
+    # Record file mtimes to detect edits
+    before = {
+        p: p.stat().st_mtime
+        for p in workdir.rglob("*.py")
+        if ".git" not in p.parts and ".remyx-recommendation" not in p.parts
+    }
+
+    log.info(f"  → pre-PR fidelity patch attempt ({len(flagged)} deviations, timeout={timeout_s}s)")
+    ok, log_tail = invoke_claude_code(workdir, timeout_s=timeout_s)
+    if not ok:
+        log.warning(f"  ⚠ patch attempt failed: {log_tail[-300:]}")
+        return False
+
+    # Did anything actually change?
+    after = {
+        p: p.stat().st_mtime
+        for p in workdir.rglob("*.py")
+        if ".git" not in p.parts and ".remyx-recommendation" not in p.parts
+    }
+    touched = any(after.get(p, 0) > before.get(p, 0) for p in after)
+    if not touched:
+        log.warning("  ⚠ patch attempt: no .py files touched")
+        return False
+    log.info(f"  ✓ patch attempt applied edits — re-running fidelity")
+    return True
 
 
 def _build_fidelity_audit_prompt_paper_anchored(

--- a/tests/test_pin_method.py
+++ b/tests/test_pin_method.py
@@ -116,9 +116,9 @@ def test_pin_method_empty_query_returns_none(monkeypatch):
 def test_target_picks_up_pin_method_env(monkeypatch):
     monkeypatch.setenv("TARGET_REPO", "owner/name")
     monkeypatch.setenv("INPUT_INTEREST_ID", "00000000-0000-0000-0000-000000000000")
-    monkeypatch.setenv("INPUT_PIN_METHOD", "knowledge distillation")
+    monkeypatch.setenv("INPUT_SEARCH_METHOD", "knowledge distillation")
     target = run.build_target_from_env()
-    assert target.pin_method == "knowledge distillation"
+    assert target.search_method == "knowledge distillation"
     assert target.pin_arxiv == ""
 
 
@@ -126,7 +126,7 @@ def test_target_pin_arxiv_and_pin_method_both_default_empty(monkeypatch):
     monkeypatch.setenv("TARGET_REPO", "owner/name")
     monkeypatch.setenv("INPUT_INTEREST_ID", "00000000-0000-0000-0000-000000000000")
     target = run.build_target_from_env()
-    assert target.pin_method == ""
+    assert target.search_method == ""
     assert target.pin_arxiv == ""
 
 
@@ -137,7 +137,7 @@ def test_main_exits_when_both_pin_inputs_set(monkeypatch):
     monkeypatch.setenv("TARGET_REPO", "owner/name")
     monkeypatch.setenv("INPUT_INTEREST_ID", "00000000-0000-0000-0000-000000000000")
     monkeypatch.setenv("INPUT_PIN_ARXIV", "2410.20305v2")
-    monkeypatch.setenv("INPUT_PIN_METHOD", "knowledge distillation")
+    monkeypatch.setenv("INPUT_SEARCH_METHOD", "knowledge distillation")
     with pytest.raises(SystemExit) as exc:
         run.main()
     assert exc.value.code == 2
@@ -155,7 +155,7 @@ def test_pin_method_bypasses_discharge_filter(monkeypatch):
     monkeypatch.setenv(
         "INPUT_INTEREST_ID", "00000000-0000-0000-0000-000000000000"
     )
-    monkeypatch.setenv("INPUT_PIN_METHOD", "2410.20305v2")
+    monkeypatch.setenv("INPUT_SEARCH_METHOD", "2410.20305v2")
 
     # Resolve the pin to a synthetic asset
     asset = {

--- a/tests/test_pre_pr_fidelity.py
+++ b/tests/test_pre_pr_fidelity.py
@@ -1,0 +1,242 @@
+"""Pre-PR fidelity gate + branch-patch stage tests.
+
+Prototype for the fidelity-before-PR-publication redesign: fidelity runs
+on the local branch, and if flagged, a single Claude Code patch attempt
+tries to resolve the deviations before deciding whether to publish.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# --- _local_git_diff --------------------------------------------------------
+
+def test_local_git_diff_returns_stdout_on_success(tmp_path):
+    fake = subprocess.CompletedProcess(
+        args=[], returncode=0,
+        stdout="diff --git a/x b/x\n+added\n", stderr="",
+    )
+    with patch.object(run.subprocess, "run", return_value=fake):
+        got = run._local_git_diff(tmp_path, "main")
+    assert "added" in got
+
+
+def test_local_git_diff_returns_empty_on_nonzero(tmp_path):
+    fake = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="err")
+    with patch.object(run.subprocess, "run", return_value=fake):
+        got = run._local_git_diff(tmp_path, "main")
+    assert got == ""
+
+
+def test_local_git_diff_returns_empty_on_subprocess_error(tmp_path):
+    with patch.object(run.subprocess, "run", side_effect=OSError("boom")):
+        got = run._local_git_diff(tmp_path, "main")
+    assert got == ""
+
+
+# --- _run_pre_pr_fidelity_check ---------------------------------------------
+
+def _make_rec(arxiv_id="2606.30560v1"):
+    """Minimal Recommendation-shape stub for tests."""
+    rec = MagicMock()
+    rec.arxiv_id = arxiv_id
+    rec.paper_title = "Test Paper"
+    return rec
+
+
+def _make_target():
+    t = MagicMock()
+    t.repo = "org/repo"
+    t.claude_timeout_s = 900
+    return t
+
+
+def test_pre_pr_fidelity_skips_when_no_reference_url(tmp_path):
+    """No reference URL in the body → skip cleanly, no needs_judgment."""
+    rec = _make_rec()
+    target = _make_target()
+    with patch.object(run, "_extract_reference_url_from_pr_body",
+                      return_value=("2606.30560v1", "")):
+        verdict = run._run_pre_pr_fidelity_check(
+            rec, target, tmp_path, "PR title", "PR body with no ref", "main",
+        )
+    assert verdict["needs_judgment"] is False
+    assert verdict["status"] == "pre_pr_fidelity_skipped_no_reference"
+
+
+def test_pre_pr_fidelity_returns_needs_judgment_when_matrix_flags(tmp_path):
+    rec = _make_rec()
+    target = _make_target()
+    fake_matrix = {
+        "items": [
+            {"name": "algo mismatch", "status": "deviation (needs-judgment)",
+             "rationale": "..."},
+        ],
+        "needs_judgment": True,
+    }
+    with patch.object(run, "_extract_reference_url_from_pr_body",
+                      return_value=("2606.30560v1", "https://github.com/x/y")):
+        with patch.object(run, "_clone_reference_repo",
+                          return_value=(True, tmp_path / "ref", "")):
+            with patch.object(run, "_local_git_diff", return_value="fake diff"):
+                with patch.object(run, "_run_claude_oneshot",
+                                  return_value=(True, "{...}")):
+                    with patch.object(run, "_extract_json_object",
+                                      return_value=fake_matrix):
+                        with patch.object(run, "_render_coverage_matrix",
+                                          return_value="## Coverage\n..."):
+                            verdict = run._run_pre_pr_fidelity_check(
+                                rec, target, tmp_path, "T", "B", "main",
+                            )
+    assert verdict["needs_judgment"] is True
+    assert verdict["items_count"] == 1
+    assert verdict["status"] == "pre_pr_fidelity_needs_judgment"
+    assert verdict["matrix"] == fake_matrix
+
+
+def test_pre_pr_fidelity_returns_clean_when_matrix_not_flagged(tmp_path):
+    rec = _make_rec()
+    target = _make_target()
+    fake_matrix = {"items": [{"name": "x", "status": "covered"}], "needs_judgment": False}
+    with patch.object(run, "_extract_reference_url_from_pr_body",
+                      return_value=("2606.30560v1", "https://github.com/x/y")):
+        with patch.object(run, "_clone_reference_repo",
+                          return_value=(True, tmp_path / "ref", "")):
+            with patch.object(run, "_local_git_diff", return_value="fake diff"):
+                with patch.object(run, "_run_claude_oneshot",
+                                  return_value=(True, "{...}")):
+                    with patch.object(run, "_extract_json_object",
+                                      return_value=fake_matrix):
+                        with patch.object(run, "_render_coverage_matrix",
+                                          return_value=""):
+                            verdict = run._run_pre_pr_fidelity_check(
+                                rec, target, tmp_path, "T", "B", "main",
+                            )
+    assert verdict["needs_judgment"] is False
+    assert verdict["status"] == "pre_pr_fidelity_clean"
+
+
+def test_pre_pr_fidelity_degrades_when_reference_clone_fails(tmp_path):
+    rec = _make_rec()
+    target = _make_target()
+    with patch.object(run, "_extract_reference_url_from_pr_body",
+                      return_value=("2606.30560v1", "https://github.com/x/y")):
+        with patch.object(run, "_clone_reference_repo",
+                          return_value=(False, None, "network error")):
+            verdict = run._run_pre_pr_fidelity_check(
+                rec, target, tmp_path, "T", "B", "main",
+            )
+    assert verdict["needs_judgment"] is False
+    assert verdict["status"] == "pre_pr_fidelity_failed_clone"
+
+
+def test_pre_pr_fidelity_degrades_when_diff_empty(tmp_path):
+    rec = _make_rec()
+    target = _make_target()
+    with patch.object(run, "_extract_reference_url_from_pr_body",
+                      return_value=("2606.30560v1", "https://github.com/x/y")):
+        with patch.object(run, "_clone_reference_repo",
+                          return_value=(True, tmp_path / "ref", "")):
+            with patch.object(run, "_local_git_diff", return_value=""):
+                verdict = run._run_pre_pr_fidelity_check(
+                    rec, target, tmp_path, "T", "B", "main",
+                )
+    assert verdict["needs_judgment"] is False
+    assert verdict["status"] == "pre_pr_fidelity_failed_no_diff"
+
+
+def test_pre_pr_fidelity_degrades_when_claude_returns_unparseable(tmp_path):
+    rec = _make_rec()
+    target = _make_target()
+    with patch.object(run, "_extract_reference_url_from_pr_body",
+                      return_value=("2606.30560v1", "https://github.com/x/y")):
+        with patch.object(run, "_clone_reference_repo",
+                          return_value=(True, tmp_path / "ref", "")):
+            with patch.object(run, "_local_git_diff", return_value="diff"):
+                with patch.object(run, "_run_claude_oneshot",
+                                  return_value=(True, "garbage")):
+                    with patch.object(run, "_extract_json_object", return_value=None):
+                        verdict = run._run_pre_pr_fidelity_check(
+                            rec, target, tmp_path, "T", "B", "main",
+                        )
+    assert verdict["needs_judgment"] is False
+    assert verdict["status"] == "pre_pr_fidelity_failed_claude"
+
+
+# --- _attempt_pre_pr_fidelity_patch -----------------------------------------
+
+def test_patch_returns_false_when_no_flagged_items(tmp_path):
+    matrix = {"items": [{"name": "x", "status": "covered"}]}
+    assert run._attempt_pre_pr_fidelity_patch(
+        tmp_path, matrix, "https://github.com/x/y",
+    ) is False
+
+
+def test_patch_returns_false_when_matrix_empty(tmp_path):
+    assert run._attempt_pre_pr_fidelity_patch(
+        tmp_path, {}, "https://github.com/x/y",
+    ) is False
+
+
+def test_patch_returns_false_when_claude_fails(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "a.py").write_text("class Foo:\n    pass\n")
+    matrix = {
+        "items": [
+            {"name": "algo mismatch", "status": "deviation (needs-judgment)",
+             "rationale": "..."},
+        ],
+    }
+    with patch.object(run, "invoke_claude_code", return_value=(False, "err")):
+        got = run._attempt_pre_pr_fidelity_patch(
+            tmp_path, matrix, "https://github.com/x/y",
+        )
+    assert got is False
+
+
+def test_patch_returns_false_when_no_files_touched(tmp_path):
+    (tmp_path / "src").mkdir()
+    src_file = tmp_path / "src" / "a.py"
+    src_file.write_text("class Foo:\n    pass\n")
+    matrix = {
+        "items": [
+            {"name": "algo mismatch", "status": "deviation (needs-judgment)"},
+        ],
+    }
+    # Claude "succeeds" but doesn't actually modify any .py files
+    with patch.object(run, "invoke_claude_code", return_value=(True, "no edits")):
+        got = run._attempt_pre_pr_fidelity_patch(
+            tmp_path, matrix, "https://github.com/x/y",
+        )
+    assert got is False
+
+
+def test_patch_returns_true_when_files_touched(tmp_path):
+    import time
+    (tmp_path / "src").mkdir()
+    src_file = tmp_path / "src" / "a.py"
+    src_file.write_text("class Foo:\n    pass\n")
+
+    matrix = {
+        "items": [
+            {"name": "algo mismatch", "status": "deviation (needs-judgment)"},
+        ],
+    }
+    def fake_claude(workdir, timeout_s=None):
+        time.sleep(0.05)  # ensure mtime moves
+        src_file.write_text("class Foo:\n    def new_method(self): pass\n")
+        return (True, "edited")
+    with patch.object(run, "invoke_claude_code", side_effect=fake_claude):
+        got = run._attempt_pre_pr_fidelity_patch(
+            tmp_path, matrix, "https://github.com/x/y",
+        )
+    assert got is True
+    assert (tmp_path / ".remyx-recommendation" / "FIDELITY_REMEDIATION.md").exists()

--- a/tests/test_pre_pr_fidelity.py
+++ b/tests/test_pre_pr_fidelity.py
@@ -239,4 +239,7 @@ def test_patch_returns_true_when_files_touched(tmp_path):
             tmp_path, matrix, "https://github.com/x/y",
         )
     assert got is True
-    assert (tmp_path / ".remyx-recommendation" / "FIDELITY_REMEDIATION.md").exists()
+    # Brief is written to INVOCATION.md (what invoke_claude_code reads at startup).
+    invoc = tmp_path / ".remyx-recommendation" / "INVOCATION.md"
+    assert invoc.exists()
+    assert "Fidelity remediation brief" in invoc.read_text()

--- a/tests/test_run_telemetry.py
+++ b/tests/test_run_telemetry.py
@@ -174,8 +174,8 @@ def test_preflight_and_routing_fields(monkeypatch):
     res = _result(
         preflight_decision="ISSUE",
         audit_anchor="reference",
-        pin_method="2606.27369v1",
-        pin_method_resolution="2606.27369v1",
+        search_method="2606.27369v1",
+        search_method_resolution="2606.27369v1",
         selection_proposed_call_site="src/foo.py:12",
         selection_team_direction_signal="rfc_issue",
         selection_contract_match=True,
@@ -188,8 +188,8 @@ def test_preflight_and_routing_fields(monkeypatch):
     body = calls[0][1]
     assert body["preflight_decision"] == "ISSUE"
     assert body["audit_anchor"] == "reference"
-    assert body["pin_method"] == "2606.27369v1"
-    assert body["pin_method_resolution"] == "2606.27369v1"
+    assert body["search_method"] == "2606.27369v1"
+    assert body["search_method_resolution"] == "2606.27369v1"
     assert body["selection_proposed_call_site"] == "src/foo.py:12"
     assert body["selection_team_direction_signal"] == "rfc_issue"
     assert body["selection_contract_match"] is True
@@ -359,7 +359,7 @@ def test_new_fields_default_to_null_on_skipped_run(monkeypatch):
     null_fields = [
         "agent", "model_backend", "cost_basis",
         "envelopes_without_usage", "num_turns", "cache_read_input_tokens",
-        "preflight_decision", "audit_anchor", "pin_method",
+        "preflight_decision", "audit_anchor", "search_method",
         "selection_proposed_call_site", "selection_external_arxiv_id",
         "chain", "self_review", "draft_dropped", "test_integration_gate",
         "stub_density", "integration_violations", "diff_risk_band",


### PR DESCRIPTION
Ships the pipeline redesign that moves fidelity from post-PR to pre-PR — fabricated drafts never become public artifacts.

## What changes

- **Pre-PR fidelity check** on the local branch (before PR opens) — clones the paper's reference repo and audits the draft's diff against it.
- **Branch-patch stage** — when fidelity flags fabrication, invokes a bounded Claude Code session with the coverage matrix as brief; re-runs fidelity on the patched branch.
- **Skip publication** when the patch attempt fails to resolve flagged deviations — no PR opened, no maintainer notification (`skipped_fidelity_fabrication_after_patch`).
- **pin-arxiv fast-path** — fetches the pinned paper directly from Remyx assets, skips the ranker pool entirely. Bypasses expensive audit + refine-query passes when the intent is "use THIS paper."
- **Input rename `pin-method` → `search-method`** — two verbs, unambiguous semantics: `pin-arxiv` for exact papers, `search-method` for free-text queries.
- **HF Hub checkpoint preflight** + **cocoindex convention precedents** (from earlier commits on this branch) — kept intact.

## Validation

Five iterative dispatches against smellslikeml/vllm's TraceLab fabrication case, each surfacing one bug in the prototype and confirming its fix:

| Run | Path exercised | Result |
|---|---|---|
| #1 | pin-arxiv fast-path + patch-brief write | INVOCATION.md crash → fixed |
| #2 | Patch stage + second commit_and_push | Safety-guard trip → fixed |
| #3 | Full pipeline through re-fidelity | Non-fast-forward push → fixed |
| #4 | Same as #3, first three fixes | Anthropic credit exhausted (infra) |
| #5 | CLI-branch dispatch, GLM backend | `issue_opened_preflight` — clean via issue-convention path |

All 858 tests green.

## Breaking change

Renames `pin-method:` action input → `search-method:`. Existing fork workflows referencing `pin-method:` will silently no-op the pin. Mass-update script prepared for the ~59 smellslikeml/* forks.