### PR TITLE
fix(scout): tolerate malformed rejected[] entries from selection pass

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -9495,24 +9495,43 @@ def _enrich_selection_rejected(
     candidates were ``no-code-link``). Including them in the per-rejected
     record makes that signal queryable at engine scale rather than only
     visible in the per-run step summary.
+
+    Entry shape is normalized defensively: the prompt specifies
+    ``{index, why}`` objects, but looser backends (observed with GLM)
+    emit bare rationale strings. Those are carried as unattributed
+    rejections; any other non-dict entry is dropped. The rejection list
+    only feeds the step summary and telemetry, so a malformed entry must
+    never fail the run.
     """
     enriched = []
     for r in raw:
+        if isinstance(r, str):
+            r = {"why": r}
+        elif not isinstance(r, dict):
+            log.warning(
+                f"  selection: dropping malformed rejected entry "
+                f"(expected dict or str, got {type(r).__name__})"
+            )
+            continue
         idx = r.get("index")
+        reason = str(r.get("why") or "")
         if isinstance(idx, int) and 0 <= idx < len(viable):
             cand = viable[idx]
             enriched.append({
                 "arxiv_id": cand.arxiv_id,
                 "title": cand.paper_title,
-                "reason": r.get("why", ""),
+                "reason": reason,
                 "license_class": cand.license_class,
                 "license_compat": cand.license_compat,
             })
         else:
             enriched.append({
                 "arxiv_id": "",
-                "title": "(candidate index out of range)",
-                "reason": r.get("why", ""),
+                "title": (
+                    "(unattributed rejection)" if idx is None
+                    else "(candidate index out of range)"
+                ),
+                "reason": reason,
                 "license_class": "unknown",
                 "license_compat": 0.0,
             })

--- a/tests/test_selection_rejected_telemetry.py
+++ b/tests/test_selection_rejected_telemetry.py
@@ -108,6 +108,51 @@ def test_enrich_out_of_range_index_gets_safe_defaults():
     assert enriched[0]["license_compat"] == 0.0
 
 
+def test_enrich_tolerates_bare_string_entries():
+    """Looser backends (observed with GLM) emit rejected
+    entries as bare rationale strings instead of the
+    ``{index, why}`` objects the selection schema specifies. These must
+    be carried as unattributed rejections, not crash the run with
+    ``'str' object has no attribute 'get'``."""
+    viable = [_rec("2606.00001v1")]
+    enriched = run._enrich_selection_rejected(
+        [
+            "paper assumes a trainer the repo lacks",
+            {"index": 0, "why": "wrong problem class"},
+        ],
+        viable,
+    )
+    assert len(enriched) == 2
+    assert enriched[0]["title"] == "(unattributed rejection)"
+    assert enriched[0]["reason"] == "paper assumes a trainer the repo lacks"
+    assert enriched[0]["license_class"] == "unknown"
+    assert enriched[1]["arxiv_id"] == "2606.00001v1"
+
+
+def test_enrich_drops_non_dict_non_str_entries():
+    """Entries that are neither dict nor str (e.g. a stray int or list)
+    are dropped rather than crashing — the rejection list only feeds the
+    step summary and telemetry."""
+    viable = [_rec("2606.00001v1")]
+    enriched = run._enrich_selection_rejected(
+        [42, ["nested"], {"index": 0, "why": "kept"}], viable
+    )
+    assert len(enriched) == 1
+    assert enriched[0]["reason"] == "kept"
+
+
+def test_enrich_coerces_non_string_why():
+    """A non-string ``why`` (None, dict, …) is coerced to str so the
+    telemetry compaction's reason-truncation slice can't crash."""
+    viable = [_rec("2606.00001v1")]
+    enriched = run._enrich_selection_rejected(
+        [{"index": 0, "why": None}, {"index": 0, "why": {"text": "odd"}}],
+        viable,
+    )
+    assert enriched[0]["reason"] == ""
+    assert isinstance(enriched[1]["reason"], str)
+
+
 def test_enrich_empty_raw_returns_empty_list():
     """Empty input → empty list; not None, not error. Downstream
     consumers can iterate without nil-checks."""


### PR DESCRIPTION
Selection's `rejected[]` can arrive as bare strings from looser backends (observed with GLM); `_enrich_selection_rejected` assumed dicts and crashed the run. Normalize entries there instead of failing. Adds regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)