### PR TITLE
fix(runner): don't crash commit_and_push on an empty diff

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -8965,7 +8965,12 @@ def parse_issue_fallback_file(path: Path) -> tuple[str, str]:
 def commit_and_push(
     workdir: Path, branch: str, title: str, repo: str, base_branch: str = "main",
 ) -> None:
-    """Stage all changes, commit, and push the branch to origin.
+    """Stage all changes, commit (if any), and push the branch to origin.
+
+    When the session made no edits — a valid outcome for warm-start
+    refinements that judge the curated branch already clean — the commit
+    is skipped and the branch is pushed as-is; it still differs from
+    base_branch by the whole implementation, so the PR opens normally.
 
     The branch's final commit is (re)created through the GitHub git data
     API with the App installation token so it's attributed to
@@ -9047,7 +9052,22 @@ def commit_and_push(
         shutil.rmtree(bundle_path, ignore_errors=True)
 
     subprocess.run(["git", "add", "-A"], cwd=workdir, check=True)
-    subprocess.run(["git", "commit", "-m", title], cwd=workdir, check=True)
+    # An empty staged diff means the session reviewed the branch and
+    # changed nothing — a valid (best-case) outcome for warm-start
+    # refinements. The branch still differs from base_branch by the
+    # whole implementation, so push + PR proceed as usual; only the
+    # commit (and the bot re-author below, which would otherwise add an
+    # empty commit) is skipped.
+    has_changes = (
+        subprocess.run(
+            ["git", "diff", "--cached", "--quiet"], cwd=workdir,
+        ).returncode
+        != 0
+    )
+    if has_changes:
+        subprocess.run(["git", "commit", "-m", title], cwd=workdir, check=True)
+    else:
+        log.info("  → no changes to commit (branch already clean); pushing as-is")
 
     # Refresh origin's URL with a freshly-minted token before pushing.
     # The URL baked into `origin` at clone time embeds the token (see
@@ -9090,8 +9110,11 @@ def commit_and_push(
     # its blobs) to the remote; we now point the branch at an identical
     # tree wrapped in an API-created commit. `head_sha` is the base we
     # branched from (asserted == origin/<base_branch> above), so it's the
-    # new commit's sole parent.
-    _recommit_via_api(workdir, repo, branch, title, parent_sha=head_sha)
+    # new commit's sole parent. Skipped when nothing was committed: the
+    # branch head IS `head_sha`, and wrapping it would only pin an empty
+    # commit on top.
+    if has_changes:
+        _recommit_via_api(workdir, repo, branch, title, parent_sha=head_sha)
 
 
 def _recommit_via_api(

--- a/src/run.py
+++ b/src/run.py
@@ -10733,10 +10733,10 @@ def process_target(target: Target) -> dict:
             workdir, branch, pr_title, repo=target.repo, base_branch=default_branch
         )
 
-        # REMYX-186: Pre-PR fidelity gate.
+        # Pre-PR fidelity gate.
         # Run fidelity on the local branch BEFORE opening the PR. If
         # substantive deviations from the reference are found, either
-        # patch the branch (REMYX-185, scoped-down single-attempt) or
+        # patch the branch (scoped-down single-attempt) or
         # skip publication entirely. Fabricated artifacts never become
         # public.
         prepub_verdict = _run_pre_pr_fidelity_check(
@@ -12843,7 +12843,7 @@ def _build_fidelity_audit_prompt(
     )
     body_excerpt = (pr_body or "")[:4000]
 
-    # Mode-aware guidance (REMYX-195). Mode 3 is handled by a separate
+    # Mode-aware guidance. Mode 3 is handled by a separate
     # function; here we branch between Mode 1 (strict) and Mode 2
     # (auxiliary-substitution-tolerant).
     substitutions = substitutions or []
@@ -13015,7 +13015,7 @@ def _run_pre_pr_fidelity_check(
     doesn't exist yet. Returns a verdict dict with ``needs_judgment``,
     ``items_count``, ``coverage_section``, ``status``, ``matrix``.
 
-    Mode-aware routing (REMYX-195): reads ``self_review['mode_cited']``
+    Mode-aware routing: reads ``self_review['mode_cited']``
     to pick the audit shape.
 
       * **Mode 1 (direct port)** — strict reference-vs-diff comparison.
@@ -14010,7 +14010,7 @@ def run_fidelity_audit(target: Target) -> dict:
     # gate so downstream chain phases see the same needs_judgment flag that
     # actually drove the labeling decision above. The prior bare `needs_judgment`
     # reference produced a NameError that crashed the fidelity-audit phase after
-    # the PR opened (atropos run 29357999483 · PR #16 · 2026-07-14).
+    # the PR opened.
     result["needs_judgment"] = effective_needs_judgment
     result["coverage_summary"] = matrix.get("summary", "")
     result["pr_url"] = pr.get("html_url", "")

--- a/tests/test_arxiv_fallback.py
+++ b/tests/test_arxiv_fallback.py
@@ -1,4 +1,4 @@
-"""Tests for the REMYX-247 arxiv-fallback path:
+"""Tests for the arxiv-fallback path:
 
   - `_fetch_arxiv_asset(arxiv_id)` fetches metadata directly from
     export.arxiv.org and shapes it as an asset envelope
@@ -10,8 +10,7 @@
 
 The motivating case: TIPSv2 (arxiv 2604.12012) published early July 2026,
 merged into transformers 2026-07-07 but not yet ingested by the Remyx
-catalog when a pin-arxiv dispatch tried to target it. See run
-smellslikeml/prismatic-vlms/actions/runs/29712103628.
+catalog when a pin-arxiv dispatch tried to target it.
 
 Run with: pytest tests/test_arxiv_fallback.py -q
 """
@@ -134,7 +133,7 @@ def test_fetch_canonical_id_falls_back_to_input(monkeypatch):
 
 def test_fetch_retries_on_429_and_succeeds(monkeypatch):
     """arxiv throttles GH Actions runner IPs — first 429 must retry, not
-    surface as a hard miss. Motivating case: run 29712953207."""
+    surface as a hard miss."""
     import urllib.error
     call_count = {"n": 0}
     def fake_urlopen(req, timeout=20):

--- a/tests/test_bot_token_default.py
+++ b/tests/test_bot_token_default.py
@@ -122,9 +122,9 @@ def test_mint_re_mints_when_cached_token_is_stale(monkeypatch):
     time would be expired at push time. `_mint_bot_token` must re-mint
     when the cached token age exceeds `_BOT_TOKEN_MAX_AGE_S`.
 
-    Regression test for the git push 401 seen on the atropos smoke
-    (run 29552199454): first mint at 03:26:34, push attempt at 04:40:24
-    — 74 min later, 14 min past the 60-min TTL, cached-token bug bit.
+    Regression test for a git push 401 seen in the wild: first mint at
+    03:26:34, push attempt at 04:40:24 — 74 min later, 14 min past the
+    60-min TTL, cached-token bug bit.
     """
     _clean_env(
         monkeypatch,

--- a/tests/test_commit_and_push_empty_diff.py
+++ b/tests/test_commit_and_push_empty_diff.py
@@ -1,0 +1,157 @@
+"""``commit_and_push`` must survive a session that changed nothing.
+
+A warm-start refinement session can review the curated branch, judge it
+already correct, and make zero edits — a valid (best-case) outcome. The
+staged diff is then empty and ``git commit`` exits 1; an unconditional
+``check=True`` commit turned that into a crashed run (status ``error``)
+before push/PR, even though the branch differs from main by the entire
+implementation and pushing it as-is works fine.
+
+Covers:
+
+- empty diff → no commit, branch still pushed to origin at the ref's
+  SHA, and the API re-author step is skipped (it would otherwise pin an
+  empty bot commit on top).
+- non-empty diff → the classic path is unchanged: a commit lands on the
+  pushed branch and the API re-author runs with the base as parent.
+
+Run with: pytest tests/test_commit_and_push_empty_diff.py -q
+"""
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# ── Setup: a bare "remote" plus a workdir cloned on the refinement ref ──
+
+
+@pytest.fixture
+def warm_start_workdir(tmp_path, monkeypatch):
+    """Clone of a fake fork, checked out on the refinement ref.
+
+    Mirrors what ``prepare_workdir`` leaves behind for a start-from-ref
+    session: HEAD on ``refine-me`` == ``origin/refine-me``, identity
+    configured. Returns (workdir, bare path, refine-me SHA).
+    """
+    seed = tmp_path / "seed"
+    # git init -b needs git >= 2.28; symbolic-ref names the unborn
+    # branch on older gits too.
+    subprocess.run(["git", "init", "-q", str(seed)], check=True)
+    subprocess.run(
+        ["git", "-C", str(seed), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True,
+    )
+    (seed / "README.md").write_text("baseline\n")
+    subprocess.run(["git", "-C", str(seed), "add", "README.md"], check=True)
+    subprocess.run(
+        ["git", "-C", str(seed), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", "baseline"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "checkout", "-q", "-b", "refine-me"],
+        check=True,
+    )
+    (seed / "impl.py").write_text("print('the entire implementation')\n")
+    subprocess.run(["git", "-C", str(seed), "add", "impl.py"], check=True)
+    subprocess.run(
+        ["git", "-C", str(seed), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", "prior draft"],
+        check=True,
+    )
+    refine_sha = subprocess.run(
+        ["git", "-C", str(seed), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    subprocess.run(["git", "-C", str(seed), "checkout", "-q", "main"], check=True)
+
+    bare = tmp_path / "fork.git"
+    subprocess.run(
+        ["git", "clone", "--bare", "-q", str(seed), str(bare)], check=True,
+    )
+
+    workdir = tmp_path / "workdir"
+    subprocess.run(["git", "clone", "-q", str(bare), str(workdir)], check=True)
+    subprocess.run(
+        ["git", "-C", str(workdir), "config", "user.email", "bot@remyx.ai"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(workdir), "config", "user.name", "remyx-ai[bot]"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(workdir), "checkout", "-q", "refine-me"], check=True,
+    )
+    monkeypatch.setenv("INPUT_START_FROM_REF", "refine-me")
+    return workdir, bare, refine_sha
+
+
+def _push_branch(workdir, bare, recommit_calls):
+    """Run commit_and_push with network-touching pieces neutralized.
+
+    An empty token skips the remote set-url rewrite, so pushes land on
+    the local bare; the API re-author is recorded instead of executed.
+    """
+    with patch.object(run, "_github_token", lambda: ""), \
+         patch.object(
+             run, "_recommit_via_api",
+             lambda *a, **kw: recommit_calls.append((a, kw)),
+         ):
+        run.commit_and_push(
+            workdir, "refine-me-refined", "refine: widget method",
+            repo="owner/repo", base_branch="main",
+        )
+
+
+# ── empty diff: push proceeds, no commit, no API re-author ──────────────
+
+
+def test_empty_diff_pushes_branch_without_commit(warm_start_workdir):
+    """Zero edits must not crash; the branch lands on origin at the ref's SHA."""
+    workdir, bare, refine_sha = warm_start_workdir
+    recommit_calls = []
+
+    _push_branch(workdir, bare, recommit_calls)
+
+    pushed_sha = subprocess.run(
+        ["git", "-C", str(bare), "rev-parse", "refs/heads/refine-me-refined"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert pushed_sha == refine_sha
+    # No new commit → nothing to re-author; wrapping would only add an
+    # empty commit on top of the base.
+    assert recommit_calls == []
+
+
+# ── non-empty diff: classic path unchanged ──────────────────────────────
+
+
+def test_nonempty_diff_still_commits_and_reauthors(warm_start_workdir):
+    """Edits present → commit lands on the pushed branch, re-author runs."""
+    workdir, bare, refine_sha = warm_start_workdir
+    (workdir / "impl.py").write_text("print('a refined implementation')\n")
+    recommit_calls = []
+
+    _push_branch(workdir, bare, recommit_calls)
+
+    pushed_sha = subprocess.run(
+        ["git", "-C", str(bare), "rev-parse", "refs/heads/refine-me-refined"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert pushed_sha != refine_sha
+    parent_sha = subprocess.run(
+        ["git", "-C", str(bare), "rev-parse", "refs/heads/refine-me-refined^"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert parent_sha == refine_sha
+    assert len(recommit_calls) == 1
+    args, kwargs = recommit_calls[0]
+    assert kwargs.get("parent_sha") == refine_sha

--- a/tests/test_lead_content_log_detail.py
+++ b/tests/test_lead_content_log_detail.py
@@ -49,7 +49,7 @@ def test_ok_status_stays_compact():
     resp = tool_response_ok(
         connector="linear",
         latency_ms=210.4,
-        inline_snippet="# REMYX-XXX ...",
+        inline_snippet="# TEAM-XXX ...",
     )
     line = _log_line_for(resp)
     assert "status=ok" in line
@@ -82,13 +82,13 @@ def test_http_400_class_error_surfaces_code_and_message():
         connector="linear",
         latency_ms=366.0,
         error_code="http_400",
-        message="Linear API returned HTTP 400 for REMYX-240",
+        message="Linear API returned HTTP 400 for TEAM-240",
     )
     line = _log_line_for(resp)
     assert "status=error" in line
     assert "latency=366ms" in line
     assert "error_code=http_400" in line
-    assert "Linear API returned HTTP 400 for REMYX-240" in line
+    assert "Linear API returned HTTP 400 for TEAM-240" in line
 
 
 def test_graphql_error_message_is_truncated_to_200_chars():

--- a/tests/test_pre_pr_fidelity.py
+++ b/tests/test_pre_pr_fidelity.py
@@ -246,7 +246,7 @@ def test_patch_returns_true_when_files_touched(tmp_path):
     assert "Fidelity remediation brief" in invoc.read_text()
 
 
-# --- REMYX-195: mode-aware fidelity gate -------------------------------------
+# --- mode-aware fidelity gate ------------------------------------------------
 
 def test_classify_mode_cited_reads_mode_1():
     assert run._classify_mode_cited({"mode_cited": "Mode 1 (direct port)"}) == "mode-1"
@@ -291,7 +291,7 @@ def test_build_fidelity_audit_prompt_mode_2_injects_substitutions():
 
 def test_build_fidelity_audit_prompt_scoped_out_lists_deferred_items():
     """Scoped-out items should appear in the prompt so the gate downgrades
-    them from needs-judgment to deferred (original REMYX-195 fix)."""
+    them from needs-judgment to deferred."""
     prompt = run._build_fidelity_audit_prompt(
         pr_title="Test", pr_body="body", pr_diff="diff",
         arxiv_id="2606.27025", reference_url="https://github.com/x/y",
@@ -497,8 +497,6 @@ def test_process_target_source_passes_self_review_to_both_fidelity_calls():
 # arxiv 2303.17580 (HuggingGPT). Comparing PLAY2PROMPT code against
 # HuggingGPT flagged every legitimate feature as fabrication and triggered
 # a false-positive `skipped_fidelity_fabrication_after_patch`.
-# See https://linear.app/remyx/issue/REMYX-234 comment thread for the
-# investigation write-up.
 
 def test_arxiv_bare_id_strips_v_suffix():
     assert run._arxiv_bare_id("2503.14432v2") == "2503.14432"

--- a/tests/test_repo_intel.py
+++ b/tests/test_repo_intel.py
@@ -1319,7 +1319,7 @@ def test_guard_bypass_lead_content(tmp_path, monkeypatch):
     workdir = _guard_test_setup(tmp_path, _INTEL_WITH_LANDING)
     monkeypatch.setenv("INPUT_MAINTAIN_STATE", "true")
     monkeypatch.setenv("INPUT_LEAD_CONTENT",
-                       "https://linear.app/remyx/issue/REMYX-XYZ")
+                       "https://linear.app/example/issue/TEAM-XYZ")
     assert (os.environ.get("INPUT_LEAD_CONTENT") or "").strip().startswith("https://")
 
 

--- a/tests/test_start_from_ref.py
+++ b/tests/test_start_from_ref.py
@@ -161,7 +161,7 @@ def test_detect_default_branch_after_ref_checkout(fake_remote, tmp_path, monkeyp
     remote's default (main) — not the currently-checked-out ref. Otherwise
     the PR base would open against the ref instead of main, and the diff
     review wouldn't show the full baseline+refinement state (observed on
-    the OLMo-core live test, run 29198542589 → PR #12 with base=T3 ref)."""
+    a live warm-start test where the PR opened with the ref as its base)."""
     bare, _main_sha, _refine_sha = fake_remote
     monkeypatch.setenv("INPUT_START_FROM_REF", "refine-me")
 

--- a/tests/test_user_intent_override.py
+++ b/tests/test_user_intent_override.py
@@ -70,7 +70,7 @@ def test_lead_content_url_form_also_triggers_override(monkeypatch):
     # here we care that either shape signals intent to the throttle.
     monkeypatch.setenv(
         "INPUT_LEAD_CONTENT",
-        "https://linear.app/remyx/issue/REMYX-239/road-vla-opus-refinement",
+        "https://linear.app/example/issue/TEAM-239/some-refinement-issue",
     )
     assert run._has_user_intent_override(_target()) is True
 


### PR DESCRIPTION
## Summary

A warm-start refinement session that reviews the curated branch and makes **zero edits** is a valid — best-case — outcome. But `commit_and_push` ran `git commit` unconditionally with `check=True`, so git exited 1 on the empty diff and the whole run died as `status: error` before push/PR — even though the branch differs from the base by the entire implementation and would open a fine PR as-is.

## Changes

- **Guard the commit behind a staged-diff check** (`git diff --cached --quiet` after `git add -A`). On an empty diff, log `no changes to commit (branch already clean); pushing as-is` and continue to push + PR.
- **Skip the API re-author step when nothing was committed** — the branch head is already the base SHA, and wrapping it would only pin an empty bot commit on top.
- Both the PR path and the `publish=branch` downgrade path share this helper, so one guard covers both.
- With the run now reaching PR creation, telemetry posts `pr_opened*` naturally instead of `error`.
- New regression tests in `tests/test_commit_and_push_empty_diff.py`: empty diff pushes the branch at the ref's SHA without a commit or re-author; non-empty diff keeps the classic commit + re-author behavior.

Also includes a follow-up commit scrubbing internal tracker IDs, workspace Linear URLs, and debug run-ID breadcrumbs from comments and test fixtures — repo-hygiene for a public repo, no behavior change.

## Testing

- `tests/test_commit_and_push_empty_diff.py` — 2 new tests, pass.
- Full suite: 1067 passed; the 6 remaining failures are pre-existing on `main` (local git 2.25 lacks `git init -b`, needs ≥ 2.28) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)