### PR TITLE
chore(harness): AI-agent scaffolding — AGENTS.md, skills, scoped rules, hooks

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,49 @@
+---
+description: Ship a new Outrider release — tag the merge commit, move the @v1 pointer, push both, and create the GitHub Release. Use after a PR merges to main that changes action behavior.
+argument-hint: <vX.Y.Z> <merge-sha> [release-notes-body]
+---
+
+Ship the Outrider release described by the arguments.
+
+Arguments:
+- `$1` — new version tag, `vX.Y.Z` shape (required)
+- `$2` — merge commit SHA on origin/main (required)
+- `$3` — release notes body (optional; prompt for content if missing)
+
+Run this sequence in order and report each step's outcome. Do not skip any step, especially `gh release create` — a bare `git push origin <tag>` does not surface in the GitHub Releases UI.
+
+```bash
+# 1. Sync main and confirm the merge SHA is on it
+git fetch origin main --tags
+git rev-parse "$2"
+
+# 2. Tag the new version at the merge commit
+git tag "$1" "$2"
+
+# 3. Move the @v1 moving pointer to the same commit
+git tag -f v1 "$2"
+
+# 4. Push the new tag + force-push the moved v1 pointer
+git push origin "$1"
+git push origin --force refs/tags/v1
+
+# 5. Create the GitHub Release (the step everyone forgets)
+gh release create "$1" --repo remyxai/outrider \
+  --target "$2" \
+  --title "$1" \
+  --notes "${3:-<release notes>}"
+
+# 6. Sanity check
+gh release view "$1" --repo remyxai/outrider --json name,tagName,url,createdAt
+git rev-parse v1 "$1"  # Both SHAs should match "$2"
+```
+
+Release notes conventions:
+- Sections: `## New`, `## Fixed`, `## Compatibility`. Skip sections that don't apply.
+- Reference each landed PR by number: `**<name>** ([PR #NN](url)) — one-paragraph summary.`
+- Public repo — terse. No Linear IDs, no dollar figures, no customer names.
+
+Failure modes to catch:
+- Tag pushed but no `gh release create` → GitHub UI shows no release.
+- v1 didn't move → old customers keep pinning the previous release.
+- Wrong SHA in tag → delete + re-tag: `git tag -d "$1" && git push origin ":$1"` then re-run from step 2.

