### PR TITLE
feat(backends): Moonshot support + per-model rate table + provider action input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -579,6 +579,15 @@ runs:
         INPUT_MODEL_BASE_URL: ${{ inputs.model-base-url }}
       run: |
         set -eu
+        # Mutual-exclusion enforcement: callers typically pass every backend's
+        # secret via the top-level env block ({ANTHROPIC,ZAI,MOONSHOT}_API_KEY
+        # all set) so `provider` can be dispatch-time-switchable. Per the
+        # docs/backends.md auth-header matrix, having both ANTHROPIC_API_KEY
+        # and ANTHROPIC_AUTH_TOKEN set makes Claude Code prefer x-api-key —
+        # which non-Anthropic backends reject with 401. Each branch below
+        # clears the non-selected auth var to $GITHUB_ENV (empty string,
+        # which Claude Code and the CLI's auth validator both treat as
+        # unset for the mutual-exclusion check).
         case "$INPUT_PROVIDER" in
           anthropic)
             if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
@@ -586,6 +595,7 @@ runs:
               exit 1
             fi
             # ANTHROPIC_API_KEY is already in the parent env — no override needed
+            echo "ANTHROPIC_AUTH_TOKEN=" >> "$GITHUB_ENV"
             ;;
           zai)
             if [ -z "${ZAI_API_KEY:-}" ]; then
@@ -593,6 +603,7 @@ runs:
               exit 1
             fi
             echo "ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY" >> "$GITHUB_ENV"
+            echo "ANTHROPIC_API_KEY=" >> "$GITHUB_ENV"
             echo "ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic" >> "$GITHUB_ENV"
             ;;
           moonshot)
@@ -601,6 +612,7 @@ runs:
               exit 1
             fi
             echo "ANTHROPIC_AUTH_TOKEN=$MOONSHOT_API_KEY" >> "$GITHUB_ENV"
+            echo "ANTHROPIC_API_KEY=" >> "$GITHUB_ENV"
             echo "ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic" >> "$GITHUB_ENV"
             ;;
           custom)
@@ -612,7 +624,8 @@ runs:
               echo "::error::provider=custom requires ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN in the caller's env block" >&2
               exit 1
             fi
-            # model-base-url passes through via INPUT_MODEL_BASE_URL to run.py
+            # model-base-url passes through via INPUT_MODEL_BASE_URL to run.py.
+            # No clearing here — caller supplied exactly what they want.
             ;;
           *)
             echo "::error::unknown provider '$INPUT_PROVIDER'; must be one of: anthropic, zai, moonshot, custom" >&2

--- a/action.yml
+++ b/action.yml
@@ -348,6 +348,55 @@ inputs:
       that the Claude Code CLI reports is computed with Anthropic-rate
       pricing applied to the backend's tokens — it's an estimate, not a
       bill. Token counts remain accurate.
+
+      For the known backends `zai` / `moonshot`, prefer the `provider`
+      input below — it configures both this URL and the correct auth env
+      var (Bearer vs x-api-key) from a single field, and picks up the
+      right per-vendor secret without a fork-side case-switch. Use
+      `model-base-url` directly only for custom / on-prem endpoints not
+      covered by the `provider` shortlist.
+    required: false
+    default: ''
+  provider:
+    description: |
+      Which Anthropic-Messages-compatible backend to route the coding
+      agent at. Consolidates the auth-env + base-URL wiring that forks
+      previously duplicated in a workflow-level Configure step.
+
+      Recognized values:
+        - `` (empty, default): existing behavior — pass through
+          `model-base-url` as-is, no auth manipulation. Backward-compatible.
+        - `anthropic`: default Anthropic API. Requires `ANTHROPIC_API_KEY`
+          in the caller's env block.
+        - `zai`: z.ai GLM Coding Plan. Requires `ZAI_API_KEY` in the
+          caller's env block. Sets `ANTHROPIC_AUTH_TOKEN` (Bearer) and
+          `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`.
+        - `moonshot`: Moonshot Kimi. Requires `MOONSHOT_API_KEY` in the
+          caller's env block. Sets `ANTHROPIC_AUTH_TOKEN` (Bearer) and
+          `ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic`.
+        - `custom`: use `model-base-url` + caller-supplied auth env var
+          for anything not in the shortlist above.
+
+      Secrets aren't magically visible inside the composite action — the
+      caller MUST pass the required secret via the `env:` block on the
+      `- uses: remyxai/outrider@v1` step (see docs/backends.md for the
+      canonical shape). The action fails clean with a specific error if
+      the required secret env var is missing.
+    required: false
+    default: ''
+  model:
+    description: |
+      Optional model name — sets `ANTHROPIC_MODEL` for the Claude Code
+      subprocess. When set, cost telemetry looks up the specific per-model
+      rate in the backend rate table (see `_BACKEND_RATES` in src/run.py)
+      rather than falling back to the host's flagship-tier default.
+
+      Examples: `claude-opus-4-8`, `claude-haiku-4-5`, `glm-5.2`,
+      `glm-4.6`, `kimi-k3`, `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`.
+
+      Empty (default) → the caller's own `ANTHROPIC_MODEL` env var wins if
+      set; otherwise the backend picks its own default and cost telemetry
+      uses the host's flagship-tier rates.
     required: false
     default: ''
   enable-cocoindex:
