### PR TITLE
fix(license): match project-page URLs by hostname, not just path

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -2517,8 +2517,16 @@ def _fetch_url_html(url: str, timeout_s: int = 10) -> str:
 
 def _extract_project_page_urls(html: str, title: str) -> list[str]:
     """Extract URLs from ``html`` that look like paper-project pages —
-    URL path contains a title-word substring. Filters out github (already
-    handled by the direct-arxiv-HTML path) and boilerplate hosts.
+    URL path OR hostname contains a title-word substring. Filters out
+    github (already handled by the direct-arxiv-HTML path) and
+    boilerplate hosts.
+
+    Hostname match catches the ``<paper-name>.github.io/`` (and
+    ``<paper-name>.io/`` / ``<lab>.<paper>.dev/``) pattern that's the
+    dominant academic project-page convention — the paper name lives in
+    the subdomain and the path is empty. The prior path-only check
+    silently skipped these, costing license detection on any paper whose
+    only code link was reachable via such a project page.
     """
     if not html:
         return []
@@ -2537,12 +2545,18 @@ def _extract_project_page_urls(html: str, title: str) -> list[str]:
             "doi.org/", "openreview.net/",
         )):
             continue
-        # Path (after the host) contains at least one title-word substring?
+        # Split into hostname + path. Empty path is common for project
+        # pages served at the root of a paper-named subdomain.
         try:
-            path = url.split("//", 1)[1].split("/", 1)[1].lower()
+            host_and_path = url.split("//", 1)[1]
         except IndexError:
             continue
-        if not any(w in path for w in title_words):
+        parts = host_and_path.split("/", 1)
+        host = parts[0].lower()
+        path = parts[1].lower() if len(parts) > 1 else ""
+        # Accept when a title-word appears in EITHER path OR hostname.
+        if not (any(w in path for w in title_words)
+                or any(w in host for w in title_words)):
             continue
         if url in seen:
             continue

