### PR TITLE
fix(research): drop 600s cap on research phase; inherit claude-timeout

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -10153,8 +10153,15 @@ def process_target(target: Target) -> dict:
         if staged in ("true", "1", "yes"):
             log.info("  → staged-synthesis enabled; running research phase before coding session")
             write_research_invocation(workdir, rec, target)
+            # Research inherits the run's claude-timeout budget in full —
+            # slow-backend runs (Kimi K3 thinking mode, GLM-5.2 reasoning)
+            # need the same headroom every other phase gets. The previous
+            # `min(600, target.claude_timeout_s)` cap ignored the caller's
+            # bumped timeout and forced research to fail-best-effort on
+            # any run where turns took >75s on average, dropping paper
+            # context from the coding session for no gain.
             research_ok, research_log = invoke_research_phase(
-                workdir, timeout_s=min(600, target.claude_timeout_s),
+                workdir, timeout_s=target.claude_timeout_s,
             )
             result["research_phase_ok"] = research_ok
             result["research_log_tail"] = research_log[-1000:]


### PR DESCRIPTION
## Summary

The research phase (invoked when \`staged-synthesis=true\`) was bounded by \`min(600, target.claude_timeout_s)\` — a hardcoded 10-min ceiling that ignored the caller's bumped \`claude-timeout\` input. On slow-backend runs (Kimi K3 thinking mode, GLM-5.2 reasoning) that set \`claude-timeout: 3600\` for the exact reason of giving each phase more headroom, research still capped at 10 min and hit its "8 turns per prompt" ceiling before the wall clock. It then fell through to the best-effort path ("research phase failed; coding session will run without research context"), silently dropping paper context from the coding session.

## Fix

Drop the \`min()\` wrapper — research inherits \`target.claude_timeout_s\` directly, matching every other phase's semantics (preflight, audit, implementation, self_review). Consistent with the "claude-timeout is the single per-phase knob" design.

\`\`\`python
# before
research_ok, research_log = invoke_research_phase(
    workdir, timeout_s=min(600, target.claude_timeout_s),
)

# after
research_ok, research_log = invoke_research_phase(
    workdir, timeout_s=target.claude_timeout_s,
)
\`\`\`

## Test plan

- [x] \`pytest tests/test_staged_synthesis.py\` — 10 pass (existing tests exercise \`invoke_research_phase\` directly with explicit \`timeout_s\`, unaffected by the callsite change)
- [x] \`pytest tests/\` — 1054 pass, 1 skipped

## Compatibility

Anthropic Opus runs are unaffected: their \`claude-timeout\` defaults to 900s, so \`target.claude_timeout_s\` = 900s vs the old \`min(600, 900)\` = 600s just means research gets 300s more before falling through — well within the 8-turns-in-10-min budget that shape was designed for. Slow-backend runs (Kimi, GLM-5.2) now get their bumped \`claude-timeout\` honored across every phase including research.