@@ -508,6 +557,71 @@ runs:
       run: |
         git config --global user.name "remyx-ai[bot]"
         git config --global user.email "289541483+remyx-ai[bot]@users.noreply.github.com"
+
+    - name: Configure backend from provider input
+      if: ${{ inputs.provider != '' }}
+      shell: bash
+      # Consolidates the per-fork Configure step that previously mapped
+      # `provider` → (auth env var, base URL, secret name). Runs only when
+      # the caller sets `provider`; empty (default) preserves existing
+      # behavior — model-base-url and auth env vars pass through untouched.
+      #
+      # Composite-action env inheritance: the caller's `env:` block on the
+      # `- uses: remyxai/outrider@v1` step propagates to every step here,
+      # so ANTHROPIC_API_KEY / ZAI_API_KEY / MOONSHOT_API_KEY (whichever
+      # the caller passed) are readable via os.environ / bash env directly.
+      # Writing to $GITHUB_ENV makes the resulting ANTHROPIC_AUTH_TOKEN /
+      # ANTHROPIC_BASE_URL visible to subsequent composite steps (including
+      # the recommend step that runs run.py).
+      env:
+        INPUT_PROVIDER: ${{ inputs.provider }}
+        INPUT_MODEL: ${{ inputs.model }}
+        INPUT_MODEL_BASE_URL: ${{ inputs.model-base-url }}
+      run: |
+        set -eu
+        case "$INPUT_PROVIDER" in
+          anthropic)
+            if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+              echo "::error::provider=anthropic requires ANTHROPIC_API_KEY in the caller's env block" >&2
+              exit 1
+            fi
+            # ANTHROPIC_API_KEY is already in the parent env — no override needed
+            ;;
+          zai)
+            if [ -z "${ZAI_API_KEY:-}" ]; then
+              echo "::error::provider=zai requires ZAI_API_KEY in the caller's env block" >&2
+              exit 1
+            fi
+            echo "ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY" >> "$GITHUB_ENV"
+            echo "ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic" >> "$GITHUB_ENV"
+            ;;
+          moonshot)
+            if [ -z "${MOONSHOT_API_KEY:-}" ]; then
+              echo "::error::provider=moonshot requires MOONSHOT_API_KEY in the caller's env block" >&2
+              exit 1
+            fi
+            echo "ANTHROPIC_AUTH_TOKEN=$MOONSHOT_API_KEY" >> "$GITHUB_ENV"
+            echo "ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic" >> "$GITHUB_ENV"
+            ;;
+          custom)
+            if [ -z "$INPUT_MODEL_BASE_URL" ]; then
+              echo "::error::provider=custom requires model-base-url to be set" >&2
+              exit 1
+            fi
+            if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+              echo "::error::provider=custom requires ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN in the caller's env block" >&2
+              exit 1
+            fi
+            # model-base-url passes through via INPUT_MODEL_BASE_URL to run.py
+            ;;
+          *)
+            echo "::error::unknown provider '$INPUT_PROVIDER'; must be one of: anthropic, zai, moonshot, custom" >&2
+            exit 1
+            ;;
+        esac
+        if [ -n "$INPUT_MODEL" ]; then
+          echo "ANTHROPIC_MODEL=$INPUT_MODEL" >> "$GITHUB_ENV"
+        fi
 
     - name: Recommend + implement + open PR
       id: recommend

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -45,7 +45,7 @@ The job-level conditional `${{ inputs.provider == 'zai' && '' || secrets.ANTHROP
 
 ## Workflow template — per-dispatch provider + model switching
 
-The canonical pattern for A/B-comparing Anthropic vs a non-default backend on the same repo. `remyxai outrider setup-local` (CLI v0.4.3+) generates the two-provider variant of this (anthropic + zai); adding the `moonshot` `case` branch shown below is a one-line fork-side edit until CLI support for it lands:
+The canonical pattern for A/B-comparing Anthropic vs a non-default backend on the same repo, using the action's built-in `provider` input:
 
 ```yaml
 on:
@@ -72,54 +72,31 @@ on:
 jobs:
   recommend:
     runs-on: ubuntu-latest
-    env:
-      REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
-      # ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_MODEL
-      # are set in the 'Configure provider auth' step below
-      # (auth env vars are mutually exclusive; ANTHROPIC_MODEL is
-      # optional and only set when the workflow_dispatch input is
-      # non-empty).
     steps:
-      - name: Configure provider auth
-        id: prov
-        shell: bash
-        env:
-          ANTHROPIC_API_KEY_SECRET: ${{ secrets.ANTHROPIC_API_KEY }}
-          ZAI_API_KEY_SECRET: ${{ secrets.ZAI_API_KEY }}
-          MOONSHOT_API_KEY_SECRET: ${{ secrets.MOONSHOT_API_KEY }}
-          MODEL_INPUT: ${{ inputs.model }}
-        run: |
-          case "${{ inputs.provider }}" in
-            zai)
-              echo "ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY_SECRET" >> "$GITHUB_ENV"
-              echo "base_url=https://api.z.ai/api/anthropic" >> "$GITHUB_OUTPUT"
-              ;;
-            moonshot)
-              echo "ANTHROPIC_AUTH_TOKEN=$MOONSHOT_API_KEY_SECRET" >> "$GITHUB_ENV"
-              echo "base_url=https://api.moonshot.ai/anthropic" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY_SECRET" >> "$GITHUB_ENV"
-              echo "base_url=" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
-          if [ -n "$MODEL_INPUT" ]; then
-            echo "ANTHROPIC_MODEL=$MODEL_INPUT" >> "$GITHUB_ENV"
-          fi
       - uses: remyxai/outrider@v1
