### PR TITLE
Two-tier drafter/refiner setup as recommended default

### DIFF
--- a/.github/workflows/outrider-daily.yml
+++ b/.github/workflows/outrider-daily.yml
@@ -1,19 +1,26 @@
-name: Outrider daily (branch-mode, GLM)
+name: Outrider daily (branch-mode, drafter)
 
-# Continuous exploration companion to outrider.yml. Dispatches once daily
-# under publish=branch on the z.ai GLM backend — no PR, no Issue, no
-# maintainer notification. Preflight-passed candidates land as fork branches
-# that the team reviews at its own cadence. Complementary to the weekly
-# Anthropic Opus run in outrider.yml, which stays the committed-tier
-# deployment.
+# Drafter role in the two-tier setup: high-frequency, cheap-model
+# exploration. Publishes as branch — no PR/Issue, no maintainer signal.
+# Every dispatch accumulates repo_intel.yaml (observed_landing_zones,
+# rejected_shapes, prior dispatches). Complements outrider-weekly-refine.yml
+# which promotes one of the accumulated branches to a ready-for-review PR
+# with layered context (start-from-ref + gap-analysis as lead-content +
+# staged-synthesis + Opus).
+#
+# Default: Anthropic Claude Haiku 4.5 (cheap, well-suited for extension-
+# point discovery + structural first drafts). Set ANTHROPIC_MODEL to
+# claude-sonnet-4-6 for higher-quality drafts, or wire the z.ai path per
+# docs/backends.md to use GLM-5.2 instead (both providers work; Anthropic
+# is the single-vendor default for onboarding simplicity).
 
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 6 * * *'   # daily 06:00 UTC; adjust cadence to workload
   workflow_dispatch: {}
 
 concurrency:
-  group: outrider-daily
+  group: outrider-drafter
   cancel-in-progress: false
 
 jobs:
@@ -25,12 +32,18 @@ jobs:
       issues: write
     env:
       REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
-      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ZAI_API_KEY }}
-      ANTHROPIC_MODEL: glm-5.2
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      ANTHROPIC_MODEL: claude-haiku-4-5
     steps:
       - uses: actions/checkout@v4
       - uses: ./
         with:
           interest-id: '29ca03e7-454d-446c-9941-32c96c53d95d'
           publish: branch
-          model-base-url: 'https://api.z.ai/api/anthropic'
+          # Drafter's distinctive defaults: accumulate intel, skip the
+          # research phase. Research is proportionate for the refiner
+          # (~$1-2 per dispatch, weekly cadence) but wastes cost at the
+          # drafter's daily frequency (~$28-56/week/fork extra vs the
+          # ~$8/week baseline drafter spend).
+          maintain-state: 'true'
+          staged-synthesis: 'false'

