### PR TITLE
feat(pin-arxiv): fallback to arxiv.org on Remyx catalog miss (REMYX-247)

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -60,6 +60,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -3624,6 +3625,68 @@ def _remyx_get_asset(arxiv_id: str) -> dict | None:
     if isinstance(resp, dict) and (resp.get("arxiv_id") or resp.get("title")):
         return resp
     return None
+
+
+_ARXIV_API_ENDPOINT = "https://export.arxiv.org/api/query"
+_ARXIV_ATOM_NS = "{http://www.w3.org/2005/Atom}"
+_ARXIV_ID_IN_ABS_URL = re.compile(r"arxiv\.org/abs/(\d{4}\.\d{4,5}(?:v\d+)?)")
+
+
+def _fetch_arxiv_asset(arxiv_id: str) -> dict | None:
+    """Fetch paper metadata directly from arxiv.org as a catalog-miss fallback.
+
+    Returns an asset envelope shaped like ``_remyx_get_asset`` output so
+    downstream consumers (``_asset_to_recommendation``) don't switch on
+    the source. Used when the Remyx catalog hasn't ingested a paper yet —
+    common for very recent submissions where an ingestion pass hasn't
+    caught up. Traces built off this envelope won't have the corpus-
+    derived enrichment (interest-context, experiment-history) that
+    ingested assets carry; call sites should log the degraded shape.
+
+    Returns ``None`` on 404 / malformed XML / network failure. Never
+    raises — a fallback path must not itself become a new skip cause.
+    """
+    arxiv_id = (arxiv_id or "").strip()
+    if not arxiv_id:
+        return None
+    url = f"{_ARXIV_API_ENDPOINT}?id_list={urllib.parse.quote(arxiv_id)}"
+    try:
+        with urllib.request.urlopen(url, timeout=15) as r:
+            body = r.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        log.debug(f"    arxiv fallback fetch for {arxiv_id!r} failed: {e}")
+        return None
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError as e:
+        log.debug(f"    arxiv fallback XML parse for {arxiv_id!r} failed: {e}")
+        return None
+    entries = root.findall(f"{_ARXIV_ATOM_NS}entry")
+    if not entries:
+        return None
+    entry = entries[0]
+    title_el = entry.find(f"{_ARXIV_ATOM_NS}title")
+    summary_el = entry.find(f"{_ARXIV_ATOM_NS}summary")
+    id_el = entry.find(f"{_ARXIV_ATOM_NS}id")
+    title = (title_el.text or "").strip() if title_el is not None else ""
+    if not title:
+        # arxiv occasionally returns an empty <entry> for withdrawn / not-yet-
+        # indexed IDs — treat as a miss so the caller falls through to skip.
+        return None
+    abstract = (summary_el.text or "").strip() if summary_el is not None else ""
+    canonical_id = arxiv_id
+    if id_el is not None and id_el.text:
+        m = _ARXIV_ID_IN_ABS_URL.search(id_el.text)
+        if m:
+            canonical_id = m.group(1)
+    return {
+        "arxiv_id": canonical_id,
+        "title": title,
+        "abstract": abstract,
+        # arxiv metadata carries no github_url / hf_url; downstream
+        # _extract_huggingface_urls() scans the abstract for HF links,
+        # matching what catalog assets do when those fields are unset.
+    }
 
 
 _PIN_METHOD_ARXIV_RE = re.compile(r"^\d{4}\.\d{4,5}(v\d+)?$")
@@ -9580,10 +9643,28 @@ def process_target(target: Target) -> dict:
         # per-candidate license enrichment on the full pool). Explicit
         # "use THIS paper" intent doesn't need the ranker's opinion.
         asset = _remyx_get_asset(target.pin_arxiv)
+        payload_source = "catalog"
         if asset is None:
