### PR TITLE
feat: add fidelity-policy input (block | advisory | off) for the pre-PR fidelity gate

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -186,6 +186,35 @@ inputs:
                            stub density, self-review) to keep PRs honest.
     required: false
     default: 'strict'
+  fidelity-policy:
+    description: |
+      How the pre-PR fidelity gate treats a needs-judgment verdict (the
+      audit that compares the drafted diff against the paper's reference
+      implementation before opening the PR). One of:
+
+        block (default) — a needs-judgment verdict blocks publication: one
+                          scoped patch attempt, then skip if it still flags
+                          (branch mode preserves the branch instead). Keeps
+                          fabricated / hallucinated implementations out of
+                          public PRs. Best for autonomous runs on arbitrary
+                          repos.
+        advisory        — run the audit and attach the "## Coverage" matrix,
+                          but never block: the PR opens even when items are
+                          flagged. Best for curated or warm-start runs
+                          (start-from-ref) where a human already vetted the
+                          branch and a strict full-reference-port comparison
+                          is the wrong lens for a scoped integration. Reuses
+                          the existing medium-confidence advisory path.
+        off             — skip the gate entirely (no reference clone, no
+                          audit). The other validators (path allowlist,
+                          integration check, stub density, self-review,
+                          diff-risk) still apply.
+
+      Independent of the medium-confidence auto-advisory behavior, which
+      still applies under `block` when the reference doesn't self-identify
+      strongly with the paper.
+    required: false
+    default: 'block'
   lookback:
     description: |
       Recommendation lookback window. The action pulls the candidate pool
@@ -657,6 +686,7 @@ runs:
         INPUT_GUARDRAILS_ALLOWLIST: ${{ inputs.guardrails-allowlist }}
         INPUT_GUARDRAILS_BLOCKLIST: ${{ inputs.guardrails-blocklist }}
         INPUT_TEST_INTEGRATION_POLICY: ${{ inputs.test-integration-policy }}
+        INPUT_FIDELITY_POLICY: ${{ inputs.fidelity-policy }}
         INPUT_CLAUDE_TIMEOUT: ${{ inputs.claude-timeout }}
         INPUT_PIN_ARXIV: ${{ inputs.pin-arxiv }}
         INPUT_SEARCH_METHOD: ${{ inputs.search-method }}

--- a/src/run.py
+++ b/src/run.py
@@ -1397,6 +1397,9 @@ DRAFT_MODES = ("always", "on_test_failure", "never")
 # Test-integration gate policy values. See Target.test_integration_policy.
 TEST_INTEGRATION_POLICIES = ("strict", "soft", "off")
 
+# Pre-PR fidelity gate policy values. See Target.fidelity_policy.
+FIDELITY_POLICIES = ("block", "advisory", "off")
+
 # Terminal statuses that should make the workflow step exit non-zero (red
 # in CI). Everything else — Issues, skips, PRs — is a legitimate green
 # outcome. `claude_failed` used to exit 0, so a run that produced no PR/Issue
@@ -1527,6 +1530,18 @@ class Target:
     # libraries) benefit from "soft"; application/pipeline repos should
     # keep "strict".
     test_integration_policy: str = "strict"
+    # Pre-PR fidelity gate policy (see `_run_pre_pr_fidelity_check`):
+    #   "block"    — default; a needs-judgment verdict blocks publication
+    #                (patch attempt, then skip; branch mode preserves the
+    #                branch). Fabricated artifacts never become public.
+    #   "advisory" — run the audit and surface the coverage matrix, but
+    #                NEVER block: the PR opens even when items are flagged.
+    #                For curated / warm-start runs where a human already
+    #                vetted the branch and a strict full-reference-port
+    #                comparison is the wrong lens (scoped integrations).
+    #                Reuses the medium-confidence advisory path.
+    #   "off"      — skip the gate entirely (no reference clone, no audit).
+    fidelity_policy: str = "block"
     # Per-run wall-clock budget for the Claude Code implementation step.
     # 600s was too tight on large repos; configurable via `claude-timeout`.
     claude_timeout_s: int = 900
@@ -11203,6 +11218,16 @@ def build_target_from_env() -> Target:
         )
         sys.exit(2)
 
