### PR TITLE
fix(refiner): resolve arxiv_id and forward runner inputs for two-tier refinement

### DIFF
--- a/.github/workflows/outrider-weekly-refine.yml
+++ b/.github/workflows/outrider-weekly-refine.yml
@@ -126,7 +126,7 @@ jobs:
               --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
               | awk -v b="$BRANCH" '
                   /confirmed_by:/ {in_cb=1; next}
-                  in_cb && /arxiv:/ {arxiv=$2; gsub(/^[ ]*|[ ]*$/, "", arxiv)}
+                  in_cb && /arxiv:/ {arxiv=$NF; gsub(/^[ ]*|[ ]*$/, "", arxiv)}
                   in_cb && /branch:/ {branch=$2; gsub(/^[ ]*|[ ]*$/, "", branch); if (branch == b) {print arxiv; exit}}
                   /^[^ ]/ {in_cb=0}
                 ' || echo "")
@@ -135,8 +135,8 @@ jobs:
           echo "→ picked branch: $BRANCH"
           echo "→ arxiv: ${ARXIV:-<unresolved>}"
 
-          if [ -z "$ARXIV" ]; then
-            echo "::error::arxiv_id could not be resolved for branch $BRANCH (checked intel yaml + override). Re-dispatch with pick-override-arxiv=<id>."
+          if ! printf '%s' "$ARXIV" | grep -qE '^(arxiv:)?[0-9]{4}\.[0-9]{4,5}(v[0-9]+)?$'; then
+            echo "::error::arxiv_id could not be resolved to a valid id for branch $BRANCH (checked intel yaml + override). Re-dispatch with pick-override-arxiv=<id>."
             exit 1
           fi
           echo "picked=$BRANCH" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/outrider.yml
+++ b/.github/workflows/outrider.yml
@@ -11,6 +11,26 @@ on:
         description: 'pr (default) or branch — under branch mode, produces a fork branch without opening PR/Issue.'
         required: false
         default: 'pr'
+      # Declared so outrider-weekly-refine.yml (the refiner) can dispatch this
+      # runner: it pins a picked draft branch (start-from-ref), pipes a gap
+      # analysis in (lead-content), and turns on staged synthesis. Defaults
+      # match the action's own, so scheduled/manual runs are unchanged.
+      mode:
+        description: 'Run mode (recommend by default). The refiner dispatches recommend against a pinned paper + start-from-ref.'
+        required: false
+        default: 'recommend'
+      start-from-ref:
+        description: 'Optional base branch to build on top of (the refiner passes the picked drafter branch). Empty = default branch.'
+        required: false
+        default: ''
+      lead-content:
+        description: 'Optional inline markdown (e.g. a gap analysis) fed to the agent as leading context.'
+        required: false
+        default: ''
+      staged-synthesis:
+        description: 'Enable the multi-pass staged-synthesis flow (the refiner sets true). Empty/false = single-pass.'
+        required: false
+        default: 'false'
       provider:
         description: 'anthropic (default) or zai for GLM.'
         type: choice
@@ -73,4 +93,9 @@ jobs:
           github-token: ${{ steps.remyx-bot.outputs.token }}
           pin-arxiv: ${{ inputs.pin-arxiv }}
           publish: ${{ inputs.publish }}
+          # Forwarded so outrider-weekly-refine.yml can dispatch a refinement run.
+          mode: ${{ inputs.mode }}
+          start-from-ref: ${{ inputs.start-from-ref }}
+          lead-content: ${{ inputs.lead-content }}
+          staged-synthesis: ${{ inputs.staged-synthesis }}
           model-base-url: ${{ inputs.provider == 'zai' && 'https://api.z.ai/api/anthropic' || '' }}


### PR DESCRIPTION
## Summary

Two fixes so a two-tier refiner dispatch (`outrider-weekly-refine.yml` -> `outrider.yml`) opens a refinement PR end to end.

**1. `outrider.yml`: declare the refiner-dispatched inputs.** The refiner dispatches the runner with `mode`, `start-from-ref`, `lead-content`, and `staged-synthesis`, but the runner declared only `pin-arxiv`/`publish`/`provider`/`model`. GitHub rejects unknown `workflow_dispatch` keys, so the dispatch step failed with no refinement run. This declares and forwards the four inputs. Defaults match `action.yml` (`mode=recommend`, `start-from-ref=''`, `lead-content=''`, `staged-synthesis=false`), so scheduled and manual runs are unchanged.

**2. `outrider-weekly-refine.yml`: resolve `arxiv_id` from `repo_intel`.** The `confirmed_by` entries in `.remyx/repo_intel.yaml` are YAML list items (`- arxiv: <id>`), so the resolution `awk`'s `$2` matched the `arxiv:` label instead of the id. The refiner then dispatched the runner with an empty `pin-arxiv`, which skipped as `skipped_pin_arxiv_not_found` and opened no PR while the workflow still reported success. This reads the id with `$NF` and validates that the resolved value is arxiv-shaped, so a bad extraction fails at the resolution gate instead of dispatching an empty pin.

## Tests

- `$NF` extraction against real `repo_intel.yaml` `confirmed_by` blocks: `$2` returns `arxiv:`, `$NF` returns the id (e.g. `2607.08535v1`).
- Shape guard accepts valid ids (`2407.11660v1`, `2607.05391`) and rejects `arxiv:`, empty, and non-arxiv strings.
- Two-tier refiner dispatch: resolves the picked branch's arxiv and dispatches `outrider.yml` with a valid `pin-arxiv` (previously dispatched empty and skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)