### PR TITLE
Cut relevance scores from PR/Issue bodies + kill Validate upsell

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -193,13 +193,12 @@ type: implementation_spec
 arxiv_id: {arxiv_id}
 arxiv_url: https://arxiv.org/abs/{arxiv_id}
 tier: {tier}
-relevance_score: {relevance_score:.2f}
 ---
 
 # Implementation spec — drafted by Remyx Recommendation
 
 **Recommended paper**: [{paper_title}](https://arxiv.org/abs/{arxiv_id})
-**Confidence**: {tier} (Remyx relevance {relevance_score:.2f})
+**Confidence**: {tier}
 **Research interest**: {interest_name}
 
 ---
@@ -1370,7 +1369,7 @@ _PR_BODY_TEMPLATE = """\
 > **Drafted by an autonomous discovery loop** — Remyx ranks recent arXiv papers against this team's research interest and shipping history; Claude Code selects the candidate most directly implementable against this repo from the lookback window and drafts it.
 >
 > **Recommended paper**: [{paper_title}](https://arxiv.org/abs/{arxiv_id})
-> **Confidence**: {tier_emoji} {tier} (Remyx relevance {relevance_score:.2f})
+> **Confidence**: {tier_emoji} {tier}
 > **Research interest**: {interest_name}
 > **Implementation by**: Claude Code as autonomous agent
 
@@ -1389,8 +1388,6 @@ _PR_BODY_TEMPLATE = """\
 {test_section}
 
 ---
-
-> **Want eval-on-every-PR?** Outrider Validate (coming soon, paid tier) runs your benchmark suite against this diff and posts the results as a PR comment. Design partner pilot is open — [join the waitlist](https://github.com/remyxai/outrider/discussions/19).
 
 _Opened by the [Remyx Recommendation]({attribution_url}) orchestrator._
 """
@@ -9445,8 +9442,7 @@ def _open_downgrade_issue(
     sections.append(
         f"**Recommended paper**: "
         f"[{rec.paper_title}](https://arxiv.org/abs/{rec.arxiv_id})\n"
-        f"**Confidence**: {rec.tier} "
-        f"(Remyx relevance {rec.relevance_score:.2f})\n"
+        f"**Confidence**: {rec.tier}\n"
         f"**Research interest**: {rec.interest_name or '(unnamed)'}\n"
         f"\n---\n"
     )
@@ -10545,8 +10541,7 @@ def process_target(target: Target) -> dict:
             issue_body = (
                 f"**Recommended paper**: "
                 f"[{rec.paper_title}](https://arxiv.org/abs/{rec.arxiv_id})\n"
-                f"**Confidence**: {rec.tier} "
-                f"(Remyx relevance {rec.relevance_score:.2f})\n"
+                f"**Confidence**: {rec.tier}\n"
                 f"**Research interest**: {rec.interest_name or '(unnamed)'}\n"
                 f"{_render_license_section(rec)}"
                 f"{checkpoint_block}"

--- a/tests/test_license_watch.py
+++ b/tests/test_license_watch.py
@@ -22,7 +22,7 @@ from run import Target  # noqa: E402
 
 ISSUE_BODY_BLOCKED_NO_CODE = """\
 **Recommended paper**: [Some Paper](https://arxiv.org/abs/2310.99999v1)
-**Confidence**: 🟡 moderate (Remyx relevance 0.65)
+**Confidence**: 🟡 moderate
 
 ## License & code availability
 
@@ -34,7 +34,7 @@ ISSUE_BODY_BLOCKED_NO_CODE = """\
 
 ISSUE_BODY_BLOCKED_MISSING_LICENSE = """\
 **Recommended paper**: [Other Paper](https://arxiv.org/abs/2606.11111v2)
-**Confidence**: 🟡 moderate (Remyx relevance 0.72)
+**Confidence**: 🟡 moderate
 
 ## License & code availability
 


### PR DESCRIPTION
## Summary

- Drops the numeric `(Remyx relevance 0.85)` decoration from PR/Issue Confidence lines and the `relevance_score:` frontmatter field in the spec markdown. Categorical tier stays. Maintainers don't need the raw score.
- Removes the *"Want eval-on-every-PR? Outrider Validate (coming soon, paid tier)"* pitch from the PR footer. Sales copy on unsolicited bot PRs gets Outrider blocked by target repos.
- Aligns license-watch test fixtures with the trimmed Confidence line.

## Test plan

- [x] `pytest tests/` — 1071 passed, 1 skipped
- [x] `python -m py_compile src/run.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)