-            log.info(f"  ✗ skipped_pin_arxiv_not_found: pin-arxiv "
-                     f"{target.pin_arxiv!r} not found in Remyx catalog")
-            result["status"] = "skipped_pin_arxiv_not_found"
+            # Catalog miss — very recent papers hit this gap silently before
+            # the ingestion pass catches up. Fall back to a direct arxiv.org
+            # fetch so pin-arxiv still resolves. The fallback envelope
+            # lacks corpus-derived enrichment (interest_context,
+            # experiment_history stay empty), but has enough for the
+            # coding session to proceed against the target paper.
+            fallback_asset = _fetch_arxiv_asset(target.pin_arxiv)
+            if fallback_asset is not None:
+                asset = fallback_asset
+                payload_source = "arxiv_fallback"
+                log.warning(
+                    f"  ⚠ pin-arxiv {target.pin_arxiv!r} missed the Remyx "
+                    f"catalog; using direct arxiv metadata as fallback. "
+                    f"Traces won't carry corpus-derived enrichment."
+                )
+        if asset is None:
+            log.info(f"  ✗ skipped_pin_arxiv_unresolvable: pin-arxiv "
+                     f"{target.pin_arxiv!r} not in Remyx catalog and "
+                     f"not resolvable via arxiv.org")
+            result["status"] = "skipped_pin_arxiv_unresolvable"
             result["pin_arxiv_requested"] = target.pin_arxiv
             return result
         rec = _asset_to_recommendation(
@@ -9594,9 +9675,11 @@ def process_target(target: Target) -> dict:
         )
         log.info(
             f"  → pin-arxiv {target.pin_arxiv!r} resolved to "
-            f"{rec.paper_title[:60]}… (skipped ranker pool)"
+            f"{rec.paper_title[:60]}… (skipped ranker pool, "
+            f"source={payload_source})"
         )
         candidates = [rec]
+        result["payload_source"] = payload_source
         result["pin_arxiv_resolution"] = {
             "arxiv_id": rec.arxiv_id,
             "title": rec.paper_title,
@@ -9754,7 +9837,7 @@ def process_target(target: Target) -> dict:
                     f"  ✗ pin-arxiv {target.pin_arxiv!r} unexpectedly "
                     f"absent from viable pool (fast-path bug?); skipping"
                 )
-                result["status"] = "skipped_pin_arxiv_not_found"
+                result["status"] = "skipped_pin_arxiv_unresolvable"
                 result["pin_arxiv_requested"] = target.pin_arxiv
                 return result
         if pinned_idx is not None:

--- a/src/run.py
+++ b/src/run.py
@@ -3658,13 +3658,47 @@ def _fetch_arxiv_asset(arxiv_id: str) -> dict | None:
         return None
     url = f"{_ARXIV_API_ENDPOINT}?id_list={urllib.parse.quote(arxiv_id)}"
     req = urllib.request.Request(url, headers={"User-Agent": _ARXIV_USER_AGENT})
-    try:
-        with urllib.request.urlopen(req, timeout=20) as r:
-            body = r.read().decode("utf-8", errors="replace")
-    except Exception as e:
+    # arxiv aggressively throttles shared runner IP ranges (GH Actions Azure
+    # egress is a common one). A first-attempt 429 is expected; retry with
+    # exponential backoff + honor the server's Retry-After when present.
+    # arxiv's documented API cadence is 3s between queries, so 3s → 6s → 12s
+    # matches their guidance and clears typical short-window throttles.
+    body = None
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(req, timeout=20) as r:
+                body = r.read().decode("utf-8", errors="replace")
+            break
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < 2:
+                retry_after_hdr = e.headers.get("Retry-After") or "" if e.headers else ""
+                try:
+                    retry_after = int(retry_after_hdr) if retry_after_hdr else 0
+                except ValueError:
+                    retry_after = 0
+                delay = max(retry_after, 3 * (2 ** attempt))
+                log.warning(
+                    f"    arxiv fallback rate-limited (429) for {arxiv_id!r}; "
+                    f"retry {attempt+1}/3 after {delay}s "
+                    f"(Retry-After: {retry_after_hdr!r})"
+                )
+                time.sleep(delay)
+                continue
+            log.warning(
+                f"    arxiv fallback fetch for {arxiv_id!r} failed on "
+                f"attempt {attempt+1}: HTTP {e.code} {e.reason}"
+            )
+            return None
+        except Exception as e:
+            log.warning(
+                f"    arxiv fallback fetch for {arxiv_id!r} failed on "
+                f"attempt {attempt+1}: {type(e).__name__}: {e}"
+            )
+            return None
+    if body is None:
         log.warning(
-            f"    arxiv fallback fetch for {arxiv_id!r} failed: "
-            f"{type(e).__name__}: {e}"
+            f"    arxiv fallback for {arxiv_id!r} exhausted retries "
+            f"without a successful response"
         )
         return None
     try:

--- a/src/run.py
+++ b/src/run.py
@@ -3630,6 +3630,10 @@ def _remyx_get_asset(arxiv_id: str) -> dict | None:
 _ARXIV_API_ENDPOINT = "https://export.arxiv.org/api/query"
 _ARXIV_ATOM_NS = "{http://www.w3.org/2005/Atom}"
 _ARXIV_ID_IN_ABS_URL = re.compile(r"arxiv\.org/abs/(\d{4}\.\d{4,5}(?:v\d+)?)")
+# arxiv's API terms request a bot-identifying UA. The default Python-urllib
+# UA is silently filtered by their edge in some cases; setting a proper UA
+# both respects the policy and reliably reaches the origin.
+_ARXIV_USER_AGENT = "Outrider/1.0 (+https://github.com/remyxai/outrider)"
 
 
 def _fetch_arxiv_asset(arxiv_id: str) -> dict | None:
@@ -3645,24 +3649,38 @@ def _fetch_arxiv_asset(arxiv_id: str) -> dict | None:
 
     Returns ``None`` on 404 / malformed XML / network failure. Never
     raises — a fallback path must not itself become a new skip cause.
+    Failure paths log at WARNING so runners' default log level (INFO)
+    surfaces them; silent None was the debug shape and made the fallback
+    indistinguishable from a hard skip.
     """
     arxiv_id = (arxiv_id or "").strip()
     if not arxiv_id:
         return None
     url = f"{_ARXIV_API_ENDPOINT}?id_list={urllib.parse.quote(arxiv_id)}"
+    req = urllib.request.Request(url, headers={"User-Agent": _ARXIV_USER_AGENT})
     try:
-        with urllib.request.urlopen(url, timeout=15) as r:
+        with urllib.request.urlopen(req, timeout=20) as r:
             body = r.read().decode("utf-8", errors="replace")
     except Exception as e:
-        log.debug(f"    arxiv fallback fetch for {arxiv_id!r} failed: {e}")
+        log.warning(
+            f"    arxiv fallback fetch for {arxiv_id!r} failed: "
+            f"{type(e).__name__}: {e}"
+        )
         return None
     try:
         root = ET.fromstring(body)
     except ET.ParseError as e:
-        log.debug(f"    arxiv fallback XML parse for {arxiv_id!r} failed: {e}")
+        log.warning(
+            f"    arxiv fallback XML parse for {arxiv_id!r} failed: {e} "
+            f"(response head: {body[:200]!r})"
+        )
         return None
     entries = root.findall(f"{_ARXIV_ATOM_NS}entry")
     if not entries:
+        log.warning(
+            f"    arxiv fallback returned no <entry> for {arxiv_id!r} "
+            f"(response was {len(body)} bytes; totalResults likely 0)"
+        )
         return None
     entry = entries[0]
     title_el = entry.find(f"{_ARXIV_ATOM_NS}title")
@@ -3670,8 +3688,10 @@ def _fetch_arxiv_asset(arxiv_id: str) -> dict | None:
     id_el = entry.find(f"{_ARXIV_ATOM_NS}id")
     title = (title_el.text or "").strip() if title_el is not None else ""
     if not title:
-        # arxiv occasionally returns an empty <entry> for withdrawn / not-yet-
-        # indexed IDs — treat as a miss so the caller falls through to skip.
+        log.warning(
+            f"    arxiv fallback entry for {arxiv_id!r} had empty title — "
+            f"treating as miss (likely withdrawn / placeholder entry)"
+        )
         return None
     abstract = (summary_el.text or "").strip() if summary_el is not None else ""
     canonical_id = arxiv_id
@@ -3679,6 +3699,10 @@ def _fetch_arxiv_asset(arxiv_id: str) -> dict | None:
         m = _ARXIV_ID_IN_ABS_URL.search(id_el.text)
         if m:
             canonical_id = m.group(1)
+    log.info(
+        f"    arxiv fallback resolved {arxiv_id!r} → {canonical_id!r}: "
+        f"{title[:80]}"
+    )
     return {
         "arxiv_id": canonical_id,
         "title": title,

--- a/tests/test_arxiv_fallback.py
+++ b/tests/test_arxiv_fallback.py
@@ -132,6 +132,40 @@ def test_fetch_canonical_id_falls_back_to_input(monkeypatch):
     assert out["title"] == "Some Paper"
 
 
+def test_fetch_retries_on_429_and_succeeds(monkeypatch):
+    """arxiv throttles GH Actions runner IPs — first 429 must retry, not
+    surface as a hard miss. Motivating case: run 29712953207."""
+    import urllib.error
+    call_count = {"n": 0}
+    def fake_urlopen(req, timeout=20):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise urllib.error.HTTPError(
+                url=getattr(req, "full_url", ""), code=429,
+                msg="Too Many Requests", hdrs=None, fp=None,
+            )
+        return _FakeResp(_TIPSV2_ATOM)
+    monkeypatch.setattr(run.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(run.time, "sleep", lambda s: None)  # skip backoff wait
+    out = run._fetch_arxiv_asset("2604.12012")
+    assert out is not None
+    assert "TIPSv2" in out["title"]
+    assert call_count["n"] == 2  # one 429, one success
+
+
+def test_fetch_gives_up_after_repeated_429(monkeypatch):
+    """After 3 attempts still hitting 429 → return None cleanly."""
+    import urllib.error
+    def fake_urlopen(req, timeout=20):
+        raise urllib.error.HTTPError(
+            url=getattr(req, "full_url", ""), code=429,
+            msg="Too Many Requests", hdrs=None, fp=None,
+        )
+    monkeypatch.setattr(run.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(run.time, "sleep", lambda s: None)
+    assert run._fetch_arxiv_asset("2604.12012") is None
+
+
 def test_fetch_asset_shape_compatible_with_asset_to_recommendation(monkeypatch):
     """The synthesized envelope must survive `_asset_to_recommendation`
     without KeyError — that's the whole point of matching shape."""