+        env:
+          REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
+          # Pass every backend's secret the workflow might select. The
+          # action reads only the one matching `provider`; the rest are
+          # ignored. Skip any secret your fork doesn't have configured.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
         with:
           interest-id: <uuid>
           pin-method: ${{ inputs.pin-method }}
-          model-base-url: ${{ steps.prov.outputs.base_url }}
+          provider: ${{ inputs.provider }}
+          model: ${{ inputs.model }}
 ```
 
 Key properties:
 
-- Default behavior unchanged: `provider=anthropic` (the default) sets `ANTHROPIC_API_KEY` and leaves `model-base-url` empty, so existing customers see no change
-- Single source of auth truth: the `Configure provider auth` step writes one and only one auth env var; subsequent steps inherit it
+- Default behavior unchanged: `provider=''` (unset) preserves the pre-v1.x action behavior — no auth manipulation, `model-base-url` passes through as-is
+- Auth resolution is the action's job: the action's Configure step picks the correct auth env var per provider (Bearer for zai/moonshot, x-api-key for anthropic) and sets `ANTHROPIC_BASE_URL` from a fixed per-provider map. No fork-side case-switch to maintain.
+- Fails clean if the required secret is missing: `provider=moonshot` with no `MOONSHOT_API_KEY` in the caller's env block errors before any Claude call
 - Per-dispatch switchable: dispatch with `provider=zai` or `provider=moonshot` to route through that vendor for one run; default cron runs stay on Anthropic
-- Model selection independent of provider: `--model glm-5.2` and `--model glm-4.6` both work with `--provider zai`; `--model kimi-k3` and `--model kimi-k2.7-code` both work with `--provider moonshot`; `--model claude-opus-4-8` and `--model claude-sonnet-4-6` both work with `--provider anthropic`
-- Adding a new backend later (Bedrock, Vertex) is a new `case` branch plus a base-URL mapping
+- Model selection independent of provider: `--model glm-5.2` and `--model glm-4.6` both work with `--provider zai`; `--model kimi-k3` and `--model kimi-k2.7-code` both work with `--provider moonshot`; `--model claude-opus-4-8` and `--model claude-sonnet-4-6` both work with `--provider anthropic`. Setting `--model` also gives per-model cost accuracy (see Cost telemetry below).
+- Custom / on-prem endpoints: set `provider: custom` + `model-base-url: <your-url>` + supply `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` in env directly. The action's provider shortlist is a UX helper for the common cases; `custom` is the escape hatch for anything else.
 
 
 ## Cost telemetry

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,29 +1,32 @@
 ---
 type: Customization Guide
 title: Model backends
-description: Route Outrider's agent at non-default model backends (z.ai GLM, Bedrock, Vertex, on-prem) — auth, workflow template, cost telemetry, debug.
+description: Route Outrider's agent at non-default model backends (z.ai GLM, Moonshot Kimi, Bedrock, Vertex, on-prem) — auth, workflow template, cost telemetry, debug.
 resource: https://github.com/remyxai/outrider/blob/main/docs/backends.md
-tags: [outrider, customization, model-backends, glm, bedrock, vertex]
-timestamp: 2026-06-30T03:57:23Z
+tags: [outrider, customization, model-backends, glm, kimi, moonshot, bedrock, vertex]
+timestamp: 2026-07-16T00:00:00Z
 ---
 
 # Model backends
 
 Outrider's coding-agent step shells out to the `claude` CLI. Anything Claude Code can authenticate against, Outrider can route through.
 
-By default Outrider talks to Anthropic's hosted API. To route at any other Anthropic-Messages-compatible backend — z.ai's GLM Coding Plan, AWS Bedrock with Claude, GCP Vertex with Claude, an on-prem proxy — set the `model-base-url` action input. The Outrider engine doesn't care which backend served the response; the spec bundle, validators, refinement chain, and selection pass are all backend-agnostic.
+By default Outrider talks to Anthropic's hosted API. To route at any other Anthropic-Messages-compatible backend — z.ai's GLM Coding Plan, Moonshot's Kimi, AWS Bedrock with Claude, GCP Vertex with Claude, an on-prem proxy — set the `model-base-url` action input. The Outrider engine doesn't care which backend served the response; the spec bundle, validators, refinement chain, and selection pass are all backend-agnostic.
 
 ## Supported backends
 
-| Backend | `model-base-url` value | Recommended secret name |
-|---|---|---|
-| Anthropic (default) | _(empty — uses `api.anthropic.com`)_ | `ANTHROPIC_API_KEY` |
-| z.ai / GLM Coding Plan | `https://api.z.ai/api/anthropic` | `ZAI_API_KEY` |
-| AWS Bedrock (Claude) | `https://bedrock-runtime.<region>.amazonaws.com` | (AWS SigV4 — uses the workflow's `aws-actions/configure-aws-credentials` chain) |
-| GCP Vertex (Claude) | `https://<region>-aiplatform.googleapis.com/v1/projects/<proj>/...` | `GOOGLE_APPLICATION_CREDENTIALS` (OAuth via service-account JSON) |
-| On-prem Anthropic-compat proxy | `https://<your-proxy>/v1` | (your convention) |
+| Backend | `model-base-url` value | Secret | Default model | Recommended `claude-timeout` |
+|---|---|---|---|---|
+| Anthropic (default) | _(empty — uses `api.anthropic.com`)_ | `ANTHROPIC_API_KEY` | `claude-opus-4-8` | `900` (default) |
+| z.ai / GLM Coding Plan | `https://api.z.ai/api/anthropic` | `ZAI_API_KEY` | `glm-5.2` | `900` (default) |
+| Moonshot / Kimi | `https://api.moonshot.ai/anthropic` | `MOONSHOT_API_KEY` | `kimi-k3` | `3600` (thinking-mode adds per-turn latency) |
+| AWS Bedrock (Claude) | `https://bedrock-runtime.<region>.amazonaws.com` | (AWS SigV4 — uses the workflow's `aws-actions/configure-aws-credentials` chain) | (varies per Bedrock configuration) | `900` (default) |
+| GCP Vertex (Claude) | `https://<region>-aiplatform.googleapis.com/v1/projects/<proj>/...` | `GOOGLE_APPLICATION_CREDENTIALS` (OAuth via service-account JSON) | (varies per Vertex configuration) | `900` (default) |
+| On-prem Anthropic-compat proxy | `https://<your-proxy>/v1` | (your convention) | (varies) | `900` (default) |
 
-Naming convention: each provider's secret follows `<PROVIDER>_API_KEY` — matches the upstream conventions for `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc. Customers reading the workflow YAML can grep the secret name to figure out which provider is wired.
+Naming convention: each provider's secret follows `<PROVIDER>_API_KEY` — matches the upstream conventions for `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `MOONSHOT_API_KEY`, etc. Customers reading the workflow YAML can grep the secret name to figure out which provider is wired.
+
+The `claude-timeout` input threads through every phase (selection, deep-search, preflight, audit, implementation, self-review). Bumping it for a slow backend lifts the ceiling on all phases uniformly — there's no per-phase timeout knob, and none is needed.
 
 
 ## Auth-header matrix (and why setting both env vars breaks)
@@ -33,7 +36,7 @@ Different backends expect different auth headers. Claude Code uses two distinct 
 | Env var | Header Claude Code sends | Right for |
 |---|---|---|
 | `ANTHROPIC_API_KEY` | `x-api-key: <value>` | Default Anthropic |
-| `ANTHROPIC_AUTH_TOKEN` | `Authorization: Bearer <value>` | z.ai's GLM (Bearer is what their gateway accepts; `x-api-key` returns HTTP 401) |
+| `ANTHROPIC_AUTH_TOKEN` | `Authorization: Bearer <value>` | Non-Anthropic backends that expect Bearer auth: z.ai's GLM, Moonshot's Kimi (both gateways return HTTP 401 to `x-api-key`) |
 
 > **Mutual exclusion.** Setting **both** env vars in the runner environment makes Claude Code prefer `ANTHROPIC_API_KEY` (the `x-api-key` path) — which non-Anthropic backends like z.ai reject. The two env vars are not additive; they're mutually exclusive, and the workflow must choose one per dispatch.
 
@@ -42,7 +45,7 @@ The job-level conditional `${{ inputs.provider == 'zai' && '' || secrets.ANTHROP
 
 ## Workflow template — per-dispatch provider + model switching
 
-The canonical pattern for A/B-comparing Anthropic vs a non-default backend on the same repo. This matches what `remyxai outrider setup-local` (CLI v0.4.3+) generates:
+The canonical pattern for A/B-comparing Anthropic vs a non-default backend on the same repo. `remyxai outrider setup-local` (CLI v0.4.3+) generates the two-provider variant of this (anthropic + zai); adding the `moonshot` `case` branch shown below is a one-line fork-side edit until CLI support for it lands:
 
 ```yaml
 on:
@@ -56,8 +59,9 @@ on:
         options:
           - anthropic
           - zai
+          - moonshot
       model:
-        description: 'Specific model name (e.g. claude-opus-4-7, glm-5.2, glm-4.6). Empty = provider default.'
+        description: 'Specific model name (e.g. claude-opus-4-8, glm-5.2, kimi-k3). Empty = provider default.'
         required: false
         default: ''
       pin-method:
@@ -77,17 +81,28 @@ jobs:
       # non-empty).
     steps:
       - name: Configure provider auth
+        id: prov
         shell: bash
         env:
           ANTHROPIC_API_KEY_SECRET: ${{ secrets.ANTHROPIC_API_KEY }}
           ZAI_API_KEY_SECRET: ${{ secrets.ZAI_API_KEY }}
+          MOONSHOT_API_KEY_SECRET: ${{ secrets.MOONSHOT_API_KEY }}
           MODEL_INPUT: ${{ inputs.model }}
         run: |
-          if [ "${{ inputs.provider }}" = "zai" ]; then
-            echo "ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY_SECRET" >> "$GITHUB_ENV"
-          else
-            echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY_SECRET" >> "$GITHUB_ENV"
-          fi
+          case "${{ inputs.provider }}" in
+            zai)
+              echo "ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY_SECRET" >> "$GITHUB_ENV"
+              echo "base_url=https://api.z.ai/api/anthropic" >> "$GITHUB_OUTPUT"
+              ;;
+            moonshot)
+              echo "ANTHROPIC_AUTH_TOKEN=$MOONSHOT_API_KEY_SECRET" >> "$GITHUB_ENV"
+              echo "base_url=https://api.moonshot.ai/anthropic" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY_SECRET" >> "$GITHUB_ENV"
+              echo "base_url=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
           if [ -n "$MODEL_INPUT" ]; then
             echo "ANTHROPIC_MODEL=$MODEL_INPUT" >> "$GITHUB_ENV"
           fi