+    fidelity_policy = _optional_env(
+        "INPUT_FIDELITY_POLICY", "block"
+    ).strip().lower()
+    if fidelity_policy not in FIDELITY_POLICIES:
+        log.error(
+            f"INPUT_FIDELITY_POLICY={fidelity_policy!r} "
+            f"is invalid. Must be one of {FIDELITY_POLICIES}."
+        )
+        sys.exit(2)
+
     # Default raised from 900s to 1500s in v1.7.24 — GLM sessions with
     # staged-synthesis routinely reach 15-20 min, and users triggering
     # runs without prior tuning were hitting the 15-min ceiling. Opus
@@ -11230,6 +11255,7 @@ def build_target_from_env() -> Target:
         guardrails_allowlist=guardrails_allowlist,
         guardrails_blocklist=guardrails_blocklist,
         test_integration_policy=test_integration_policy,
+        fidelity_policy=fidelity_policy,
         claude_timeout_s=claude_timeout_s,
         pin_arxiv=_optional_env("INPUT_PIN_ARXIV", ""),
         search_method=_optional_env("INPUT_SEARCH_METHOD", ""),
@@ -13013,6 +13039,29 @@ def _classify_mode_cited(review: "dict | None") -> str:
     return ""
 
 
+def _fidelity_advisory(target: "Target", base_advisory: bool) -> bool:
+    """True when fidelity flags should surface but never block publication.
+
+    Advisory when ANY of:
+      * ``base_advisory`` — the reference confidence is only medium (the
+        reference doesn't self-identify strongly enough to trust the flag
+        count as ground truth);
+      * ``fidelity-policy: advisory`` — curated / warm-start runs where a
+        human already vetted the branch;
+      * ``fidelity-policy: off`` — the pre-PR gate is short-circuited before
+        this is reached, so this only governs the post-PR chain, where "off"
+        must likewise not re-apply a needs-judgment label the gate skipped.
+
+    Defaults to the medium-confidence behavior when ``target`` has no policy
+    attribute (defensive; the field always exists on a normally-constructed
+    Target).
+    """
+    return (
+        base_advisory
+        or getattr(target, "fidelity_policy", "block") in ("advisory", "off")
+    )
+
+
 def _run_pre_pr_fidelity_check(
     rec: "Recommendation",
     target: "Target",
@@ -13071,6 +13120,14 @@ def _run_pre_pr_fidelity_check(
         "mode_cited": mode or "mode-1",
     }
 
+    # Policy gate: "off" skips the audit entirely — no reference clone, no
+    # Claude call. The default verdict (needs_judgment=False) lets the flow
+    # proceed to open the PR. Applies to every mode.
+    if getattr(target, "fidelity_policy", "block") == "off":
+        verdict["status"] = "pre_pr_fidelity_skipped_policy_off"
+        log.info("  → pre-PR fidelity: policy=off — skipping the gate")
+        return verdict
+
     # Mode 3 has its own audit shape — insight-preservation, no reference impl needed.
     if mode == "mode-3":
         return _run_mode3_insight_preservation_check(
@@ -13119,11 +13176,13 @@ def _run_pre_pr_fidelity_check(
         )
         return verdict
 
-    advisory_only = (confidence == "medium")
+    advisory_only = _fidelity_advisory(target, confidence == "medium")
     if advisory_only:
+        _why = ("fidelity-policy=advisory"
+                if getattr(target, "fidelity_policy", "block") == "advisory"
+                else "medium-confidence reference (title-token match only)")
         log.info(
-            f"  → pre-PR fidelity: medium-confidence reference "
-            f"(title-token match only); running in advisory mode "
+            f"  → pre-PR fidelity: {_why}; running in advisory mode "
             f"(flags surfaced but non-blocking)"
         )
 
@@ -13385,7 +13444,12 @@ def _run_mode3_insight_preservation_check(
         for k in ("docstring_cites_paper", "docstring_frames_as_inspired",
                   "code_embodies_insight")
     )
-    needs_judgment = bool(matrix.get("needs_judgment", False)) or insight_fail
+    raw_needs_judgment = bool(matrix.get("needs_judgment", False)) or insight_fail
+    # fidelity-policy=advisory surfaces the flags but never blocks (mirrors
+    # the reference-anchored advisory path). "off" is short-circuited before
+    # this function is reached.
+    advisory_only = _fidelity_advisory(target, False)
+    needs_judgment = raw_needs_judgment and not advisory_only
 
     verdict.update({
         "needs_judgment": needs_judgment,
@@ -13393,14 +13457,17 @@ def _run_mode3_insight_preservation_check(
         "coverage_section": coverage_section,
         "matrix": matrix,
         "insight_check": insight_check,
+        "advisory_only": advisory_only,
         "status": (
-            "pre_pr_fidelity_mode3_needs_judgment" if needs_judgment
+            "pre_pr_fidelity_advisory" if (advisory_only and raw_needs_judgment)
+            else "pre_pr_fidelity_mode3_needs_judgment" if needs_judgment
             else "pre_pr_fidelity_mode3_insight_preserved"
         ),
     })
     log.info(
         f"  ✓ pre-PR fidelity (mode-3): {verdict['items_count']} items, "
         f"insight_check={insight_check}, needs_judgment={needs_judgment}"
+        + (" (advisory-only)" if advisory_only and raw_needs_judgment else "")
     )
     return verdict
 
@@ -13985,7 +14052,10 @@ def run_fidelity_audit(target: Target) -> dict:
     # with the paper strongly enough to trust judgment as ground truth.
     # Surface the coverage matrix + flag count in the run summary but
     # don't apply the needs-judgment label that would gate reviewer flow.
-    advisory_only = (reference_confidence == "medium")
+    # fidelity-policy=advisory forces the same non-blocking behavior, so the
+    # post-PR chain doesn't re-apply a needs-judgment label the pre-PR gate
+    # deliberately withheld.
+    advisory_only = _fidelity_advisory(target, reference_confidence == "medium")
     effective_needs_judgment = raw_needs_judgment and not advisory_only
 
     if effective_needs_judgment:


### PR DESCRIPTION
## Summary

Adds a `fidelity-policy` action input that controls how the **pre-PR fidelity gate** treats a `needs-judgment` verdict. Default (`block`) is unchanged; `advisory` and `off` are new opt-ins.

## Motivation

Before opening a PR, Outrider audits the drafted diff against the paper's reference implementation. At high reference confidence, a `needs-judgment` verdict **blocks publication** (one scoped patch attempt, then skip). This is the right default for autonomous runs on arbitrary repos — it keeps hallucinated or fabricated implementations out of public PRs.

It is the wrong lens, however, for a **scoped integration** of a paper into a host library — a warm-start run (`start-from-ref`) on a branch a human has already vetted, where the diff deliberately implements only the paper's core mechanism and omits the reference repo's benchmarks, ablations, and training harness. A strict "direct port" (Mode 1) audit flags every un-ported component as fabrication, so the run ends in `skipped_fidelity_fabrication_after_patch` and never opens a PR — even though the diff is correct and its tests pass.

`fidelity-policy: advisory` lets these runs open the PR while still surfacing the audit as a `## Coverage` matrix, so a reviewer sees exactly what was and wasn't covered.

## Behavior

| `fidelity-policy` | Effect on the pre-PR gate |
|---|---|
| `block` (default) | Unchanged — a needs-judgment verdict blocks publication (patch, then skip; branch mode preserves the branch). |
| `advisory` | Run the audit and attach the `## Coverage` matrix, but never block — the PR opens even when items are flagged. Reuses the existing medium-confidence advisory path. |
| `off` | Skip the gate entirely (no reference clone, no audit). Other validators — path allowlist, integration check, stub density, self-review, diff-risk — still apply. |

Independent of the existing medium-confidence auto-advisory behavior, which still applies under `block`.

## Implementation

Mirrors the existing `test-integration-policy` input end to end:

- `action.yml`: new input (default `block`) + `INPUT_FIDELITY_POLICY` mapping on the run step.
- `FIDELITY_POLICIES` constant, `Target.fidelity_policy` field (default `"block"`), and env read + validation in `build_target_from_env`.
- A single `_fidelity_advisory()` helper feeds all three advisory computations — the reference-anchored gate, the Mode-3 insight check, and the post-PR chain audit — so `advisory` is honored consistently and `off` never lets the post-PR chain re-apply a needs-judgment label the gate skipped.

## Backward compatibility

With the default `block`, `_fidelity_advisory(target, base)` returns exactly `base` — i.e. the original `(confidence == "medium")` expression — so existing runs are byte-for-byte unchanged. No existing caller passes the input.

## Testing

`src/run.py` parses, `action.yml` is valid YAML, and the advisory truth table plus every wiring point (constant, field, env validation, constructor, the three advisory sites, and the action input + env mapping) are covered by an offline check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
