### PR TITLE
fix(chain): continue to convention + test on fidelity_skipped_*

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -16420,12 +16420,34 @@ def run_refinement_chain(target: Target, pr_number: int) -> dict:
     log.info("  ─── chain phase: fidelity audit ───")
     fidelity = run_fidelity_audit(target)
     chain["fidelity_status"] = fidelity.get("status")
-    if not str(fidelity.get("status", "")).startswith("fidelity_audited"):
+    # Chain-continuation taxonomy:
+    #   audited (any suffix) → run convention + test (existing behavior)
+    #   skipped_* except no_pr → run convention + test (audit couldn't
+    #       run — no reference URL, not bot-authored, reference URL
+    #       doesn't back-reference the arxiv — but the PR is unchanged
+    #       and downstream phases don't need fidelity's signal)
+    #   skipped_no_pr → short-circuit (nothing to work on)
+    #   failed_* → short-circuit (audit crashed; something went wrong,
+    #       don't muck with the PR further pending investigation)
+    status = str(fidelity.get("status", ""))
+    audited = status.startswith("fidelity_audited")
+    skipped_with_pr = (
+        status.startswith("fidelity_skipped")
+        and status != "fidelity_skipped_no_pr"
+    )
+    if not (audited or skipped_with_pr):
         log.info(
-            f"  ↪ fidelity did not audit (status={fidelity.get('status')!r}); "
+            f"  ↪ fidelity did not audit and cannot continue "
+            f"(status={fidelity.get('status')!r}); "
             f"skipping convention + test phases"
         )
         return chain
+    if not audited:
+        log.info(
+            f"  ↪ fidelity skipped ({fidelity.get('status')!r}) — continuing "
+            f"to convention + test (PR unchanged; downstream phases don't "
+            f"depend on fidelity signal)"
+        )
 
     log.info("  ─── chain phase: convention pass ───")
     convention = run_convention_pass(target)

--- a/tests/test_inline_refinement_chain.py
+++ b/tests/test_inline_refinement_chain.py
@@ -135,17 +135,45 @@ def test_chain_runs_all_phases_for_paper_anchored_audit(monkeypatch, audited_sta
 
 
 @pytest.mark.parametrize("skip_status", [
-    "fidelity_skipped_no_reference",
-    "fidelity_skipped_not_bot",
-    "fidelity_failed_clone",
+    "fidelity_skipped_no_pr",       # no PR → downstream also can't run
+    "fidelity_failed_claude",       # audit crashed → conservative short-circuit
+    "fidelity_failed_clone",        # audit crashed → conservative short-circuit
 ])
-def test_chain_short_circuits_when_fidelity_does_not_audit(monkeypatch, skip_status):
+def test_chain_short_circuits_when_fidelity_fails_or_has_no_pr(monkeypatch, skip_status):
     _base_env(monkeypatch)
     calls = _record_phases(monkeypatch, skip_status)
     chain = run.run_refinement_chain(run.Target(repo="owner/repo"), 42)
 
     assert [c[0] for c in calls] == ["fidelity"]  # convention/test never ran
     assert chain == {"pr_number": 42, "fidelity_status": skip_status}
+
+
+@pytest.mark.parametrize("skipped_status", [
+    "fidelity_skipped_no_reference",
+    "fidelity_skipped_not_bot",
+    "fidelity_skipped_reference_mismatch",
+])
+def test_chain_continues_when_fidelity_skipped_but_pr_exists(monkeypatch, skipped_status):
+    """Fidelity-skipped statuses (no_reference, not_bot, reference_mismatch)
+    mean the audit couldn't run against the paper's reference impl — but the
+    PR itself is unchanged and downstream phases don't depend on fidelity's
+    signal. Convention (PR-body rewrite) and test (pytest gate) must still
+    fire. Regression test for the atropos PR #18 case (2026-07-17): a Kimi
+    refinement pass on a paper whose reference URL was generic (`verl` —
+    doesn't back-reference the arxiv) got convention + test skipped, so the
+    PR shipped with unadapted body + no test-gate label transition."""
+    _base_env(monkeypatch)
+    calls = _record_phases(monkeypatch, skipped_status)
+    chain = run.run_refinement_chain(run.Target(repo="owner/repo"), 42)
+
+    assert [c[0] for c in calls] == ["fidelity", "convention", "test"]
+    assert chain == {
+        "pr_number": 42,
+        "fidelity_status": skipped_status,
+        "convention_status": "convention_aligned",
+        "test_status": "test_passed",
+        "draft_dropped": True,
+    }
 
 
 # ─── main(): recommend-mode continuation gated by chain_enabled ─────────────


### PR DESCRIPTION
## Summary

The refinement chain (fidelity → convention → test) short-circuited on every non-\`fidelity_audited*\` status, treating "audit ran and found nothing" the same as "audit couldn't run because the reference URL doesn't back-reference the arxiv". Convention (PR-body rewrite) and test (pytest gate) don't depend on fidelity's signal — they should still fire when the audit was skipped for reasons that leave the PR itself unchanged.

**Regression observed on** [smellslikeml/atropos#18](https://github.com/smellslikeml/atropos/pull/18) (Kimi refinement on \`arxiv:2509.09675\` whose reference impl \`github.com/volcengine/verl\` doesn't self-identify with the paper's arxiv): the PR shipped with unadapted body + no test-gate label transition because \`fidelity_skipped_reference_mismatch\` triggered the same short-circuit as an actual audit failure.

## New chain-continuation taxonomy

| Status | Continues to convention + test |
|---|---|
| \`fidelity_audited*\` | ✅ yes (existing behavior) |
| \`fidelity_skipped_no_reference\` | ✅ **NEW** |
| \`fidelity_skipped_not_bot\` | ✅ **NEW** |
| \`fidelity_skipped_reference_mismatch\` | ✅ **NEW** |
| \`fidelity_skipped_no_pr\` | ❌ no — nothing to work on |
| \`fidelity_failed_claude\` | ❌ no — audit crashed |
| \`fidelity_failed_clone\` | ❌ no — audit crashed |

## Test plan

- [x] Existing \`test_chain_short_circuits_when_fidelity_does_not_audit\` retargeted to the \`failed_*\` + \`skipped_no_pr\` set (renamed \`_when_fidelity_fails_or_has_no_pr\`)
- [x] New parametrized \`test_chain_continues_when_fidelity_skipped_but_pr_exists\` pins the three skipped-with-PR statuses to running the full chain
- [x] \`pytest tests/\` — 1057 pass, 1 skipped (+3 new)

## Compatibility

Existing chain-continuation semantics on \`fidelity_audited*\` unchanged. The only behavioral change is on the three \`fidelity_skipped_*\` statuses (excluding \`no_pr\`), which now run convention + test where they previously short-circuited. No API-input or workflow-YAML changes.