### PR TITLE
feat: wire REVIEW.md into orientation, fidelity audit, and convention pass

### DIFF
--- a/docs/REVIEW-template.md
+++ b/docs/REVIEW-template.md
@@ -1,0 +1,73 @@
+# REVIEW.md — starter template
+
+Copy this file to your repo root as `REVIEW.md` (or `.github/REVIEW.md`) and
+adapt to your review conventions. Outrider reads it on dispatch and threads
+it into the drafter, fidelity audit, and convention pass so the generated PRs
+respect your norms without you having to infer them from PR history.
+
+Sections below are suggestions — drop any that don't fit, add repo-specific
+ones as needed. Aim for terse and decision-forcing over exhaustive; a review
+convention that produces false negatives is worse than one that stays silent.
+
+---
+
+# REVIEW.md — <your-repo>
+
+Review conventions for this repo. Loaded as first-class context by Outrider
+on dispatch. Complements `CLAUDE.md` (coordination-before-coding) and
+`CONTRIBUTING.md` (broad contribution guide).
+
+## Verdicts
+
+- **approve** — <what triggers approve on your repo: scoped diff, tests
+  updated, CI green, PR body names the ticket/decision it lands, …>
+- **request-changes** — <what triggers a blocking review: missing tests
+  on new code paths, cross-cutting refactor bundled with a feature, an
+  anti-pattern below, …>
+- **comment** — advisory only (style, alt approaches, docs). Non-blocking
+
+## Test bar
+
+- <the minimum tests you expect for a merge — unit for logic, integration
+  for X, benchmarks on eval harness Y if the PR touches Z>
+- CI green on the PR branch
+- <if the repo has an eval harness or benchmark set that PRs should run>
+
+## Scope stance
+
+- <how you feel about PR size / splitting: e.g. one mechanism per PR;
+  refactor separate from feature; formatting separate>
+- <what unrelated changes get rejected on sight>
+
+## Formatter / style
+
+- <your linter/formatter and whether it's enforced at CI or review>
+
+## Author-preference policy
+
+- <do you prefer paper-authors or upstream maintainers submit PRs when
+  possible? escalation window if they don't respond?>
+- <if this is a target repo Outrider drafts against, note whether the
+  maintainer wants Outrider PRs at all vs. Issues surfacing findings>
+
+## Response norms
+
+- <how reviewers respond: suggested-changes vs comment threads, expected
+  turnaround, stale-review handling>
+
+## Benchmark expectations
+
+- <if your repo has an eval harness: when should PRs run it, and how
+  should results be reported in the PR body>
+
+## Anti-patterns
+
+- <patterns that get PRs auto-rejected — e.g. wholesale reformat bundled
+  with feature, brittle regex rules, silent truncation without a log line,
+  cross-cutting refactor in a feature PR, …>
+
+## Meta
+
+- Maintainer-authored; Outrider reads, does not write
+- To propose an update to these conventions: PR against this file with
+  rationale in the body