--- a/tests/test_project_page_hostname_match.py
+++ b/tests/test_project_page_hostname_match.py
@@ -1,0 +1,130 @@
+"""Tests for the hostname-match extension in `_extract_project_page_urls`.
+
+Prior behavior: title-word substring must appear in the URL PATH.
+New behavior: match in EITHER path OR hostname (subdomain).
+
+Motivating case: TIPSv2 (arxiv 2604.12012) project page is
+https://gdm-tipsv2.github.io/ — hostname carries the paper name,
+path is empty. Prior extractor returned [] and the one-hop-to-
+github discovery of `google-deepmind/tips` never fired, downgrading
+the recommendation from PR to Issue with `no-code-link`.
+
+Run with: pytest tests/test_project_page_hostname_match.py -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+_TIPSV2_TITLE = (
+    "TIPSv2: Advancing Vision-Language Pretraining with Enhanced Patch-Text Alignment"
+)
+
+
+# ─── The bug we're fixing ───────────────────────────────────────────────
+
+
+def test_hostname_match_catches_paper_named_github_io():
+    """The motivating case: `<paper>.github.io/` with empty path was skipped."""
+    html = "See the code at https://gdm-tipsv2.github.io/ for details."
+    urls = run._extract_project_page_urls(html, _TIPSV2_TITLE)
+    assert "https://gdm-tipsv2.github.io/" in urls
+
+
+def test_hostname_match_paper_named_io_domain():
+    """Also common: `<paper>.io/` (or `.ai/`, `.dev/`) with empty or short path."""
+    html = 'Project page: <a href="https://dreamerv3.io/">Dreamer V3</a>'
+    urls = run._extract_project_page_urls(html, "DreamerV3: World Models for Everything")
+    # 'dreamerv' or 'dreamer' should match against 'dreamerv3.io'
+    assert any("dreamerv3.io" in u for u in urls)
+
+
+def test_hostname_match_lab_prefixed_subdomain():
+    """Real-world shape: `<lab>-<paper>.github.io` — the paper name is
+    embedded in a compound subdomain."""
+    html = "https://gdm-tipsv2.github.io/index.html"
+    urls = run._extract_project_page_urls(html, _TIPSV2_TITLE)
+    assert len(urls) == 1
+    assert "gdm-tipsv2.github.io" in urls[0]
+
+
+# ─── Regression guards — prior path-match behavior preserved ────────────
+
+
+def test_path_match_still_works():
+    """Prior path-only behavior — title-word in the path — must still hit."""
+    html = "Details at https://example.com/tipsv2-project/"
+    urls = run._extract_project_page_urls(html, _TIPSV2_TITLE)
+    assert "https://example.com/tipsv2-project/" in urls
+
+
+def test_neither_path_nor_host_matches_returns_empty():
+    """A URL with no title-word overlap in path or host must still be skipped."""
+    html = "Unrelated: https://random-blog.com/post/12345"
+    urls = run._extract_project_page_urls(html, _TIPSV2_TITLE)
+    assert urls == []
+
+
+# ─── Exclusion rules still applied ──────────────────────────────────────
+
+
+def test_github_com_still_excluded_even_when_hostname_matches():
+    """github.com is filtered before the hostname check — direct github
+    URLs go through _extract_github_urls, not this extractor."""
+    html = "Repo: https://github.com/gdm-tipsv2/tips"
+    urls = run._extract_project_page_urls(html, _TIPSV2_TITLE)
+    assert urls == []
+
+
+def test_arxiv_still_excluded():
+    """arxiv is filtered similarly."""
+    html = "https://arxiv.org/abs/2604.12012 tipsv2 paper"
+    urls = run._extract_project_page_urls(html, _TIPSV2_TITLE)
+    assert urls == []
+
+
+def test_huggingface_still_excluded_even_with_matching_hostname():
+    """huggingface.co is filtered."""
+    html = "Model: https://huggingface.co/google/tipsv2-l14"
+    urls = run._extract_project_page_urls(html, _TIPSV2_TITLE)
+    assert urls == []
+
+
+# ─── Edge cases ─────────────────────────────────────────────────────────
+
+
+def test_empty_html_returns_empty():
+    assert run._extract_project_page_urls("", _TIPSV2_TITLE) == []
+
+
+def test_empty_title_returns_empty():
+    """No title words → nothing to match against → no false positives."""
+    html = "https://gdm-tipsv2.github.io/"
+    assert run._extract_project_page_urls(html, "") == []
+
+
+def test_fanout_cap_respected_with_hostname_match():
+    """The 3-URL fanout cap must still apply even when all match by hostname."""
+    html = " ".join([
+        "https://tipsv2-a.example.com/",
+        "https://tipsv2-b.example.com/",
+        "https://tipsv2-c.example.com/",
+        "https://tipsv2-d.example.com/",
+        "https://tipsv2-e.example.com/",
+    ])
+    urls = run._extract_project_page_urls(html, _TIPSV2_TITLE)
+    assert len(urls) == 3
+
+
+def test_dedup_across_path_and_host_match():
+    """Same URL discovered by different match paths dedupes correctly."""
+    html = ("https://gdm-tipsv2.github.io/ "
+            "https://gdm-tipsv2.github.io/ "  # dup
+            "https://example.com/tipsv2-page/")
+    urls = run._extract_project_page_urls(html, _TIPSV2_TITLE)
+    assert len(urls) == 2
+    assert "https://gdm-tipsv2.github.io/" in urls
+    assert "https://example.com/tipsv2-page/" in urls


### PR DESCRIPTION
`_extract_project_page_urls()` matches title-word substrings against the URL path only. Project pages served at the root of a paper-named subdomain (`<paper>.github.io/`) have an empty path — so the extractor skips them, the one-hop-to-github fallback never fires, and license detection falls back to `no-code-link`.

**Motivating case**: TIPSv2 (arxiv 2604.12012). Abstract page has `https://gdm-tipsv2.github.io/` (and only that; no direct github.com link). The project page has `https://github.com/google-deepmind/tips` (Apache 2.0). But `_extract_project_page_urls(html, "TIPSv2: ...")` returns `[]` — hostname `gdm-tipsv2` contains the title-word `tipsv` but path is empty.

**Change**: accept a URL when a title-word substring appears in EITHER path OR hostname. Catches `<paper>.github.io/`, `<paper>.io/`, `<lab>.<paper>.dev/` and similar academic project-page conventions.

- 12 new tests: motivating case, hostname variants, path-match regression, exclusion regressions (github.com / arxiv / huggingface still filtered), empty-input edges, dedup across host+path match, fanout cap preserved
- Full suite passes (1080/1 skipped)