@@ -95,16 +110,16 @@ jobs:
         with:
           interest-id: <uuid>
           pin-method: ${{ inputs.pin-method }}
-          model-base-url: ${{ inputs.provider == 'zai' && 'https://api.z.ai/api/anthropic' || '' }}
+          model-base-url: ${{ steps.prov.outputs.base_url }}
 ```
 
 Key properties:
 
 - Default behavior unchanged: `provider=anthropic` (the default) sets `ANTHROPIC_API_KEY` and leaves `model-base-url` empty, so existing customers see no change
 - Single source of auth truth: the `Configure provider auth` step writes one and only one auth env var; subsequent steps inherit it
-- Per-dispatch switchable: dispatch with `provider=zai` to route through z.ai for that one run; default cron runs stay on Anthropic
-- Model selection independent of provider: `--model glm-5.2` and `--model glm-4.6` both work with `--provider zai`; `--model claude-opus-4-7` and `--model claude-sonnet-4-6` both work with `--provider anthropic`
-- Adding a new backend later (Bedrock, Vertex) is a per-elif branch in the Configure step plus a `model-base-url` mapping
+- Per-dispatch switchable: dispatch with `provider=zai` or `provider=moonshot` to route through that vendor for one run; default cron runs stay on Anthropic
+- Model selection independent of provider: `--model glm-5.2` and `--model glm-4.6` both work with `--provider zai`; `--model kimi-k3` and `--model kimi-k2.7-code` both work with `--provider moonshot`; `--model claude-opus-4-8` and `--model claude-sonnet-4-6` both work with `--provider anthropic`
+- Adding a new backend later (Bedrock, Vertex) is a new `case` branch plus a base-URL mapping
 
 
 ## Cost telemetry
@@ -114,10 +129,10 @@ Outrider tracks token counts straight from each Claude Code response envelope. C
 | `cost_basis` value | Meaning |
 |---|---|
 | `claude_code_envelope` | Default Anthropic path — the CLI's `total_cost_usd` field is authoritative because the CLI knows Anthropic's rates |
-| `backend_rate_table` | Outrider has a per-million-token rate entry for the configured backend (currently: `api.z.ai`). Cost is computed from `tokens × table rates`, overriding the CLI's Anthropic-rate estimate |
+| `backend_rate_table` | Outrider has per-model rate rows for the configured backend (currently: `api.z.ai` covers `glm-5.2`/`glm-4.6`; `api.moonshot.ai` covers `kimi-k3`/`kimi-k2.7-code`/`kimi-k2.7-code-highspeed`). Cost is computed from `tokens × per-model rates`, keyed by `ANTHROPIC_MODEL` (or the envelope's `model` field when present) and overriding the CLI's Anthropic-rate estimate |
 | (none + step-summary warning) | Backend isn't in the rate table; falling back to the CLI's value with a "may be approximate" annotation. Token counts stay accurate; dollars are approximate by however much the backend's pricing differs from Anthropic's |
 
-Customers routing at a backend Outrider doesn't yet recognize see accurate token counts and a step-summary annotation flagging the cost approximation. Customer-supplied per-backend rate inputs are on the roadmap.
+When `ANTHROPIC_MODEL` names a model not in the host's rate row (e.g. a newly-released tier we haven't added yet), cost is computed at the host's default-tier rates (glm-5.2 for z.ai; kimi-k3 for Moonshot) — closer than nothing, but off by the tier delta (3-4x on tier pairs). Customers routing at a backend Outrider doesn't yet recognize see accurate token counts and a step-summary annotation flagging the cost approximation.
 
 
 The step summary shows the agent + backend pair on every run:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -47,9 +47,9 @@ Set to a free-text method query (e.g. `"knowledge distillation"`) or a literal `
 
 ### Model backend — `model-base-url`
 
