### PR TITLE
fix(bot-token): re-mint on TTL expiry; refresh git remote URL before push

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -1651,7 +1651,14 @@ class Recommendation:
 # per run, success or failure. `permissions` carries the scopes the engine
 # actually granted so capability-aware callers (the Discussion post) can
 # branch instead of discovering a 403.
-_BOT_TOKEN = {"attempted": False, "token": "", "permissions": {}}
+_BOT_TOKEN = {"attempted": False, "token": "", "permissions": {}, "minted_at": 0.0}
+
+# GitHub App installation tokens have a 60-minute TTL. Slow-backend runs
+# (Kimi K3 thinking mode, GLM-5.2 with reasoning) can spend 30-40 min per
+# phase — a full recommend → implement → self-review → push cycle blows
+# past that. Re-mint before the cached token expires; 5-min safety margin
+# so a call made just under the wire still gets a fresh token.
+_BOT_TOKEN_MAX_AGE_S = 55 * 60  # 3300s
 
 
 def _mint_bot_token() -> str:
@@ -1660,14 +1667,33 @@ def _mint_bot_token() -> str:
     The action already holds REMYX_API_KEY — exactly the credential the
     engine's ``/github/installation-token`` endpoint authenticates — so
     the bot identity must not depend on the customer's workflow YAML