--- a/.github/workflows/outrider-weekly-refine.yml
+++ b/.github/workflows/outrider-weekly-refine.yml
@@ -1,0 +1,208 @@
+name: Outrider weekly refine
+
+# Refiner role in the two-tier setup: low-frequency, capable-model
+# commitment. Reviews the past week's drafter output, picks the strongest
+# candidate, generates a targeted gap analysis, and dispatches an Opus
+# refinement pass with the gap analysis piped in as lead-content. The
+# refinement's chain (fidelity → convention → test) runs inline; terminal
+# artifact is a ready-for-review draft PR.
+#
+# Companion to outrider-daily.yml (the drafter). This workflow does the
+# selection + spec authorship + dispatch; the refinement itself runs via
+# outrider.yml (mode=recommend + pin-arxiv + start-from-ref + lead-content).
+#
+# Requires ANTHROPIC_API_KEY for the gap-analysis LLM call and the
+# downstream refinement dispatch. Linear connector is optional — this
+# workflow passes the gap analysis inline as raw markdown, no Linear
+# write side needed.
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'   # Mondays 12:00 UTC — after weekend accumulates
+  workflow_dispatch:
+    inputs:
+      lookback-days:
+        description: 'Days to look back for drafter branches (default 7).'
+        required: false
+        default: '7'
+      pick-override:
+        description: 'Optional branch name to pick, bypassing the heuristic. Useful for testing before a full week accumulates.'
+        required: false
+        default: ''
+
+concurrency:
+  group: outrider-refiner
+  cancel-in-progress: false
+
+jobs:
+  refine:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write        # to dispatch outrider.yml
+      pull-requests: read   # to check whether candidates are already promoted
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Pick candidate from past week's drafter output
+        id: pick
+        run: |
+          set -euo pipefail
+          LOOKBACK_DAYS="${{ inputs.lookback-days || '7' }}"
+          OVERRIDE="${{ inputs.pick-override || '' }}"
+          REPO="${GITHUB_REPOSITORY}"
+
+          if [ -n "$OVERRIDE" ]; then
+            echo "→ pick override: $OVERRIDE"
+            BRANCH="$OVERRIDE"
+          else
+            # Enumerate branches newer than the lookback window, skip main
+            # + refined/promotion-suffixed branches. Prefer most-recent.
+            SINCE=$(date -u -d "$LOOKBACK_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)
+            BRANCH=$(gh api "repos/$REPO/branches?per_page=100" \
+              --jq --arg since "$SINCE" '
+                .[]
+                | select(.name != "main" and (.name | endswith("-refined-v2") | not))
+                | select(.name | test("(-refined|^refined|/refined|^remyx-recommendation/)"; "i") | not)
+                | .name' \
+              | while read -r name; do
+                  # Pull last-commit date from the branch head; keep only branches
+                  # created/updated within the lookback window
+                  DATE=$(gh api "repos/$REPO/branches/$name" \
+                    --jq '.commit.commit.committer.date' 2>/dev/null || echo "")
+                  if [ -n "$DATE" ] && [ "$DATE" \> "$SINCE" ]; then
+                    echo "$DATE $name"
+                  fi
+                done \
+              | sort -r | head -1 | awk '{print $2}')
+          fi
+
+          if [ -z "$BRANCH" ]; then
+            echo "::warning::No candidate branches in past $LOOKBACK_DAYS days on $REPO"
+            echo "picked=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Skip if an open PR already targets this branch (idempotency)
+          OPEN_PR=$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$OPEN_PR" ]; then
+            echo "::warning::Branch $BRANCH already has open PR #$OPEN_PR; skipping"
+            echo "picked=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Pull arxiv_id from the branch's SPEC.md (deposited by the drafter's coding session)
+          ARXIV=$(gh api "repos/$REPO/contents/.remyx-recommendation/SPEC.md?ref=$BRANCH" \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
+            | grep -oE 'arxiv[_ ]?id[^0-9]*[0-9]+\.[0-9]+(v[0-9]+)?' \
+            | head -1 | grep -oE '[0-9]+\.[0-9]+(v[0-9]+)?' || echo "")
+
+          echo "→ picked branch: $BRANCH"
+          echo "→ arxiv: ${ARXIV:-<unresolved>}"
+          echo "picked=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "arxiv=$ARXIV" >> "$GITHUB_OUTPUT"
+
+      - name: Generate gap analysis for the picked candidate
+        id: gap
+        if: steps.pick.outputs.picked != ''
+        env:
+          BRANCH: ${{ steps.pick.outputs.picked }}
+          ARXIV: ${{ steps.pick.outputs.arxiv }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PYEOF' > gap_analysis.md
+          import json, os, urllib.request, subprocess
+
+          repo = os.environ["REPO"]
+          branch = os.environ["BRANCH"]
+          arxiv = os.environ.get("ARXIV", "")
+
+          # Diff summary — files touched by the branch vs main
+          diff = subprocess.check_output([
+              "gh", "api", f"repos/{repo}/compare/main...{branch}",
+              "--jq", "[.files[] | {status, additions, deletions, path: .filename}]"
+          ], text=True).strip()
+
+          # Paper title from arxiv (if available)
+          paper_title = "(unknown)"
+          if arxiv:
+              try:
+                  req = urllib.request.Request(f"https://export.arxiv.org/api/query?id_list={arxiv}")
+                  body = urllib.request.urlopen(req, timeout=15).read().decode()
+                  import re
+                  m = re.search(r"<title>([^<]+)</title>", body)
+                  if m and "arXiv.org" not in m.group(1):
+                      paper_title = m.group(1).strip().replace("\n", " ")
+              except Exception:
+                  pass
+
+          prompt = f"""You are auditing an Outrider-drafted GLM branch against its source paper before an Opus refinement pass. Produce a structured gap analysis matching this exact template:
+
+- Lead paragraph: what the branch attempted vs what the paper actually specifies (2-3 sentences)
+- ## Gap N — <short title>
+    - **File:** path:line
+    - **Current:** what the code does now
+    - **Paper (arxiv:{arxiv}):** what the paper specifies
+    - **Fix:** the specific replacement/addition needed
+- Repeat per gap
+- ## Acceptance criteria (bulleted list of verifiable outcomes)
+
+Focus on MECHANISM-LEVEL divergences (wrong math, invented heuristics, missing paper rules, category errors) — not stylistic. If the branch is faithful, say so and list only cosmetic items.
+
+Branch: {branch}
+Paper: {paper_title} (arxiv:{arxiv})
+Files touched:
+{diff}
+
+Now read the paper (arxiv HTML at https://arxiv.org/html/{arxiv}) and compare against the actual branch code (repo {repo}, ref {branch}). Emit the gap analysis in markdown."""
+
+          req = urllib.request.Request(
+              "https://api.anthropic.com/v1/messages",
+              data=json.dumps({
+                  "model": "claude-sonnet-4-6",
+                  "max_tokens": 4096,
+                  "messages": [{"role": "user", "content": prompt}],
+              }).encode(),
+              headers={
+                  "Content-Type": "application/json",
+                  "x-api-key": os.environ["ANTHROPIC_API_KEY"],
+                  "anthropic-version": "2023-06-01",
+              },
+              method="POST",
+          )
+          resp = urllib.request.urlopen(req, timeout=120).read()
+          data = json.loads(resp)
+          print(data["content"][0]["text"])
+          PYEOF
+
+          echo "→ gap analysis (first 400 chars):"
+          head -c 400 gap_analysis.md
+          echo ""
+          # Multi-line output for step outputs
+          {
+            echo 'markdown<<GAP_EOF'
+            cat gap_analysis.md
+            echo 'GAP_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch Opus refinement
+        if: steps.pick.outputs.picked != '' && steps.gap.outputs.markdown != ''
+        env:
+          BRANCH: ${{ steps.pick.outputs.picked }}
+          ARXIV: ${{ steps.pick.outputs.arxiv }}
+          GAP: ${{ steps.gap.outputs.markdown }}
+        run: |
+          set -euo pipefail
+          gh workflow run outrider.yml \
+            --ref main \
+            -f mode=recommend \
+            -f provider=anthropic \
+            -f model=claude-opus-4-8 \
+            -f pin-arxiv="$ARXIV" \
+            -f start-from-ref="$BRANCH" \
+            -f lead-content="$GAP" \
+            -f staged-synthesis=true \
+            -f publish=pr
+          echo "→ dispatched Opus refinement on $BRANCH (arxiv:$ARXIV)"

--- a/.github/workflows/outrider-weekly-refine.yml
+++ b/.github/workflows/outrider-weekly-refine.yml
@@ -29,6 +29,10 @@ on:
         description: 'Optional branch name to pick, bypassing the heuristic. Useful for testing before a full week accumulates.'
         required: false
         default: ''
+      pick-override-arxiv:
+        description: 'Optional arxiv_id to pair with pick-override when the branch does not have a resolvable arxiv (SPEC.md is a runtime artifact, not persisted on the branch).'
+        required: false
+        default: ''
 
 concurrency:
   group: outrider-refiner
@@ -51,6 +55,7 @@ jobs:
           set -euo pipefail
           LOOKBACK_DAYS="${{ inputs.lookback-days || '7' }}"
           OVERRIDE="${{ inputs.pick-override || '' }}"
+          OVERRIDE_ARXIV="${{ inputs.pick-override-arxiv || '' }}"
           REPO="${GITHUB_REPOSITORY}"
 
           if [ -n "$OVERRIDE" ]; then
@@ -92,14 +97,31 @@ jobs:
             exit 0
           fi
 
-          # Pull arxiv_id from the branch's SPEC.md (deposited by the drafter's coding session)
-          ARXIV=$(gh api "repos/$REPO/contents/.remyx-recommendation/SPEC.md?ref=$BRANCH" \
-            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
-            | grep -oE 'arxiv[_ ]?id[^0-9]*[0-9]+\.[0-9]+(v[0-9]+)?' \
-            | head -1 | grep -oE '[0-9]+\.[0-9]+(v[0-9]+)?' || echo "")
+          # Resolve arxiv_id, in order of source reliability:
+          #   1. Explicit override input (unambiguous)
+          #   2. Intel yaml's observed_landing_zones (drafter writes it on landing)
+          #   3. Empty (LLM gap analysis handles unresolved case; downstream refinement
+          #      still needs a value, so we surface the miss to the operator)
+          if [ -n "$OVERRIDE_ARXIV" ]; then
+            ARXIV="$OVERRIDE_ARXIV"
+          else
+            ARXIV=$(gh api "repos/$REPO/contents/.remyx/repo_intel.yaml?ref=main" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
+              | awk -v b="$BRANCH" '
+                  /confirmed_by:/ {in_cb=1; next}
+                  in_cb && /arxiv:/ {arxiv=$2; gsub(/^[ ]*|[ ]*$/, "", arxiv)}
+                  in_cb && /branch:/ {branch=$2; gsub(/^[ ]*|[ ]*$/, "", branch); if (branch == b) {print arxiv; exit}}
+                  /^[^ ]/ {in_cb=0}
+                ' || echo "")
+          fi
 
           echo "→ picked branch: $BRANCH"
           echo "→ arxiv: ${ARXIV:-<unresolved>}"
+
+          if [ -z "$ARXIV" ]; then
+            echo "::error::arxiv_id could not be resolved for branch $BRANCH (checked intel yaml + override). Re-dispatch with pick-override-arxiv=<id>."
+            exit 1
+          fi
           echo "picked=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "arxiv=$ARXIV" >> "$GITHUB_OUTPUT"
 
@@ -113,57 +135,51 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PYEOF' > gap_analysis.md
-          import json, os, urllib.request, subprocess
+          import json, os, re, subprocess, textwrap, urllib.request
 
           repo = os.environ["REPO"]
           branch = os.environ["BRANCH"]
           arxiv = os.environ.get("ARXIV", "")
 
-          # Diff summary — files touched by the branch vs main
           diff = subprocess.check_output([
               "gh", "api", f"repos/{repo}/compare/main...{branch}",
               "--jq", "[.files[] | {status, additions, deletions, path: .filename}]"
           ], text=True).strip()
 
-          # Paper title from arxiv (if available)
           paper_title = "(unknown)"
           if arxiv:
               try:
                   req = urllib.request.Request(f"https://export.arxiv.org/api/query?id_list={arxiv}")
                   body = urllib.request.urlopen(req, timeout=15).read().decode()
-                  import re
                   m = re.search(r"<title>([^<]+)</title>", body)
                   if m and "arXiv.org" not in m.group(1):
                       paper_title = m.group(1).strip().replace("\n", " ")
               except Exception:
                   pass
 
-          prompt = f"""You are auditing an Outrider-drafted GLM branch against its source paper before an Opus refinement pass. Produce a structured gap analysis matching this exact template:
+          prompt_body = textwrap.dedent(f"""
+              You are auditing an Outrider-drafted GLM branch against its source paper before an Opus refinement pass. Produce a structured gap-analysis markdown with this shape:
 
-- Lead paragraph: what the branch attempted vs what the paper actually specifies (2-3 sentences)
-- ## Gap N — <short title>
-    - **File:** path:line
-    - **Current:** what the code does now
-    - **Paper (arxiv:{arxiv}):** what the paper specifies
-    - **Fix:** the specific replacement/addition needed
-- Repeat per gap
-- ## Acceptance criteria (bulleted list of verifiable outcomes)
+              * Lead paragraph naming what the branch attempted vs what the paper actually specifies (2-3 sentences)
+              * A section per gap: `## Gap N — <short title>` with fields for File (path:line), Current behavior, Paper (arxiv:{arxiv}) specification, and the specific Fix.
+              * Final `## Acceptance criteria` bulleted list of verifiable outcomes.
 
-Focus on MECHANISM-LEVEL divergences (wrong math, invented heuristics, missing paper rules, category errors) — not stylistic. If the branch is faithful, say so and list only cosmetic items.
+              Focus on MECHANISM-LEVEL divergences (wrong math, invented heuristics, missing paper rules, category errors) — not stylistic. If the branch is faithful, say so and list only cosmetic items.
 
-Branch: {branch}
-Paper: {paper_title} (arxiv:{arxiv})
-Files touched:
-{diff}
+              Branch: {branch}
+              Paper: {paper_title} (arxiv:{arxiv})
+              Files touched:
+              {diff}
 
-Now read the paper (arxiv HTML at https://arxiv.org/html/{arxiv}) and compare against the actual branch code (repo {repo}, ref {branch}). Emit the gap analysis in markdown."""
+              Read the paper (arxiv HTML at https://arxiv.org/html/{arxiv}) and compare against the actual branch code (repo {repo}, ref {branch}). Emit the gap analysis in markdown.
+              """).strip()
 
           req = urllib.request.Request(
               "https://api.anthropic.com/v1/messages",
               data=json.dumps({
                   "model": "claude-sonnet-4-6",
                   "max_tokens": 4096,
-                  "messages": [{"role": "user", "content": prompt}],
+                  "messages": [{"role": "user", "content": prompt_body}],
               }).encode(),
               headers={
                   "Content-Type": "application/json",
@@ -196,6 +212,7 @@ Now read the paper (arxiv HTML at https://arxiv.org/html/{arxiv}) and compare ag
         run: |
           set -euo pipefail
           gh workflow run outrider.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref main \
             -f mode=recommend \
             -f provider=anthropic \

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -119,7 +119,39 @@ When the agent is choosing among candidates, it has these read-only tools at han
 These tools are what make selection "structural fit" rather than keyword match.
 
 
-## 5. Common customization recipes
+## 5. Two-tier drafter / refiner setup (recommended default)
+
+Outrider ships with two companion workflow templates that split exploration and commitment across two schedules and two model tiers. This is the recommended shape for any repo you want the pipeline to run continuously on.
+
+### The two roles
+
+| Role | Cadence | Model | Publish | Distinctive defaults | Cost/run |
+|---|---|---|---|---|---|
+| **Drafter** ([`outrider-daily.yml`](../.github/workflows/outrider-daily.yml)) | Daily (or `*/15` for high frequency) | Anthropic Claude Haiku 4.5 | `branch` — no PR/Issue | `maintain-state=true`, `staged-synthesis=false` | ~$0.20-0.40 |
+| **Refiner** ([`outrider-weekly-refine.yml`](../.github/workflows/outrider-weekly-refine.yml)) | Weekly (Monday noon UTC) | Anthropic Claude Opus 4.8 | `pr` — opens draft PR + chain | `maintain-state=true`, `staged-synthesis=true` | ~$5-10 (incl. gap-gen + chain) |
+
+The drafter accumulates a pool of branches through the arxiv frontier — every dispatch adds an `observed_landing_zone` or `rejected_shape` to `.remyx/repo_intel.yaml`. The refiner picks one candidate from that pool each week, generates a targeted gap analysis via Sonnet 4.6, and dispatches an Opus refinement with the gap analysis piped in as `lead-content`. The refinement's chain (fidelity → convention → test) runs inline; terminal artifact is a ready-for-review draft PR.
+
+### Why the split
+
+- **Higher commit-to-PR rate on borderline cases.** With a drafter branch already anchoring the extension point + test scaffolding + landing-zone shape, Opus's preflight has more grounding to commit to PR-shape rather than defer to Issue.
+- **Cheap exploration of the arxiv frontier.** Daily drafter dispatches sample from an ever-growing candidate pool (arxiv adds ~200 ML papers/day); a single-shot refiner-only setup would need spec-generation to substitute for that breadth, and spec generators saturate on any given paper × repo pair while the arxiv corpus keeps growing.
+- **Compounding intel accumulation.** Even failed drafter branches (category errors, no-code-link candidates) contribute negative-space signal to `repo_intel.yaml` — future preflight decisions benefit from the accumulated observed / rejected shape history.
+
+### Onboarding
+
+Requires one secret: `ANTHROPIC_API_KEY`. Optional: `LINEAR_API_KEY` for the durable-state pattern (refiner can file gap analyses as Linear issues and read them back via URL), but the default setup passes the gap analysis inline as raw markdown so no Linear provisioning is needed.
+
+For customers with existing z.ai credits or Anthropic-outage hedging needs, either role can be routed at a different backend via `model-base-url` — see [`backends.md`](backends.md).
+
+### Manual triggers for testing
+
+Both workflows expose `workflow_dispatch` so you can run either role on demand:
+- Drafter: any workflow dispatch produces one branch immediately (bypasses the cron)
+- Refiner: `pick-override=<branch-name>` selects a specific branch, `pick-override-arxiv=<id>` provides the arxiv when it can't be resolved from `repo_intel.yaml` (useful before the drafter has landed a full week of dispatches)
+
+
+## 5.1. Common customization recipes
 
 | Goal | Set this |
 |---|---|


### PR DESCRIPTION
## Summary

Adds the two-tier drafter/refiner workflow pattern as the recommended default configuration for Outrider. Companion workflow templates + docs.

**Drafter** (`outrider-daily.yml`): high-frequency, publish=branch, Anthropic Haiku 4.5 default (previously z.ai/GLM-5.2 hardcoded). Distinctive defaults: `maintain-state=true`, `staged-synthesis=false`.

**Refiner** (`outrider-weekly-refine.yml`, new): weekly cron + workflow_dispatch. Three steps in one job — pick candidate from past 7 days of drafter output, generate targeted gap analysis via Sonnet 4.6, dispatch Opus refinement with the gap analysis piped in as `lead-content` (no Linear write side needed for the initial version — passed inline as raw markdown).

**Docs**: new Section 5 in `docs/customization.md` covers the two-tier setup — roles, cadences, distinctive defaults, single-vendor onboarding.

## E2E validation

Tested end-to-end on `smellslikeml/atropos` (run [29367168137](https://github.com/smellslikeml/atropos/actions/runs/29367168137)):

- Refiner picked EnvRL branch via `pick-override`, resolved arxiv `2606.17680v1` via `pick-override-arxiv`
- Sonnet 4.6 gap analysis (~$0.10) correctly identified the category error autonomously (matches manual gap analysis from earlier session — same diagnosis, same root cause)
- Downstream Opus dispatch preflight-routed to Issue #17 (correct call given the architectural mismatch: paper's mechanism is auxiliary CE losses in the trainer, atropos exposes only `reward_fns/`)
- `issue_convention_aligned` recast the Issue body to atropos's Feature-request template

Total pipeline: ~$1.55, ~10 min end-to-end.

## Three bugs discovered + fixed during E2E

1. YAML block-scalar parse: Python heredoc lines starting with `-` at column 0 broke the `run: |` block. Fixed with `textwrap.dedent` + starred bullets.
2. arxiv_id resolution: `SPEC.md` isn't committed to the branch (runtime artifact only). Resolve from `.remyx/repo_intel.yaml`'s `observed_landing_zones` or via new `pick-override-arxiv` input.
3. `gh workflow run` needed `--repo` when the runner has no local checkout.

## Not in this PR

- Linear `file_issue` write side of the connector — deferred; refiner passes gap analysis inline. Enables durable-state pattern for teams that want it (opt-in follow-up).
- `mode=promote-branch` (REMYX-214) — nice-to-have consolidation of the existing chain-phase modes; not blocking (chain runs inline in the refinement dispatch already).
- Engine-side dispatcher (REMYX-108) — fork-side YAML is fine for initial rollout.

## Test plan

- [x] YAML parses via PyYAML + GitHub Actions accepts workflow_dispatch trigger
- [x] Refiner E2E on atropos: pick → gap-gen → dispatch → chain
- [x] Autonomous gap analysis (Sonnet 4.6) reproduces manual gap-analysis quality on EnvRL
- [x] Preflight correctly routes to Issue for architectural-mismatch candidates
- [x] `issue_convention_aligned` chain phase runs post-v1.7.27 without crashing