-Optional override that routes the Claude Code subprocess at any Anthropic-Messages-compatible backend (z.ai's GLM Coding Plan, AWS Bedrock, GCP Vertex, on-prem proxies). Empty (default) = Anthropic's API.
+Optional override that routes the Claude Code subprocess at any Anthropic-Messages-compatible backend (z.ai's GLM Coding Plan, Moonshot's Kimi, AWS Bedrock, GCP Vertex, on-prem proxies). Empty (default) = Anthropic's API.
 
-The full backend matrix — including the auth-header gotcha that bites on z.ai (the env vars `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` are mutually exclusive), the per-dispatch backend-switching workflow template, cost-telemetry behavior per backend, and a 401-debug checklist — lives in [`backends.md`](backends.md).
+The full backend matrix — supported backends with their base URLs, secret names, default models, and recommended `claude-timeout` values; the auth-header gotcha that bites on non-Anthropic backends (the env vars `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` are mutually exclusive); the per-dispatch backend-switching workflow template; cost-telemetry behavior per backend; and a 401-debug checklist — lives in [`backends.md`](backends.md).
 
 ### Filesystem reach — `guardrails-allowlist`
 
@@ -142,7 +142,7 @@ The drafter accumulates a pool of branches through the arxiv frontier — every 
 
 Requires one secret: `ANTHROPIC_API_KEY`. Optional: `LINEAR_API_KEY` for the durable-state pattern (refiner can file gap analyses as Linear issues and read them back via URL), but the default setup passes the gap analysis inline as raw markdown so no Linear provisioning is needed.
 
-For customers with existing z.ai credits or Anthropic-outage hedging needs, either role can be routed at a different backend via `model-base-url` — see [`backends.md`](backends.md).
+For customers with existing z.ai / Moonshot credits or Anthropic-outage hedging needs, either role can be routed at a different backend via `model-base-url` — see [`backends.md`](backends.md).
 
 ### Manual triggers for testing
 

--- a/src/run.py
+++ b/src/run.py
@@ -6181,22 +6181,43 @@ def _reset_run_cost() -> None:
 # ── Per-backend pricing for cost telemetry ─────────────────────────────────
 #
 # When ``ANTHROPIC_BASE_URL`` routes Claude Code at a non-Anthropic backend
-# (z.ai / GLM, Bedrock, on-prem proxies), the CLI's ``total_cost_usd`` field
-# uses its built-in Anthropic-rate table — wrong by a constant factor for
-# any other backend. This table lets us override with the backend's actual
-# rate card when the URL matches a known host substring.
+# (z.ai / GLM, Moonshot / Kimi, on-prem proxies), the CLI's ``total_cost_usd``
+# field uses its built-in Anthropic-rate table — wrong by a constant factor
+# for any other backend. This table lets us override with the backend's
+# actual rate card when the URL matches a known host substring.
 #
-# Rates are USD per million tokens: ``(input, output, cache_read)``. Update
-# as providers publish new rates. Backends not in the table fall back to
-# the CLI's ``total_cost_usd`` (with a "may be approximate" note in the
-# step summary so the operator knows the figure isn't authoritative for
-# their backend).
-_BACKEND_RATES: dict[str, tuple[float, float, float]] = {
-    # z.ai GLM (Anthropic-Messages-compat endpoint) — PAYG rates for the
-    # default GLM-4.6 routing. Users on the GLM Coding Plan subscription
-    # don't pay per-token, but the per-token estimate stays useful as a
-    # "what would this cost outside the subscription" indicator.
-    "api.z.ai": (0.60, 2.20, 0.06),
+# Keyed by host substring, then by ANTHROPIC_MODEL name. Rates are USD per
+# million tokens: ``(input, output, cache_read)``. Update as providers
+# publish new rates. Backends not in the table fall back to the CLI's
+# ``total_cost_usd`` (with a "may be approximate" note in the step summary
+# so the operator knows the figure isn't authoritative for their backend).
+#
+# A tier pair (drafter + refiner) can differ 3-4x per token — z.ai's
+# glm-4.6 vs glm-5.2, Moonshot's kimi-k2.7-code vs kimi-k3 — so cost
+# accuracy requires per-model rates within each host. Subscription plans
+# (z.ai's GLM Coding Plan) don't pay per-token, but the per-token estimate
+# stays useful as a "what would this cost outside the subscription"
+# indicator.
+_BACKEND_RATES: dict[str, dict[str, tuple[float, float, float]]] = {
+    "api.z.ai": {
+        # PAYG rates per docs.z.ai/guides/overview/pricing.md
+        "glm-5.2": (1.40, 4.40, 0.26),
+        "glm-4.6": (0.60, 2.20, 0.11),
+    },
+    "api.moonshot.ai": {
+        # PAYG rates per platform.kimi.ai/docs/pricing/*
+        "kimi-k3": (3.00, 15.00, 0.30),
+        "kimi-k2.7-code": (0.95, 4.00, 0.19),
+        "kimi-k2.7-code-highspeed": (1.90, 8.00, 0.38),
+    },
+}
+
+# Per-host fallback when ANTHROPIC_MODEL is unset or names a model we don't
+# have rates for — pick the model most callers are actually likely to be
+# running so the estimate is closer than "no idea".
+_BACKEND_DEFAULT_MODEL: dict[str, str] = {
+    "api.z.ai": "glm-5.2",
+    "api.moonshot.ai": "kimi-k3",
 }
 
 
@@ -6296,7 +6317,10 @@ def _validate_claude_auth_env() -> tuple[bool, list[str]]:
     return True, warnings
 
 
-def _detect_backend(base_url: str) -> tuple[str, tuple[float, float, float] | None]:
+def _detect_backend(
+    base_url: str,
+    model: str = "",
+) -> tuple[str, tuple[float, float, float] | None]:
     """Identify the Anthropic-Messages-compat backend behind ANTHROPIC_BASE_URL.
 
     Returns ``(display_name, rates_or_None)``. When the host isn't in the
@@ -6304,15 +6328,27 @@ def _detect_backend(base_url: str) -> tuple[str, tuple[float, float, float] | No
     rates — the caller falls back to the CLI's reported ``total_cost_usd``
     (which is Anthropic-rate; only correct for default Anthropic or
     Bedrock-Claude, miscalibrated for any other backend).
+
+    When ``model`` is empty or names a model not in the host's rate row,
+    falls back to ``_BACKEND_DEFAULT_MODEL[host_key]`` — closer than
+    "no idea", but slightly off for tier pairs (e.g. cost reported as
+    kimi-k3 when the actual call was kimi-k2.7-code will overestimate
+    ~3x). Callers with a known model should pass it.
     """
     if not base_url:
         return ("Anthropic", None)  # default — CLI's envelope cost is correct
     host = base_url.split("://", 1)[-1].split("/", 1)[0]
     display_overrides = {
         "api.z.ai": "z.ai (GLM)",
+        "api.moonshot.ai": "Moonshot (Kimi)",
     }
-    for key, rates in _BACKEND_RATES.items():
+    for key, model_rates in _BACKEND_RATES.items():
         if key in host:
+            rates = model_rates.get(model) if model else None
+            if rates is None:
+                default_model = _BACKEND_DEFAULT_MODEL.get(key)
+                if default_model:
+                    rates = model_rates.get(default_model)
             return (display_overrides.get(key, host), rates)
     return (host, None)
 
@@ -6348,7 +6384,11 @@ def _record_claude_usage(env: dict) -> None:
         )
 
     base_url = os.environ.get("ANTHROPIC_BASE_URL", "")
-    backend_name, rates = _detect_backend(base_url)
+    # Prefer the envelope's model (what was actually served) over the env
+    # var (what we requested) — same in practice, but envelope wins when
+    # both are present.
+    model = env.get("model") or os.environ.get("ANTHROPIC_MODEL", "")
+    backend_name, rates = _detect_backend(base_url, model)
     if rates is not None and "api.anthropic.com" not in base_url:
         # Compute from tokens × backend rates (USD per million).
         rate_in, rate_out, rate_cache = rates

--- a/tests/test_model_base_url.py
+++ b/tests/test_model_base_url.py
@@ -149,34 +149,103 @@ def test_detect_backend_recognizes_zai():
     assert rates is not None and rates[0] > 0 and rates[1] > 0
 
 
+def test_detect_backend_recognizes_moonshot():
+    name, rates = run._detect_backend("https://api.moonshot.ai/anthropic")
+    assert name == "Moonshot (Kimi)"
+    assert rates is not None and rates[0] > 0 and rates[1] > 0
+
+
 def test_detect_backend_unknown_returns_host_with_no_rates():
     name, rates = run._detect_backend("https://api.example.com/anthropic")
     assert name == "api.example.com"
     assert rates is None  # caller falls back to CLI's envelope cost
 
 
-def test_cost_override_for_zai_uses_glm_rates(monkeypatch):
-    """When ANTHROPIC_BASE_URL routes to z.ai, _record_claude_usage
-    must compute cost from tokens × GLM rates and ignore the CLI's
-    Anthropic-rate estimate in total_cost_usd."""
+def test_detect_backend_zai_explicit_model_selects_row():
+    _, glm46 = run._detect_backend("https://api.z.ai/api/anthropic", "glm-4.6")
+    _, glm52 = run._detect_backend("https://api.z.ai/api/anthropic", "glm-5.2")
+    assert glm46 == (0.60, 2.20, 0.11)
+    assert glm52 == (1.40, 4.40, 0.26)
+
+
+def test_detect_backend_moonshot_explicit_model_selects_row():
+    _, k3 = run._detect_backend("https://api.moonshot.ai/anthropic", "kimi-k3")
+    _, k27 = run._detect_backend("https://api.moonshot.ai/anthropic", "kimi-k2.7-code")
+    _, k27hs = run._detect_backend("https://api.moonshot.ai/anthropic", "kimi-k2.7-code-highspeed")
+    assert k3 == (3.00, 15.00, 0.30)
+    assert k27 == (0.95, 4.00, 0.19)
+    assert k27hs == (1.90, 8.00, 0.38)
+
+
+def test_detect_backend_unknown_model_on_known_host_falls_back_to_default():
+    """A model name we don't have rates for still returns the host's default
+    rates — closer than nothing, and matches how a fork without ANTHROPIC_MODEL
+    set would behave."""
+    _, moonshot_unknown = run._detect_backend("https://api.moonshot.ai/anthropic", "kimi-unreleased")
+    _, moonshot_default = run._detect_backend("https://api.moonshot.ai/anthropic", "")
+    assert moonshot_unknown == moonshot_default  # both fall back to kimi-k3
+    _, zai_unknown = run._detect_backend("https://api.z.ai/api/anthropic", "glm-6")
+    _, zai_default = run._detect_backend("https://api.z.ai/api/anthropic", "")
+    assert zai_unknown == zai_default  # both fall back to glm-5.2
+
+
+def test_cost_override_for_zai_uses_default_glm52_rates(monkeypatch):
+    """When ANTHROPIC_BASE_URL routes to z.ai with no ANTHROPIC_MODEL set,
+    _record_claude_usage falls back to the per-host default (glm-5.2) — the
+    tier-flagship default matches Anthropic (Opus) and Moonshot (kimi-k3)."""
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.z.ai/api/anthropic")
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
     run._reset_run_cost()
     # Pretend Claude Code reported a (wrong, Anthropic-rate) cost of $1.00
-    # for 1M input + 1M output tokens. With GLM rates (0.60 + 2.20), the
-    # real cost is $2.80, not $1.00.
+    # for 1M input + 1M output tokens. With glm-5.2 rates (1.40 + 4.40),
+    # the real cost is $5.80, not $1.00.
     envelope = {
         "total_cost_usd": 1.00,
         "usage": {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
         "num_turns": 1,
     }
     run._record_claude_usage(envelope)
-    # Cost should be computed from GLM rates, not the envelope's value.
-    assert run._RUN_COST["cost_usd"] == pytest.approx(0.60 + 2.20, abs=0.01)
+    assert run._RUN_COST["cost_usd"] == pytest.approx(1.40 + 4.40, abs=0.01)
     assert run._RUN_COST["cost_basis"] == "backend_rate_table"
     assert run._RUN_COST["model_backend"] == "z.ai (GLM)"
     # Token counts come straight from the envelope — accurate regardless.
     assert run._RUN_COST["input_tokens"] == 1_000_000
     assert run._RUN_COST["output_tokens"] == 1_000_000
+
+
+def test_cost_override_reads_model_from_env(monkeypatch):
+    """ANTHROPIC_MODEL selects the specific rate row — verifies the
+    drafter-tier accuracy case that the default-fallback path misses."""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.z.ai/api/anthropic")
+    monkeypatch.setenv("ANTHROPIC_MODEL", "glm-4.6")
+    run._reset_run_cost()
+    envelope = {
+        "total_cost_usd": 1.00,
+        "usage": {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        "num_turns": 1,
+    }
+    run._record_claude_usage(envelope)
+    # glm-4.6 rates: 0.60 + 2.20 = 2.80 (not the 5.80 that glm-5.2 default would give)
+    assert run._RUN_COST["cost_usd"] == pytest.approx(0.60 + 2.20, abs=0.01)
+    assert run._RUN_COST["cost_basis"] == "backend_rate_table"
+
+
+def test_cost_override_envelope_model_wins_over_env(monkeypatch):
+    """When the envelope names a model, that wins over ANTHROPIC_MODEL —
+    envelope = what was actually served, env = what we requested."""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.moonshot.ai/anthropic")
+    monkeypatch.setenv("ANTHROPIC_MODEL", "kimi-k3")  # we asked for k3
+    run._reset_run_cost()
+    envelope = {
+        "model": "kimi-k2.7-code",  # but got k2.7-code back
+        "total_cost_usd": 1.00,
+        "usage": {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        "num_turns": 1,
+    }
+    run._record_claude_usage(envelope)
+    # Cost priced at kimi-k2.7-code rates (0.95 + 4.00), not kimi-k3
+    assert run._RUN_COST["cost_usd"] == pytest.approx(0.95 + 4.00, abs=0.01)
+    assert run._RUN_COST["model_backend"] == "Moonshot (Kimi)"
 
 
 def test_cost_trusts_envelope_for_default_anthropic(monkeypatch):


### PR DESCRIPTION
## Summary

- **Per-model cost telemetry** — nested `_BACKEND_RATES` (`{host: {model: rates}}`) so tier pairs price correctly. A `kimi-k2.7-code` run no longer bills at `kimi-k3` rates (~3x over); a `glm-4.6` run no longer bills at `glm-5.2` rates (~2x over). Model read from envelope OR `ANTHROPIC_MODEL`, with per-host flagship default fallback.
- **New `provider` + `model` action inputs** — consolidates the auth wiring + base-URL case-switch every fork previously duplicated. `provider: moonshot` + `MOONSHOT_API_KEY` in the caller's env is all that's needed. Mutual-exclusion enforced (clears the non-selected auth var to avoid Claude Code preferring x-api-key against non-Anthropic backends). Empty `provider` preserves existing behavior.
- **Moonshot backend added** — `kimi-k3` / `kimi-k2.7-code` / `kimi-k2.7-code-highspeed` in the rate table; auth wiring for `provider: moonshot`.
- **z.ai `glm-5.2` added** alongside `glm-4.6`; cache-read rate corrected from 0.06 to 0.11 per current docs.z.ai.

## Test plan

- [x] `pytest tests/` — 1052 pass, 1 skipped (6 new tests in `test_model_base_url.py`)
- [x] `yaml.safe_load` on `action.yml`
- [x] End-to-end smoke on `smellslikeml/atropos` with `provider: moonshot` (mutual-exclusion path exercised — every backend's secret passed in env, action clears the non-selected one). Configure step passed early; Kimi coding session still running at PR-open time.

## Compatibility

Backward-compatible. `provider` unset preserves existing behavior byte-for-byte. Existing forks on `@v1` continue to work with zero migration.

## Docs

- `backends.md` — unified table with default-model + recommended `claude-timeout` columns; Moonshot row added; workflow template simplified to use the new `provider` input (no fork-side Configure step needed).
- `customization.md` — hedging sentence expanded to mention Moonshot.

## `remyxai-cli` companion

`--backend` flag for `remyxai outrider setup-local` lands in a follow-up on `remyxai/remyxai-cli` once `@v1` moves.