-    carrying a mint step. Called lazily by ``_github_token``; one attempt
-    per run. Best-effort: any failure (engine unreachable, App not
-    installed, no provisioned action for this repo) returns ``""`` and
-    the caller falls back to GITHUB_TOKEN — the same graceful semantics
-    as the YAML mint step's ``|| token=""``.
+    carrying a mint step. Called lazily by ``_github_token``. Best-effort:
+    any failure (engine unreachable, App not installed, no provisioned
+    action for this repo) returns ``""`` and the caller falls back to
+    GITHUB_TOKEN — the same graceful semantics as the YAML mint step's
+    ``|| token=""``.
+
+    Caching semantics:
+      - Successful mint: cached for up to _BOT_TOKEN_MAX_AGE_S. Older
+        than that, we re-mint before returning (installation tokens
+        expire at 60 min; slow-backend runs push after that window).
+      - Failed mint: cached-empty for the run. Not retried on every
+        call — that would flood the engine when the App isn't installed
+        or the endpoint is down.
     """
+    now = time.time()
     if _BOT_TOKEN["attempted"]:
-        return _BOT_TOKEN["token"]
+        # Prior mint attempt returned empty (App not installed, engine
+        # unreachable) — honor the cached-empty result; don't retry.
+        if not _BOT_TOKEN["token"]:
+            return ""
+        # Cached success: reuse if still fresh; otherwise fall through
+        # to re-mint.
+        age_s = now - _BOT_TOKEN["minted_at"]
+        if age_s < _BOT_TOKEN_MAX_AGE_S:
+            return _BOT_TOKEN["token"]
+        log.info(f"  bot token stale (age {int(age_s)}s > "
+                 f"{_BOT_TOKEN_MAX_AGE_S}s); re-minting")
     _BOT_TOKEN["attempted"] = True
     api_key = (
         os.environ.get("REMYX_API_KEY") or os.environ.get("REMYXAI_API_KEY")
@@ -1695,6 +1721,7 @@ def _mint_bot_token() -> str:
     _BOT_TOKEN["token"] = (data.get("token") or "").strip()
     _BOT_TOKEN["permissions"] = data.get("permissions") or {}
     if _BOT_TOKEN["token"]:
+        _BOT_TOKEN["minted_at"] = now
         log.info(f"  ✓ self-minted remyx[bot] token (scopes: "
                  f"{sorted(_BOT_TOKEN['permissions']) or '(unreported)'})")
     return _BOT_TOKEN["token"]
@@ -6175,7 +6202,7 @@ def _reset_run_cost() -> None:
         envelopes_without_usage=0,
     )
     _RUN_REFINE_QUERIES.clear()
-    _BOT_TOKEN.update(attempted=False, token="", permissions={})
+    _BOT_TOKEN.update(attempted=False, token="", permissions={}, minted_at=0.0)
 
 
 # ── Per-backend pricing for cost telemetry ─────────────────────────────────
@@ -8900,6 +8927,21 @@ def commit_and_push(
 
     subprocess.run(["git", "add", "-A"], cwd=workdir, check=True)
     subprocess.run(["git", "commit", "-m", title], cwd=workdir, check=True)
+
+    # Refresh origin's URL with a freshly-minted token before pushing.
+    # The URL baked into `origin` at clone time embeds the token (see
+    # prepare_workdir). Installation tokens have a 60-min TTL and long
+    # coding sessions (Kimi K3 thinking mode, GLM-5.2 reasoning) can
+    # extend the clone→push window past that. `_github_token()` re-mints
+    # on staleness (see `_BOT_TOKEN_MAX_AGE_S`) but the git remote URL
+    # stays frozen at clone time unless we explicitly rewrite it.
+    fresh_token = _github_token()
+    if fresh_token:
+        subprocess.run(
+            ["git", "remote", "set-url", "origin",
+             f"https://x-access-token:{fresh_token}@github.com/{repo}.git"],
+            cwd=workdir, check=True, capture_output=True,
+        )
 
     # Delete any orphan branch with the same name from the remote before
     # pushing. Two reasons:

--- a/tests/test_bot_token_default.py
+++ b/tests/test_bot_token_default.py
@@ -28,7 +28,7 @@ def _clean_env(monkeypatch, **env):
         monkeypatch.delenv(var, raising=False)
     for var, value in env.items():
         monkeypatch.setenv(var, value)
-    run._BOT_TOKEN.update(attempted=False, token="", permissions={})
+    run._BOT_TOKEN.update(attempted=False, token="", permissions={}, minted_at=0.0)
 
 
 class _FakeMintResponse:
@@ -114,6 +114,88 @@ def test_mint_skipped_without_api_key(monkeypatch):
         "must not call the engine without REMYX_API_KEY"
     ))
     assert run._github_token() == "builtin"
+
+
+def test_mint_re_mints_when_cached_token_is_stale(monkeypatch):
+    """Installation tokens have a 60-min TTL. Long-running Kimi/GLM
+    sessions can spend 30-40 min per phase — a cached token from clone
+    time would be expired at push time. `_mint_bot_token` must re-mint
+    when the cached token age exceeds `_BOT_TOKEN_MAX_AGE_S`.
+
+    Regression test for the git push 401 seen on the atropos smoke
+    (run 29552199454): first mint at 03:26:34, push attempt at 04:40:24
+    — 74 min later, 14 min past the 60-min TTL, cached-token bug bit.
+    """
+    _clean_env(
+        monkeypatch,
+        GITHUB_TOKEN="builtin",
+        REMYX_API_KEY="rmxa_x",
+        TARGET_REPO="owner/name",
+    )
+    mint_calls = []
+    counter = {"n": 0}
+
+    def fake_urlopen(req, timeout=15):
+        counter["n"] += 1
+        mint_calls.append(counter["n"])
+        return _FakeMintResponse({
+            "token": f"ghs_bot_v{counter['n']}",
+            "permissions": {"contents": "write"},
+        })
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    # First call at t=1000 — mints for the first time.
+    now = [1000.0]
+    monkeypatch.setattr(run.time, "time", lambda: now[0])
+    assert run._github_token() == "ghs_bot_v1"
+    assert mint_calls == [1]
+
+    # Second call at t=1000 + 30min — cached token still fresh, no re-mint.
+    now[0] = 1000.0 + 30 * 60
+    assert run._github_token() == "ghs_bot_v1"
+    assert mint_calls == [1]
+
+    # Third call at t=1000 + 74min — past the 55-min freshness window;
+    # must re-mint (this is exactly the push-time scenario from the smoke).
+    now[0] = 1000.0 + 74 * 60
+    assert run._github_token() == "ghs_bot_v2"
+    assert mint_calls == [1, 2]
+
+    # Fourth call at t=1000 + 74min + 5min — cached refresh still fresh.
+    now[0] = 1000.0 + 79 * 60
+    assert run._github_token() == "ghs_bot_v2"
+    assert mint_calls == [1, 2]
+
+
+def test_mint_does_not_retry_after_cached_failure_even_when_stale(monkeypatch):
+    """A cached-empty result (App not installed, engine unreachable) must
+    NOT re-attempt just because time passed — the failure was structural,
+    not TTL-related. Retrying on every call would flood the engine."""
+    _clean_env(
+        monkeypatch,
+        GITHUB_TOKEN="builtin",
+        REMYX_API_KEY="rmxa_x",
+        TARGET_REPO="owner/name",
+    )
+    counter = {"n": 0}
+
+    def boom(req, timeout=15):
+        counter["n"] += 1
+        raise urllib.error.URLError("engine down")
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    now = [1000.0]
+    monkeypatch.setattr(run.time, "time", lambda: now[0])
+
+    # First call: engine unreachable, cached-empty.
+    assert run._github_token() == "builtin"
+    assert counter["n"] == 1
+
+    # Fast-forward well past _BOT_TOKEN_MAX_AGE_S — still no retry.
+    now[0] = 1000.0 + 6 * 3600
+    assert run._github_token() == "builtin"
+    assert counter["n"] == 1
 
 
 def test_mint_normalizes_url_shaped_target_repo(monkeypatch):


### PR DESCRIPTION
## Summary

GitHub App installation tokens have a 60-min TTL. \`_mint_bot_token\` cached the token once per run and never re-minted; on slow-backend runs (Kimi K3 thinking mode, GLM-5.2 reasoning) where the coding + pytest + self-review chain exceeds 60 min, the cached token was expired at push time and \`git push\` failed with:

\`\`\`
Invalid username or token. Password authentication is not supported for Git operations.
\`\`\`

**Observed on** [atropos smoke run 29552199454](https://github.com/smellslikeml/atropos/actions/runs/29552199454) — first mint at 03:26:34 (clone), push attempt at 04:40:24 (74 min later, 14 min past TTL). Full Kimi pipeline had already succeeded (5 files, 733 insertions, \$2.57 via \`backend_rate_table\`); only the final push failed.

## Two changes

**1. \`_mint_bot_token\` tracks \`minted_at\` and re-mints when the cached token's age exceeds \`_BOT_TOKEN_MAX_AGE_S\`** (55 min = TTL - 5-min safety margin). Cached-empty results still short-circuit for the run — a structural failure (App not installed, engine unreachable) isn't TTL-related and shouldn't retry on every call.

**2. \`commit_and_push\` refreshes \`origin\`'s URL with a freshly-minted token before push.** The URL baked into \`origin\` at clone time embeds the token; even after \`_github_token()\` returns a fresh token, \`git push\` uses the URL's frozen embedded token unless we \`git remote set-url\` it first.

## Test plan

- [x] \`pytest tests/\` — 1054 pass, 1 skipped (2 new tests added)
- [x] \`test_mint_re_mints_when_cached_token_is_stale\` — pins the exact timeline from the failed smoke (mint at t=0, no re-mint at 30min, forced re-mint at 74min, cached again through 79min)
- [x] \`test_mint_does_not_retry_after_cached_failure_even_when_stale\` — cached-empty results honor structural-failure semantics regardless of elapsed time

## Compatibility

Runs that finish inside 55 min hit the fresh-cache path unchanged. Runs that exceed 55 min now silently re-mint instead of failing at push time. No API-input or workflow-YAML changes.