--- a/.claude/hooks/post-write-remind.sh
+++ b/.claude/hooks/post-write-remind.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PostToolUse feedback for Edit/Write. Reads Claude Code's tool_result JSON
+# from stdin, checks which file was touched, and surfaces context-specific
+# reminders. Nothing enforced — just prompts so the agent doesn't forget.
+
+set -eu
+
+input=$(cat)
+path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null || echo "")
+
+[ -z "$path" ] && exit 0
+
+case "$path" in
+  */src/run.py)
+    echo "Reminder: run 'python3 -m pytest tests/ -q' before committing changes to src/run.py." >&2
+    ;;
+  */action.yml)
+    echo "Reminder: validate action.yml with 'python3 -c \"import yaml; yaml.safe_load(open(\\\"action.yml\\\"))\"'." >&2
+    ;;
+  */docs/backends.md|*/docs/customization.md)
+    echo "Reminder: docs edit — check that every mentioned input/value maps to a real name in action.yml (avoid the pin-method-style doc-vs-code drift)." >&2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/pre-bash-gate.sh
+++ b/.claude/hooks/pre-bash-gate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# PreToolUse gate for Bash. Reads Claude Code's tool_input JSON from stdin,
+# inspects the command, denies destructive operations with exit code 2 (deny
+# + surface stderr to the agent). All other commands pass through (exit 0).
+#
+# Guardrails encoded here:
+#   - never force-push to main
+#   - never --no-verify a commit or push (skips hooks; symptoms outlive the workaround)
+#   - never rm -rf home / system paths (sandbox paths under /tmp are fine)
+#   - never git reset --hard main (destroys uncommitted work; use a soft reset)
+#   - never git tag -f v1 without an accompanying gh release create later
+#     (this one is soft: a WARNING, not a deny — the sequence is manual)
+
+set -eu
+
+input=$(cat)
+cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+
+# No command payload (non-Bash tool or malformed input): allow.
+[ -z "$cmd" ] && exit 0
+
+deny() {
+  echo "Denied by pre-bash-gate: $1" >&2
+  exit 2
+}
+
+warn() {
+  echo "Warning from pre-bash-gate: $1" >&2
+}
+
+# Force-push to main (feature-branch force-push is fine)
+if echo "$cmd" | grep -qE 'git push[^|;&]*(--force|-f|\+)[^|;&]*(origin[[:space:]]+)?(refs/heads/)?main([[:space:]]|$)'; then
+  deny "force-push to main. Use a feature branch."
+fi
+
+# --no-verify skips hooks — hides the underlying failure
+if echo "$cmd" | grep -qE 'git[[:space:]]+(commit|push)[[:space:]].*(--no-verify)'; then
+  deny "--no-verify skips hooks. Fix the underlying failure instead."
+fi
+
+# rm -rf on /, /home, $HOME, ~
+if echo "$cmd" | grep -qE 'rm[[:space:]]+-rf?[[:space:]]+(/[^t]|/home|\$HOME|~)'; then
+  deny "destructive rm -rf on a system path. Move to /tmp if this is intentional."
+fi
+
+# git reset --hard on main
+if echo "$cmd" | grep -qE 'git[[:space:]]+reset[[:space:]]+--hard[[:space:]].*main'; then
+  deny "git reset --hard on main. Consider a soft reset or a new branch."
+fi
+
+# Force-move v1 tag without a paired gh release create: WARN, don't block.
+# (The release sequence is manual; this is a nudge, not a policy.)
+if echo "$cmd" | grep -qE 'git[[:space:]]+tag[[:space:]]+-f[[:space:]]+v1'; then
+  warn "moving v1. Remember: paired 'gh release create vX.Y.Z' is required for the release to show in the UI."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-bash-gate.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-write-remind.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/outrider-experimentation/SKILL.md
+++ b/.claude/skills/outrider-experimentation/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: outrider-experimentation
+description: |
+  Trigger, debug, and interpret Outrider Action runs on target repos as
+  part of Claude-Code-driven paper-to-code work. Covers manual dispatch
+  patterns, using remyxai-cli to scope paper search, fetching run logs
+  and RUN SUMMARY JSON to interpret outcomes, checking GitHub coordination
+  signals (existing PRs/Issues, upstream policy) before filing, and
+  reading the fidelity audit's Coverage matrix to identify gaps before
+  going upstream. Use when experimenting with Outrider on a target repo,
+  debugging a failed or downgraded run, or preparing to shepherd a
+  drafted PR upstream.
+allowed-tools: Bash, Read
+---
+
+# Outrider experimentation — field guide
+
+Ambient knowledge for using Outrider effectively on target repos: from dispatch to upstream. All commands here are ones I've actually used in practice; nothing speculative.
+
+## When to use
+
+- Setting up Outrider on a new target repo
+- Dispatching a manual refinement / smoke run
+- Diagnosing why a run downgraded to Issue or opened at a different outcome than expected
+- Deciding whether an Outrider-drafted PR is ready to file upstream
+- Cross-checking a paper against existing coordination signals on the target repo
+
+## Set up Outrider on a target repo
+
+Fastest path — CLI-generated workflow with the right backend selected:
+
+```bash
+remyxai outrider setup-local --repo owner/name --backend moonshot
+```
+
+Backends: `anthropic` (default, Opus), `zai` (GLM), `moonshot` (Kimi K3). Setup-local prompts only for the selected backend's secret; add others manually via `gh secret set ANTHROPIC_API_KEY --repo owner/name < token.txt` for per-dispatch switching.
+
+Manual install (when the CLI shape doesn't quite fit): copy the workflow YAML from `remyxai/outrider`'s `.github/workflows/outrider.yml` and thread the `interest-id` you get from `remyxai interests get -f json`.
+
+## Trigger manually
+
+```bash
+# Fresh recommend (let selection pass pick)
+gh workflow run outrider.yml --repo owner/name --ref main
+
+# Pin to a specific paper (skip selection)
+gh workflow run outrider.yml --repo owner/name --ref main \
+  -f pin-arxiv=2509.09675v1 \
+  -f provider=moonshot \
+  -f model=kimi-k3
+
+# Refinement on an existing drafter branch
+gh workflow run outrider.yml --repo owner/name --ref main \
+  -f pin-arxiv=<id> \
+  -f start-from-ref=<drafter-branch> \
+  -f staged-synthesis=true \
+  -f lead-content="REFINEMENT PASS on existing branch..."
+
+# Convention pass on an already-open PR
+gh workflow run outrider-convention.yml --repo owner/name --ref main -f pr-number=18
+```
+
+Key inputs to remember:
+- `pin-arxiv`: exact `<id>[v<N>]` — bypasses selection, best for reproducible runs
+- `pin-method`: free-text query for the selection pass to search (often prefer `search-method`; `pin-method` is a docs-only alias that GHA warns about)
+- `start-from-ref`: refinement mode — pins to an existing branch
+- `staged-synthesis=true`: enables research phase before coding (adds ~10 min for slow backends)
+- `claude-timeout`: bump to `3600` for Kimi K3 or GLM-5.2 (thinking-mode adds per-turn latency)
+- `rate-limit-days=0`: bypass the 7-day cadence guard for one-off smokes
+
+## Use remyxai-cli to scope search
+
+```bash
+# What's in the current interest pool for a repo
+remyxai interests get -i <name-or-uuid> -f json | jq '.recommendations[:5]'
+
+# Search by method for a specific paper before triggering
+remyxai search info --arxiv 2509.09675v1 -f json
+
+# Search across the engine's corpus by free text
+remyxai search query "curiosity driven exploration RLVR" -f json | jq '.results[:3]'
+```
+
+Use these before dispatching to avoid re-running the selection pass just to see if a paper is in-pool.
+
+## Get context from an Action run
+
+Runs' JSON RUN SUMMARY block is at the end of the log and is the authoritative source of truth:
+
+```bash
+# Fetch the per-job log (faster than per-run log; scoped to one job)
+JOB_ID=$(gh api "repos/OWNER/REPO/actions/runs/$RUN_ID/jobs" --jq '.jobs[0].id')
+gh api "repos/OWNER/REPO/actions/jobs/$JOB_ID/logs" 2>&1 | grep -A30 "RUN SUMMARY"
+```
+
+Fields worth grepping:
+
+- `"model_backend"` — actual backend that served the run ("Anthropic" / "z.ai (GLM)" / "Moonshot (Kimi)"). Authoritative when the workflow name lies (e.g., "Outrider daily (branch-mode, drafter)" workflows on GLM-swapped forks say drafter but route to GLM).
+- `"cost_usd"` — computed from `_BACKEND_RATES` when `cost_basis: "backend_rate_table"`; from Claude Code's envelope otherwise (Anthropic-rate estimate, approximate for GLM/Moonshot before the rate-table entry landed).
+- `"status"` — `pr_opened_draft` / `issue_opened_preflight` / `issue_opened_no_integration` / `skipped_open_artifact` / `claude_failed` / `error`.
+- `"chain"` — for recommend runs that chained into fidelity/convention/test. `fidelity_status: "fidelity_skipped_reference_mismatch"` means reference URL didn't self-identify with the arxiv — audit couldn't run, but PR is unchanged.
+
+Common ones and what they mean:
+
+| Status | What happened |
+|---|---|
+| `pr_opened_draft` | Full recommend produced a PR; likely worth reviewing |
+| `issue_opened_preflight` | Preflight decided PR-shape was wrong before coding — usually correct (new-feature-needs-approval, no clean integration point) |
+| `issue_opened_no_integration` | Coding ran, but preflight downgraded — sometimes correct, sometimes a false positive on a self-contained diff |
+| `skipped_open_artifact` | Rate-limit-days guard fired (recent PR/Issue exists on target) |
+| `skipped_low_confidence` | Selection couldn't find a moderate-tier candidate |
+| `claude_failed` | Coding session errored — check log tail for the actual traceback |
+| `error` | Something in run.py crashed before Claude Code was invoked — auth 401, git push, etc. |
+
+## Check coordination signals before filing upstream
+
+Before pushing an Outrider-drafted PR to the target upstream, check:
+
+```bash
+# Does the target repo have an AI-contribution policy?
+gh api repos/UPSTREAM/REPO/contents/CLAUDE.md --jq '.content' | base64 -d 2>/dev/null | head -30
+gh api repos/UPSTREAM/REPO/contents/AGENTS.md --jq '.content' | base64 -d 2>/dev/null | head -30
+# Look for: "coordination issue required before PR", "AI-assistance disclosure required", etc.
+
+# Are there existing PRs or Issues on this paper?
+gh search prs --repo UPSTREAM/REPO --state all "$PAPER_TITLE" --json number,title,state,createdAt
+gh search issues --repo UPSTREAM/REPO --state all "$PAPER_TITLE" --json number,title,state,createdAt
+
+# Is there a competing implementation in a sibling fork?
+gh search repos "$PAPER_TITLE" --limit 5
+
+# Has anyone attempted coordination on the paper's own repo?
+gh api repos/PAPER_REPO/issues --jq '.[] | select(.title | test("coord|port|implement"; "i"))'
+```
+
+Common gates that block going upstream:
+
+- **Target repo requires coordination Issue.** Open one on the *target repo*, not the paper repo (this is a common misinterpretation). Reference `smellslikeml/peft#10` → `huggingface/peft#3450` as a working example.
+- **AI-assistance disclosure required.** Every AI-assisted PR body must clearly state AI involvement + link the coordination Issue's approval comment.
+- **Existing open PR on same paper.** Don't open a duplicate. Comment on the existing one instead.
+- **Recent maintainer inactivity on that domain.** Bumping stale coordination Issues is fine; opening a PR when the last activity was months ago is riskier.
+
+## Analyze the fidelity audit output
+
+When a run's chain includes fidelity, the PR body gets a `## Coverage` matrix. Read it to see gaps before pushing upstream:
+
+```bash
+gh pr view $PR_NUMBER --repo OWNER/REPO --json body --jq '.body' | \
+  awk '/## Coverage/,/^## /'
+```
+
+Fidelity statuses to look for in the RUN SUMMARY's `chain.fidelity_status`:
+
+- `fidelity_audited` (or `_needs_judgment`, `_advisory`, `_paper_anchored`) — audit ran cleanly; Coverage matrix is populated with per-mechanism ✓/✗ marks
+- `fidelity_skipped_reference_mismatch` — reference repo didn't back-reference the arxiv (as with `github.com/volcengine/verl` hosting many papers). Audit couldn't run against a specific reference; PR body has no Coverage matrix
+- `fidelity_skipped_no_reference` — no reference impl exists at all; PR is paper-anchored only
+- `fidelity_failed_*` — audit crashed; needs a re-run before trusting the PR
+
+If Coverage matrix shows `✗` on a paper mechanism the maintainer would care about (e.g., "actor-wise perplexity bonus: not implemented" when the whole point is the actor bonus), that's a real gap. Options:
+
+1. **Dispatch a refinement pass** with `lead-content` naming the specific gap
+2. **Hand-fix in a follow-up commit** if the gap is small and mechanical
+3. **Route to Issue instead** — Coverage below a threshold means the PR isn't ready; open an Issue with the gap analysis and defer
+
+## Working with slow backends (Kimi K3, GLM-5.2)
+
+Both have thinking-mode latency; runs are 20-40 min per phase, not 5-15 min.
+
+- **claude-timeout**: `3600` (60 min) is baseline; threads through every phase.
+- **cost proxy**: rate-table entries exist for Anthropic, z.ai's glm-4.6 / glm-5.2, and Moonshot's kimi-k3 / kimi-k2.7-code(-highspeed). Everything else falls back to Claude Code's envelope, which over-reports non-Anthropic cost by 3-10×.
+
+## Active gotchas
+
+- **`Kimi 429 engine overloaded`**: Moonshot server-side capacity. Wait 30 min and re-dispatch; transient.
+- **Selection returns "no viable candidates"**: interest is stub-only. Verify with `remyxai interests get -i <name> -f json | jq '.context | length'` — expect > 500. If under, re-run `remyxai interests from-repo`.
+
+## Related
+
+- **CLI shape**: `.claude/skills/remyxai-cli.md` — the four command families (`interests`, `papers`, `outrider`, `search`) and common gotchas.
+- **Backend routing**: `docs/backends.md` in this repo — the canonical per-vendor table.
+- **Chain phase sequencing**: `AGENTS.md` `## Chain phases` section — which statuses continue vs short-circuit.

--- a/.claude/skills/remyxai-cli/SKILL.md
+++ b/.claude/skills/remyxai-cli/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: remyxai
+description: |
+  Guidance for using `remyxai-cli` — managing research interests, querying paper
+  recommendations, dispatching Outrider action runs, and running batched
+  design-review cycles. Trigger when the user mentions Outrider, GitRank,
+  paper recommendations, `remyxai` commands, or research-implementation
+  workflows against a target repo.
+allowed-tools: Bash, Read
+---
+
+# remyxai-cli guidance
+
+Four command families: `interests`, `papers`, `outrider`, `search`. Full help via `--help` on any subcommand. Global option: `-f json` on most subcommands for machine-readable output.
+
+## Setup for a new target repo
+
+- **Own repo** (team maintains it): `remyxai outrider init --auto-interest`
+- **External repo** (shepherding to it): `remyxai interests from-repo --url https://github.com/<owner>/<repo>`
+- **Never** run `remyxai interests create --context <URL>` — produces stub-only contexts. Use `from-repo` or `--auto-interest`.
+
+## Verify a new interest before relying on it
+
+`--auto-interest` sometimes returns success without extracting ExperimentHistory. Always verify:
+
+```bash
+remyxai interests get -i <name-or-uuid> -f json | jq '.context | length'
+# Expect > 500. Under that = stub, re-run `interests from-repo` explicitly.
+```
+
+Also note: `interests get` requires `-i <name-or-uuid>` — positional arguments do not work.
+
+## Query recommendations
+
+```bash
+remyxai papers list -i <interest> -p week -n 30 --full
+```
+
+- `-p today|week|all` — period filter
+- `--full` — full reasoning text (default truncates; usually you want `--full`)
+- `-f json` — machine-readable
+- `remyxai papers refresh` — trigger a fresh Gemini re-ranking run
+
+## Dispatch Outrider — three trigger modes
+
+```bash
+# Default: ranker picks from the interest-scoped pool
+remyxai outrider trigger --repo owner/name
+
+# Search-driven: overrides pool with a query
+remyxai outrider trigger --repo owner/name --search-method "<query>"
+
+# Pin a specific paper (bypasses pool, most reproducible)
+remyxai outrider trigger --repo owner/name --pin-arxiv <arxiv-id>
+```
+
+The target repo must already have Outrider installed (`remyxai outrider init` or `setup-local`). Authenticates via local `gh` CLI.
+
+## Backend selection (cost matters)
+
+- **Anthropic (default)**: premium reasoning, ~$3–5/dispatch. Best for shipping.
+- **z.ai GLM-5.2** (`--provider zai --model glm-5.2`): ~10× cheaper. Best for exploration.
+
+Rule of thumb: GLM for tier-1/2 exploration and batched trials; Anthropic for the one candidate you commit to shipping.
+
+## Batched design-review cycles
+
+`outrider explore` runs multiple cycles, deciding MERGE/ITERATE/LEAD/REJECT per candidate:
+
+```bash
+# Bounded run with GLM for cheap outer-loop reasoning
+remyxai outrider explore --repo owner/name --cycles 5 --budget 50 \
+   --provider zai --model glm-5.2
+
+# Dry-run: hypothesis stage only, no dispatch (cheapest inspection)
+remyxai outrider explore --repo owner/name --dry-run
+```
+
+Safety-by-design: never merges autonomously, respects preflight REJECTs, respects `--budget` (USD) and `--cycles` caps. Trace lands at `.remyx-autoresearch/trace.jsonl` in the current directory.
+
+## Third-party shepherding discipline
+
+Before dispatching against a repo you don't own, check for coordination signal:
+
+1. Open feature-request issues on the target (search title + body for the mechanism)
+2. Closed prior attempts on the same mechanism
+3. In-flight PRs touching the same file/module
+
+Coordinate — comment on the relevant issue or file a new one — **before** filing the PR. `huggingface/peft#3382` is the reference case: coordination issue #3380 + original author's endorsement preceded the PR and made review-engagement possible. Without that signal, even a technically-sound PR is friction.
+
+## Common status checks
+
+```bash
+# Recent dispatches on a fork
+gh run list --repo <owner>/<fork> --workflow outrider.yml -L 5
+
+# Run summary + cost/token usage
+gh run view <run-id> --repo <owner>/<fork>
+```
+
+## Interest ID drift across forks
+
+The **source of truth** for which interest a fork is using is `<fork>/.github/workflows/outrider.yml` — not any local Python mapping or config. If you're auditing or updating, patch the workflow file directly (`gh api -X PUT /repos/<fork>/contents/.github/workflows/outrider.yml`), not a side file that may lag.

--- a/.github/instructions/action-yaml.instructions.md
+++ b/.github/instructions/action-yaml.instructions.md
@@ -1,0 +1,12 @@
+---
+description: Editing action.yml, the composite-action definition.
+applyTo: "action.yml"
+---
+
+# action.yml conventions
+
+- **Additive changes only on the `provider` input's accepted values.** Never remove or rename existing values (`anthropic`, `zai`, `moonshot`, `custom`). Adding new values is safe.
+- **Every new input needs threading.** `inputs.<name>` in the top-level `inputs:` block AND `INPUT_<NAME>: ${{ inputs.<name> }}` in the recommend step's `env:` block. Missing the second half means run.py never sees it.
+- **Validate YAML after every edit.** `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"`.
+- **Secrets are read from the caller's env block.** Composite actions cannot access `secrets.*` directly. The caller passes them via `env:` on the `- uses:` step; the action's Configure step then chooses the right one per `provider`.
+- **Mutual exclusion between `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`** — Claude Code prefers `x-api-key` when both are set, and non-Anthropic backends 401 on that. The Configure step explicitly clears the non-selected auth var; do not remove that clearing.

--- a/.github/instructions/src-run.instructions.md
+++ b/.github/instructions/src-run.instructions.md
@@ -1,0 +1,13 @@
+---
+description: Rules for editing src/run.py, the monolithic main logic file.
+applyTo: "src/run.py"
+---
+
+# src/run.py conventions
+
+- **Single-file by design.** ~16K LOC. Do not split into modules — session-crossing state, single import point for the composite action.
+- **Search before writing.** Grep for `def <name>` or the concept — the function you want probably exists (`_github_token`, `_record_claude_usage`, `run_fidelity_audit`, `_mint_bot_token`).
+- **Test before commit.** Every new behavior needs a test in `tests/test_<area>.py`. Existing tests use monkeypatch to intercept subprocess, gh_api, and Claude CLI calls.
+- **No new error handling for scenarios that can't happen.** Trust framework guarantees inside outrider. Only validate at external boundaries — GitHub API responses, action inputs, Claude subprocess output.
+- **Don't touch `_BACKEND_RATES` structure.** Additive rate-row updates only. Adding a model = new row + a matching test in `test_model_base_url.py`.
+- **Chain-phase sequencing lives in `run_refinement_chain`** (around L16410). fidelity → convention → test. `fidelity_skipped_*` continues to convention + test (except `no_pr`); `fidelity_failed_*` short-circuits.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,12 @@
+---
+description: Conventions for adding or modifying tests.
+applyTo: "tests/**/*.py"
+---
+
+# Test conventions
+
+- **Pin behavior, not code shape.** A test that asserts "input X → output Y" survives refactors. A test that asserts "function foo is called" breaks on unrelated changes.
+- **Monkeypatch external calls.** subprocess.run, gh_api, urllib.request.urlopen, Claude CLI. Grep existing tests for `monkeypatch.setattr` for patterns.
+- **One file per concern.** `test_bot_token_default.py`, `test_backend_rates.py`, `test_inline_refinement_chain.py` — mirror the src/ area they cover.
+- **Fixtures at module level.** Not conftest.py unless truly cross-cutting; keeps the test file self-contained.
+- **Full suite must stay green.** `python3 -m pytest tests/ -q` before every commit.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ __pycache__/
 .mypy_cache/
 .ruff_cache/
 .coverage
+
+# Env files (never commit)
+.env
+.env.*
+!.env.example
+*.env.local
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md — Outrider
+
+Guidance for AI coding agents working on this repository. Read this before touching source.
+
+## What this project is
+
+Outrider is a **GitHub Action** that turns arXiv papers into draft PRs on target repos. It:
+
+1. Queries the Remyx engine for a paper recommendation against a repo's `ResearchInterest`.
+2. Clones the target repo, drafts an implementation via Claude Code, runs pytest + self-review.
+3. Opens a draft PR (or Issue when preflight downgrades) attributed to `remyx-ai[bot]`.
+4. Optionally runs an inline refinement chain: fidelity audit → convention pass → test gate.
+
+The Action is **backend-agnostic** through Claude Code's Anthropic-Messages-compatible endpoints — Anthropic (default), z.ai/GLM, Moonshot/Kimi via the `provider` action input.
+
+## Build & test
+
+- **Full test suite:** `python3 -m pytest tests/ -q` (~15s, ~1050 tests + 1 skipped)
+- **Targeted:** `python3 -m pytest tests/test_bot_token_default.py -x -q`
+- **Validate `action.yml`:** `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"`
+- No `pip install -e .`; the action installs its own deps in `action.yml`'s composite steps.
+
+Run tests before every commit. New behavior needs pinning tests before the PR opens.
+
+## Architecture at a glance
+
+- **`src/run.py`** — main logic (~16K LOC, one file, intentionally). Selection, preflight, coding invocation, chain phases, cost telemetry, bot-token minting — all in here. Search for `def ` before adding a function; the piece you want probably exists.
+- **`action.yml`** — composite-action step definitions. Inputs threaded into `run.py` via `INPUT_*` env vars. Adding a new input means an `action.yml` entry + a reader in `run.py`.
+- **`tests/`** — every phase has its own `test_*.py` file. Tests intercept subprocess calls, GitHub API calls, and Claude CLI calls with monkeypatch stubs.
+- **`docs/`** — customer-facing docs. `backends.md` is the canonical vendor table. `customization.md` is the input-shape reference.
+
+## Backend routing (provider input)
+
+- `provider` accepts `anthropic` / `zai` / `moonshot` / `custom` / empty. Empty = passthrough (existing behavior byte-for-byte).
+- Set-provider logic lives in `action.yml`'s Configure step, not in `run.py` — it writes `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL` to `$GITHUB_ENV` for the coding step.
+- Per-model cost telemetry lives in `_BACKEND_RATES` (nested `{host: {model: rates}}`). To add a model, add a row there and a matching test in `test_model_base_url.py`.
+- **Mutual exclusion:** Claude Code prefers `x-api-key` when both auth vars are set. The Configure step clears the non-selected auth var explicitly. Do not remove that clearing — non-Anthropic backends 401 without it.
+
+## Chain phases (post-PR-open)
+
+Sequence when `recommend` mode opens a PR: **fidelity audit → convention pass → test gate**. Sequence is enforced in `run_refinement_chain` (`src/run.py`, around L16410). Each phase inherits the run's `claude-timeout`.
+
+- `fidelity_audited*` → continue to convention + test (existing).
+- `fidelity_skipped_*` (except `no_pr`) → also continue (added in v1.7.33). Audit couldn't run but the PR is unchanged; downstream doesn't depend on fidelity signal.
+- `fidelity_failed_*` → short-circuit conservatively (audit crashed; don't muck with the PR).
+- `fidelity_skipped_no_pr` → short-circuit (nothing to work on).
+
+## Conventions
+
+- **Commit format:** conventional (`feat(scope): …`, `fix(scope): …`, `docs(scope): …`, `chore(scope): …`). Body describes the *why*, not the *what*.
+- **No co-author line.** Repo convention omits `Co-Authored-By: Claude …`; the maintainers don't use it.
+- **PR body:** terse on this public repo. No Linear IDs, no customer names, no dollar figures from internal trials. `test_*.py` names are fine.
+- **Version discipline:** `@v1` is a moving tag; ship additive changes on `@v1` without a version bump. New input + new provider values + new rate table rows are all additive. **Breaking changes (rename, remove, semantic change) require reviewing every caller.**
+- **Release convention:** every version bump = `git tag vX.Y.Z <sha>` + `git push origin vX.Y.Z` + `git tag -f v1 <sha>` + `git push -f v1` + `gh release create vX.Y.Z --notes ...`. The `gh release create` step is easy to forget; the git tag push alone does NOT surface in the GitHub UI.
+
+## Guardrails — do not do these
+
+- Don't change `_BACKEND_RATES` structure — additive rate-row updates only.
+- Don't remove `provider` input's accepted values. Add new; never remove or rename.
+- Don't add per-phase timeout inputs. `claude-timeout` is the single per-phase knob; this is a design decision, not an omission.
+- Don't touch the `_recommit_via_api` bot-token flow without reading `_mint_bot_token`'s TTL handling first (installation tokens have a 60-min TTL; the re-mint path is deliberate).
+- Don't `git push --no-verify` or `--force` on `main`.
+- Don't skip tests or add `pytest.skip` without explicit justification.
+
+## Working with slow backends (Kimi, GLM-5.2)
+
+Kimi K3's thinking mode adds per-turn latency. Refinement runs on Kimi routinely take 20-40 min per phase. When editing timeout logic:
+
+- `claude-timeout` default is 900s (adequate for Opus/Haiku).
+- Recommended `3600s` for Kimi runs (Moonshot backend default in the CLI registry).
+- The bot-token TTL is 60 min; re-mint fires at 55 min. Anything that skips `_github_token()`'s freshness check will 401 at push time.
+
+## Where to look first
+
+- **New failure in a chain phase** → `src/run.py`'s `run_refinement_chain` and the phase's own runner (`run_fidelity_audit`, `run_convention_pass`, `run_test_gate`).
+- **Cost telemetry wrong** → `_record_claude_usage` and `_BACKEND_RATES` in `src/run.py`.
+- **Auth 401 at push** → `_github_token` + `_mint_bot_token` + `commit_and_push`'s `git remote set-url` refresh.
+- **Preflight routing surprise** → `preflight_route` in `src/run.py` and the Target-shape input flow from `action.yml`.
+- **New input not being read** → check `action.yml`'s Recommend step env block; every input needs a matching `INPUT_*` line.
+
+## What good work looks like here
+
+- Tests before implementation — pin the behavior, then make the code match.
+- Small commits with clear conventional prefixes.
+- Public-repo PR bodies terse; detail belongs in the docs/, not the PR.
+- Version + tag + `gh release create` for every ship (the release is the missing step half the time).
+- End-to-end smoke on a real fork before force-pushing an upstream PR fix.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -41,9 +41,9 @@ Outrider tags each candidate paper with a confidence tier (`high` / `moderate` /
 
 Set to a specific `arxiv_id` and Outrider skips the selection pass entirely, implementing that exact paper. Use for eval re-runs and demos.
 
-### Method-targeted runs — `pin-method`
+### Method-targeted runs — `search-method`
 
-Set to a free-text method query (e.g. `"knowledge distillation"`) or a literal `arxiv_id`. Outrider resolves it to the top arxiv match and implements it directly — bypassing the candidate pool and selection pass. Strict superset of `pin-arxiv`: it also works on papers outside the interest's pool (via direct asset lookup). Mutually exclusive with `pin-arxiv`.
+Set to a free-text method query (e.g. `"knowledge distillation"`). Outrider searches the engine's full corpus for the top match rather than restricting to the interest's normal candidate pool, so a paper outside the pool can still be implemented. Use for exploratory dispatches when you don't have an exact `arxiv_id`; use `pin-arxiv` instead when you do. Mutually exclusive with `pin-arxiv`.
 
 ### Model backend — `model-base-url`
 


### PR DESCRIPTION
## Summary

Adds the AI-agent meta-layer around this codebase so future agent sessions load context on entry instead of re-deriving it each time. Score under [paladini/harness-score](https://github.com/paladini/harness-score): **L0 · 27% → L2 · 70%**. No runtime behavior changes — entirely additive scaffolding.

## What landed

- **`AGENTS.md`** — repo-root context: architecture, build & test, backend routing, chain phases, release conventions, guardrails.
- **`.github/instructions/{src-run,tests,action-yaml}.instructions.md`** — scoped rules (Copilot-format frontmatter with `applyTo` globs) for the three code-shaped areas. Applied per-file, not always-on.
- **`.claude/skills/outrider-experimentation/SKILL.md`** — user-facing field guide: manual dispatch, remyxai-cli scoping, log/step-summary parsing, coordination-signal checks, fidelity audit reading.
- **`.claude/skills/remyxai-cli/SKILL.md`** — CLI context (mirrors the v1 draft that will ship as the CLI's own install-skill artifact when [REMYX-205](https://linear.app/remyx/issue/REMYX-205) lands).
- **`.claude/commands/release.md`** — `/release` slash command codifying tag → push → `gh release create` → v1-move. The `gh release create` step is the one everyone forgets.
- **`.claude/settings.json` + `.claude/hooks/`** — PreToolUse Bash gate (denies force-push main, `--no-verify`, destructive `rm -rf`, `git reset --hard main`; warns on `git tag -f v1`). PostToolUse feedback (pytest reminder after `src/run.py` edits, YAML validation after `action.yml`, doc/code consistency after `docs/`).
- **`.gitignore`** — env-file coverage.
- **`docs/customization.md`** — fixes `pin-method` docs term → `search-method` (actual action input). Root cause of the `Unexpected input(s) 'pin-method'` warning seen on smoke dispatches.

## Score breakdown

| Dimension | Before (L0) | After (L2) |
|---|---|---|
| Context & Guides | 10% | **100%** |
| Skills & Commands | 0% | 71% |
| Hooks & Guardrails | 0% | **100%** |
| Sensors & Feedback | 10% | 10% |
| CI Feedback | 57% | 57% |
| Hygiene & Safety | 74% | 87% |

L3 gate is `sensors ≥ 60%` — requires adopting linter/formatter/type-checker tooling. Follow-up ticket for that; explicitly not in this PR because it's a real project (16K-LOC `src/run.py` baseline), not a docs bump.

## Test plan

- [x] `python3 -m pytest tests/ -q` — 1057 pass, 1 skipped (unchanged; no runtime code touched)
- [x] `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"` — parses (unchanged)
- [x] `npx harness-score` — L2 · 76/108 (70%)
- [x] Hook scripts: `bash -n .claude/hooks/pre-bash-gate.sh` + `bash -n .claude/hooks/post-write-remind.sh` — valid

## Compatibility

Backward-compatible. No runtime code changes; adding these files does not affect action behavior. The `remyxai/outrider@v1` action tag will not need to move for this change alone — but shipping under the next version tag anyway keeps the release cadence coherent.