--- a/src/run.py
+++ b/src/run.py
@@ -323,6 +323,7 @@ for you. Use the patterns below to shape your generated code, PR title,
 PR body, and commit messages. Do NOT re-explore these files yourself
 (that's redundant cost) — the relevant content is summarized here.
 
+{review_conventions_block}
 {contributor_guides_block}
 {pr_template_block}
 {recent_merged_prs_block}
@@ -333,6 +334,12 @@ PR body, and commit messages. Do NOT re-explore these files yourself
 
 ## How to use this orientation
 
+- **Review conventions**: if the "Review conventions (`REVIEW.md`)" block
+  above is present, it is the highest-precedence signal for verdict
+  triggers, test bar, scope stance, and anti-patterns. Shape the diff,
+  PR title, and PR body so the maintainer can apply the block's `approve`
+  criteria without asking for changes. When the block is absent, fall
+  back to the contributor-guide / PR-history signals below.
 - **PR title**: match the convention shown in the recent merged PRs above
   (the title pattern — e.g. `<scope>: <verb> <thing>` if that's what
   recent merges follow). Do not use Remyx-prefixed titles.
@@ -4922,6 +4929,36 @@ def detect_package_name(workdir: Path) -> str:
     return "src"
 
 
+def _orient_review_conventions(workdir: Path, cap: int = 4000) -> str:
+    """Read the target repo's ``REVIEW.md`` (or ``.github/REVIEW.md``).
+
+    Complements the contributor-guide files: ``REVIEW.md`` carries a repo's
+    review conventions — verdict triggers, test bar, scope stance,
+    author-preference policy, benchmark expectations, anti-patterns — that
+    are usually implicit and rarely captured in ``CONTRIBUTING.md``. When
+    the maintainer authors one, threading it into the agent's context lets
+    the drafter and the downstream fidelity / convention passes shape
+    changes against those norms instead of inferring them from PR history.
+
+    Absent file → empty string (caller omits the section).
+    """
+    for rel in ("REVIEW.md", ".github/REVIEW.md"):
+        path = workdir / rel
+        if not path.is_file():
+            continue
+        try:
+            body = path.read_text(errors="replace").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        snippet = body[:cap] + ("\n…[truncated]" if len(body) > cap else "")
+        return f"### `{rel}`\n\n{snippet}"
+    log.info("  · no REVIEW.md found in target repo; "
+             "review conventions will be inferred from CONTRIBUTING.md + PR history")
+    return ""
+
+
 def _orient_contributor_guides(workdir: Path, cap: int = 3000) -> str:
     """Read the canonical agent-instruction files; concatenate, truncate to ``cap``.
 
@@ -5225,6 +5262,9 @@ def _collect_repo_orientation(workdir: Path, target: Target, package: str) -> st
         return f"## {title}\n\n{body}"
 
     blocks = {
+        "review_conventions_block": _section(
+            "Review conventions (`REVIEW.md`)", _orient_review_conventions(workdir)
+        ),
         "contributor_guides_block": _section(
             "Contributor guides", _orient_contributor_guides(workdir)
         ),
@@ -12986,6 +13026,13 @@ Focus on the math/algorithm-bearing pieces — function bodies, numerical
 constants, control-flow shape, what's multiplied by what. Don't flag stylistic
 differences (variable naming, docstring shape, test framework) as deviations.
 
+If a ``REVIEW.md`` file is present at the repo root (or ``.github/REVIEW.md``),
+also cross-check the diff against its scope-stance, test-bar, and anti-pattern
+sections. Convention-shaped mismatches surfaced by REVIEW.md belong in the
+Coverage matrix as ``deviation`` / ``needs-judgment`` when they touch the
+mechanism the PR is landing; pure convention mismatches (formatting, PR-body
+shape) are out of scope for this audit and stay with the convention pass.
+
 # Output
 
 Return ONLY a valid JSON object (no prose before or after):
@@ -14718,6 +14765,11 @@ tools as needed.
 If a misalignment is ambiguous between "convention" and "algorithm", skip it
 and leave a note in your final summary. **It is strictly better to skip an
 unclear patch than to make one that touches paper-anchored math.**
+
+If a ``REVIEW.md`` is present at the repo root (or ``.github/REVIEW.md``), treat
+it as the highest-precedence source for scope-stance, test-bar, and
+anti-pattern conventions — it overrides any extracted-from-history pattern
+below where they conflict.
 
 ## Extracted conventions
 

--- a/tests/test_review_conventions.py
+++ b/tests/test_review_conventions.py
@@ -1,0 +1,85 @@
+"""Tests for REVIEW.md discovery and orientation-block inclusion.
+
+Covers the consumer half of the REVIEW.md convention: Outrider reads the
+target repo's ``REVIEW.md`` (or ``.github/REVIEW.md``), threads it into
+the orientation block ahead of the contributor-guide block, and falls
+back silently when absent.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# --- _orient_review_conventions ---------------------------------------------
+
+def test_review_root_file_is_read(tmp_path: Path) -> None:
+    (tmp_path / "REVIEW.md").write_text("## Verdicts\n\n- approve when scoped\n")
+    got = run._orient_review_conventions(tmp_path)
+    assert "`REVIEW.md`" in got
+    assert "approve when scoped" in got
+
+
+def test_review_dotgithub_fallback(tmp_path: Path) -> None:
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "REVIEW.md").write_text("## Test bar\n\n- CI green\n")
+    got = run._orient_review_conventions(tmp_path)
+    assert "`.github/REVIEW.md`" in got
+    assert "CI green" in got
+
+
+def test_review_root_takes_precedence_over_dotgithub(tmp_path: Path) -> None:
+    (tmp_path / "REVIEW.md").write_text("root wins\n")
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "REVIEW.md").write_text("dotgithub loses\n")
+    got = run._orient_review_conventions(tmp_path)
+    assert "root wins" in got
+    assert "dotgithub loses" not in got
+
+
+def test_review_missing_returns_empty(tmp_path: Path) -> None:
+    assert run._orient_review_conventions(tmp_path) == ""
+
+
+def test_review_empty_file_returns_empty(tmp_path: Path) -> None:
+    (tmp_path / "REVIEW.md").write_text("   \n\n")
+    assert run._orient_review_conventions(tmp_path) == ""
+
+
+def test_review_truncated_at_cap(tmp_path: Path) -> None:
+    body = "A" * 5000
+    (tmp_path / "REVIEW.md").write_text(body)
+    got = run._orient_review_conventions(tmp_path, cap=1000)
+    # snippet cap + truncation marker
+    assert "[truncated]" in got
+    assert "A" * 1000 in got
+
+
+# --- _collect_repo_orientation includes REVIEW.md block --------------------
+
+def test_orientation_block_includes_review_section(tmp_path: Path) -> None:
+    (tmp_path / "REVIEW.md").write_text("## Anti-patterns\n\n- brittle regexes\n")
+    # Minimal Target stub — _collect_repo_orientation only reads .repo for
+    # the recent-merged-PRs block, which returns "" when repo is empty.
+    class _Target:
+        repo = ""
+    body = run._collect_repo_orientation(tmp_path, _Target(), "src")
+    assert "Review conventions" in body
+    assert "brittle regexes" in body
+
+
+def test_orientation_block_omits_review_section_when_absent(tmp_path: Path) -> None:
+    # Provide something else so the whole block isn't empty (which would
+    # short-circuit _collect_repo_orientation to "").
+    (tmp_path / "CONTRIBUTING.md").write_text("## How to contribute\n\nRun tests.\n")
+    class _Target:
+        repo = ""
+    body = run._collect_repo_orientation(tmp_path, _Target(), "src")
+    # The section HEADER should be absent; the how-to-use bullet mentioning
+    # REVIEW.md is fine (agents ignore it when the block is empty).
+    assert "## Review conventions (`REVIEW.md`)" not in body


### PR DESCRIPTION
Consumer half of the REVIEW.md convention (producer landed in #107). When the target repo authors a `REVIEW.md` at root (or `.github/REVIEW.md`), Outrider now threads its content into the agent's context as the highest-precedence signal for verdict triggers, test bar, scope stance, and anti-patterns.

## What ships

- `_orient_review_conventions()` reads `REVIEW.md` (root wins over `.github/`) with silent info-level fallback when absent
- New "Review conventions (`REVIEW.md`)" section in the orientation block, inserted before contributor guides so the agent reads it first
- `_ORIENTATION_MD_TEMPLATE` gains a how-to-use bullet explaining the block is the highest-precedence signal
- Fidelity audit prompt cross-checks against `REVIEW.md`'s scope-stance and anti-pattern sections when they touch mechanism-level matters
- Convention patch invocation treats `REVIEW.md` as highest-precedence over patterns extracted from PR history
- `docs/REVIEW-template.md` — starter template maintainers can adapt

## Test plan

- [x] `tests/test_review_conventions.py`: 8 tests — root/dot-github discovery, precedence, empty file, truncation cap, orientation-block inclusion and omission
- [x] Full suite: 1093 passed, 1 skipped, 0 regressions