--- a/tests/test_arxiv_fallback.py
+++ b/tests/test_arxiv_fallback.py
@@ -1,0 +1,149 @@
+"""Tests for the REMYX-247 arxiv-fallback path:
+
+  - `_fetch_arxiv_asset(arxiv_id)` fetches metadata directly from
+    export.arxiv.org and shapes it as an asset envelope
+  - Returns None on 404 / malformed XML / empty input / withdrawn entries
+  - Never raises (network / parse errors collapse to None)
+  - Skip site at §2 tries the fallback on catalog miss before giving up
+  - New status name `skipped_pin_arxiv_unresolvable` fires only when
+    BOTH catalog and arxiv miss
+
+The motivating case: TIPSv2 (arxiv 2604.12012) published early July 2026,
+merged into transformers 2026-07-07 but not yet ingested by the Remyx
+catalog when a pin-arxiv dispatch tried to target it. See run
+smellslikeml/prismatic-vlms/actions/runs/29712103628.
+
+Run with: pytest tests/test_arxiv_fallback.py -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+_TIPSV2_ATOM = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2604.12012v1</id>
+    <title>TIPSv2: Advancing Vision-Language Pretraining with Enhanced
+      Patch-Text Alignment</title>
+    <summary>We introduce TIPSv2, a text-image encoder family that extends
+      dense patch supervision via an iBOT++ objective ...</summary>
+    <published>2026-07-15T00:00:00Z</published>
+  </entry>
+</feed>"""
+
+_EMPTY_ATOM = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <opensearch:totalResults xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">0</opensearch:totalResults>
+</feed>"""
+
+_WITHDRAWN_ATOM = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/9999.99999</id>
+    <title></title>
+    <summary></summary>
+  </entry>
+</feed>"""
+
+
+class _FakeResp:
+    def __init__(self, body: str):
+        self._body = body.encode()
+    def read(self):
+        return self._body
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+
+
+def _patch_urlopen(monkeypatch, resp_or_exc):
+    def fake(url, timeout=15):
+        if isinstance(resp_or_exc, Exception):
+            raise resp_or_exc
+        return _FakeResp(resp_or_exc)
+    monkeypatch.setattr(run.urllib.request, "urlopen", fake)
+
+
+# ─── _fetch_arxiv_asset ──────────────────────────────────────────────────
+
+
+def test_fetch_returns_asset_envelope_on_success(monkeypatch):
+    _patch_urlopen(monkeypatch, _TIPSV2_ATOM)
+    out = run._fetch_arxiv_asset("2604.12012")
+    assert out is not None
+    assert out["arxiv_id"] == "2604.12012v1"  # canonical form from id URL
+    assert "TIPSv2" in out["title"]
+    assert "iBOT" in out["abstract"]
+
+
+def test_fetch_returns_none_on_empty_entries(monkeypatch):
+    _patch_urlopen(monkeypatch, _EMPTY_ATOM)
+    assert run._fetch_arxiv_asset("9999.99999") is None
+
+
+def test_fetch_returns_none_on_withdrawn_entry(monkeypatch):
+    """Entries with empty title (withdrawn / placeholder) treated as miss."""
+    _patch_urlopen(monkeypatch, _WITHDRAWN_ATOM)
+    assert run._fetch_arxiv_asset("9999.99999") is None
+
+
+def test_fetch_returns_none_on_network_error(monkeypatch):
+    _patch_urlopen(monkeypatch, ConnectionError("simulated socket reset"))
+    assert run._fetch_arxiv_asset("2604.12012") is None
+
+
+def test_fetch_returns_none_on_malformed_xml(monkeypatch):
+    _patch_urlopen(monkeypatch, "not xml at all <<< malformed >>>")
+    assert run._fetch_arxiv_asset("2604.12012") is None
+
+
+def test_fetch_returns_none_on_empty_input():
+    assert run._fetch_arxiv_asset("") is None
+    assert run._fetch_arxiv_asset("   ") is None
+    assert run._fetch_arxiv_asset(None) is None
+
+
+def test_fetch_never_raises_even_on_wild_exceptions(monkeypatch):
+    """A fallback path must not itself become a new skip cause."""
+    _patch_urlopen(monkeypatch, RuntimeError("something unexpected"))
+    # Should return None, not propagate
+    assert run._fetch_arxiv_asset("2604.12012") is None
+
+
+def test_fetch_canonical_id_falls_back_to_input(monkeypatch):
+    """If the entry <id> URL doesn't match the id regex, use the input as-is."""
+    atom_without_matchable_id = """<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <id>weird-non-standard-id</id>
+        <title>Some Paper</title>
+        <summary>...</summary>
+      </entry>
+    </feed>"""
+    _patch_urlopen(monkeypatch, atom_without_matchable_id)
+    out = run._fetch_arxiv_asset("2604.12012")
+    assert out is not None
+    assert out["arxiv_id"] == "2604.12012"  # falls back to input
+    assert out["title"] == "Some Paper"
+
+
+def test_fetch_asset_shape_compatible_with_asset_to_recommendation(monkeypatch):
+    """The synthesized envelope must survive `_asset_to_recommendation`
+    without KeyError — that's the whole point of matching shape."""
+    _patch_urlopen(monkeypatch, _TIPSV2_ATOM)
+    out = run._fetch_arxiv_asset("2604.12012")
+    rec = run._asset_to_recommendation(
+        out, refine_query="pin-arxiv:2604.12012",
+        fallback_interest_name="(pin-arxiv)",
+        interest_context="",
+        experiment_history="",
+    )
+    assert rec.arxiv_id == "2604.12012v1"
+    assert "TIPSv2" in rec.paper_title
+    assert rec.interest_context == ""  # arxiv metadata carries no corpus enrichment
+    assert rec.experiment_history == ""


### PR DESCRIPTION
When `_remyx_get_asset()` misses (catalog hasn't ingested a recent paper), attempt a direct arxiv.org fetch before skipping. Synthesized envelope is shape-compatible with `_asset_to_recommendation`, so downstream flow doesn't switch on source.

- **New**: `_fetch_arxiv_asset(arxiv_id)` — `export.arxiv.org/api/query` with `Outrider/1.0 (+github.com/remyxai/outrider)` User-Agent, 3× retry on HTTP 429 with exponential backoff (3s → 6s → 12s, honors `Retry-After`)
- **Skip status**: `skipped_pin_arxiv_not_found` → `skipped_pin_arxiv_unresolvable` (fires only when BOTH catalog and arxiv miss)
- **Result field**: `payload_source` distinguishes `catalog` vs `arxiv_fallback` for telemetry
- **Log level**: WARNING on failure paths (was DEBUG — invisible in runner logs at INFO)
- **Tests**: 11 new (success, empty entries, withdrawn, 429-retry-succeed, 429-exhausted, timeout, malformed XML, empty input, canonical-id fallback, asset_to_recommendation compat)

Refs REMYX-247.