### PR TITLE
fix: robust JSON envelope extraction, tolerant of fences + stray braces

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -7221,19 +7221,90 @@ def _run_claude_oneshot_streaming(
     return _run_claude_stream(cmd, prompt, workdir, timeout_s)
 
 
+_JSON_FENCE_RE = re.compile(
+    r"```(?:json)?\s*\n?(.*?)```",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
 def _extract_json_object(s: str) -> dict | None:
-    """Pull the first JSON object out of `s`. Tolerant of prose wrappers."""
+    """Pull the first well-formed JSON object out of ``s``.
+
+    Tolerant of prose wrappers, Markdown code fences (``` ```json …
+    ``` ```), and leading/trailing commentary. The previous first-``{``/
+    last-``}`` heuristic tripped whenever the response contained any
+    stray ``{`` in prose before the JSON envelope (bracketed template
+    placeholders like ``{title}``, lettered list items with braces,
+    example config snippets in explanations) — the substring between
+    the wrong braces then failed to parse and the whole call was lost.
+
+    Strategy, in order:
+      1. Extract fenced code blocks (```` ```json … ``` ```` /
+         ```` ``` … ``` ````) and try each in text order — this is the
+         model's own "here's the payload" delimiter when it uses one.
+      2. Bracket-match forward from every ``{``, respecting string
+         escapes, and return the first substring that parses as a
+         JSON object.
+
+    Returns ``None`` if nothing parses — same contract as before.
+    """
     if not s:
         return None
-    try:
-        start = s.index("{")
-        end = s.rindex("}")
-    except ValueError:
-        return None
-    try:
-        return json.loads(s[start:end + 1])
-    except json.JSONDecodeError:
-        return None
+
+    # Strategy 1 — fenced blocks. Model output like ``Here's the
+    # analysis:\n```json\n{...}\n``` `` gets picked up cleanly.
+    for match in _JSON_FENCE_RE.finditer(s):
+        candidate = match.group(1).strip()
+        if not candidate:
+            continue
+        try:
+            result = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(result, dict):
+            return result
+
+    # Strategy 2 — bracket-match. Scan every ``{`` and try to find its
+    # matching ``}``, respecting string escapes; return the first
+    # substring that parses. Handles unfenced responses and responses
+    # where prose containing ``{`` precedes the envelope.
+    for i, ch in enumerate(s):
+        if ch != "{":
+            continue
+        depth = 0
+        in_string = False
+        escape_next = False
+        end_idx = None
+        for j in range(i, len(s)):
+            c = s[j]
+            if escape_next:
+                escape_next = False
+                continue
+            if in_string:
+                if c == "\\":
+                    escape_next = True
+                elif c == '"':
+                    in_string = False
+                continue
+            if c == '"':
+                in_string = True
+            elif c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    end_idx = j
+                    break
+        if end_idx is None:
+            continue
+        try:
+            result = json.loads(s[i:end_idx + 1])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(result, dict):
+            return result
+
+    return None
 
 
 def _repo_layout_manifest(workdir: Path, package: str, max_lines: int = 60) -> str:

--- a/tests/test_extract_json_object.py
+++ b/tests/test_extract_json_object.py
@@ -1,0 +1,160 @@
+"""``_extract_json_object`` — pull a well-formed JSON object out of a
+prose/fence-wrapped model response.
+
+Direct unit coverage; the helper is called from every JSON-parsing site
+in ``run.py`` (candidate selection, misalignment, PR body rewrite,
+downgrade, self-review, pre-PR fidelity, extraction), so a regression
+here can silently drop model output on any of those paths.
+
+Regression origin: outrider#110 — a convention-pass on VQASynth PR #128
+returned ``convention_failed_misalignment`` because the old
+first-``{``/last-``}`` heuristic picked a stray ``{`` in prose before
+the JSON envelope and produced an unparseable slice.
+
+Run with: pytest tests/test_extract_json_object.py -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# ─── Positive: plain, fenced, wrapped ───────────────────────────────
+
+
+def test_plain_json():
+    """Response is exactly a JSON object — parse straight through."""
+    assert run._extract_json_object('{"a": 1, "b": "x"}') == {"a": 1, "b": "x"}
+
+
+def test_json_wrapped_in_prose():
+    """Common case: a short prose lead-in before the JSON envelope."""
+    s = 'Sure — here is the analysis: {"actions": [], "count": 0}'
+    assert run._extract_json_object(s) == {"actions": [], "count": 0}
+
+
+def test_fenced_json_block():
+    """Model wraps output in a ``` ```json … ``` ``` fence."""
+    s = 'Here you go:\n\n```json\n{"a": 1}\n```\n'
+    assert run._extract_json_object(s) == {"a": 1}
+
+
+def test_fenced_plain_block():
+    """Fence with no language tag — also handled."""
+    s = '```\n{"a": 1}\n```'
+    assert run._extract_json_object(s) == {"a": 1}
+
+
+def test_fenced_json_with_leading_and_trailing_prose():
+    """Prose both before and after the fence — takes the fenced payload."""
+    s = (
+        "Sure, here is the analysis of the misalignments:\n\n"
+        "```json\n"
+        '{"actions": [{"id": 1, "verdict": "misaligned"}]}\n'
+        "```\n\n"
+        "Let me know if you'd like me to elaborate."
+    )
+    result = run._extract_json_object(s)
+    assert result == {"actions": [{"id": 1, "verdict": "misaligned"}]}
+
+
+# ─── Negative-space: prose with stray braces ────────────────────────
+
+
+def test_prose_with_stray_open_brace_before_envelope():
+    """Regression fixture (outrider#110): prose contains ``{title}``
+    template placeholders BEFORE the actual JSON envelope. The old
+    heuristic sliced from the wrong ``{`` and failed to parse."""
+    s = (
+        "The PR body currently reads `{title}: {summary}` but the "
+        "canonical convention on this repo is different. Actions:\n\n"
+        '{"actions": [{"description": "rewrite body"}]}'
+    )
+    result = run._extract_json_object(s)
+    assert result == {"actions": [{"description": "rewrite body"}]}
+
+
+def test_bracket_matching_survives_strings_with_braces():
+    """The JSON envelope's own string values may contain ``{`` or ``}``
+    (e.g. describing a template shape). Bracket matcher must respect
+    string quoting so it doesn't count those as structural braces."""
+    s = '{"description": "use the template `{title}` here", "ok": true}'
+    result = run._extract_json_object(s)
+    assert result == {
+        "description": "use the template `{title}` here", "ok": True,
+    }
+
+
+def test_bracket_matching_survives_escaped_quotes_in_strings():
+    """String contents containing escaped quotes shouldn't confuse the
+    in-string tracker."""
+    s = r'{"a": "she said \"hi\" then {x} appeared", "b": 1}'
+    result = run._extract_json_object(s)
+    assert result["a"] == 'she said "hi" then {x} appeared'
+    assert result["b"] == 1
+
+
+def test_pr_128_regression_shape():
+    """Fixture mirroring the shape of the PR #128 misalignment call —
+    lettered list items ``a. ... b. ... e. ...`` inside a JSON envelope
+    with backtick-fenced markdown inside string values (`` `## Training`
+    `` etc.). The old heuristic parsed nothing; the new one recovers
+    the envelope."""
+    s = (
+        "Here are the actionable misalignments identified for the PR:\n\n"
+        "```json\n"
+        "{\n"
+        '  "actions": [\n'
+        '    {"id": "a", "description": "point at the training README"},\n'
+        '    {"id": "e", "description": '
+        '"Add a short README section (under the existing '
+        "experiments/training area, or a new `## Training` / "
+        "`## Fine-tuning` section) pointing at "
+        "`experiments/train_qwen2_5_vl_3b/README.md` with a "
+        'one-line summary and the quick-start command.", '
+        '"files_likely_touched": ["README.md"]}\n'
+        "  ]\n"
+        "}\n"
+        "```"
+    )
+    result = run._extract_json_object(s)
+    assert result is not None
+    assert "actions" in result
+    ids = [a["id"] for a in result["actions"]]
+    assert ids == ["a", "e"]
+    assert result["actions"][1]["files_likely_touched"] == ["README.md"]
+
+
+# ─── Falsy cases ────────────────────────────────────────────────────
+
+
+def test_empty_string_returns_none():
+    assert run._extract_json_object("") is None
+
+
+def test_no_braces_returns_none():
+    assert run._extract_json_object("plain prose, no braces here") is None
+
+
+def test_unparseable_returns_none():
+    """Non-JSON content wrapped in braces — should return None, not
+    accidentally succeed."""
+    assert run._extract_json_object("{ this is not JSON }") is None
+
+
+def test_returns_none_when_only_arrays_present():
+    """Contract: return a ``dict`` or ``None``. A response that only
+    contains a JSON array (not wrapped in an object) is not what
+    callers expect."""
+    assert run._extract_json_object('[1, 2, 3]') is None
+
+
+def test_prefers_first_valid_object_when_multiple_present():
+    """If two candidate objects appear, return the first that parses.
+    Callers only ever consume one; being deterministic here keeps
+    behavior predictable."""
+    s = '{"first": true} then {"second": true}'
+    result = run._extract_json_object(s)
+    assert result == {"first": True}


### PR DESCRIPTION
Fixes #110.

## Summary

- Replaces `_extract_json_object`'s greedy first-`{`/last-`}` heuristic with a fence-aware + bracket-matching parser.
- Two strategies, in order:
  1. Extract fenced code blocks (```` ```json … ``` ```` / ```` ``` … ``` ````) and try each in text order.
  2. Bracket-match forward from every `{`, respecting string escapes, and return the first substring that parses as a JSON object.
- Same `dict | None` return contract as before; every existing caller picks up the fix without signature changes.

## Motivating incident

Convention-pass dispatch on VQASynth PR #128 returned `convention_failed_misalignment` — the model emitted valid JSON but the response contained `{title}` template placeholders in the surrounding prose, so the old first-`{`/last-`}` slice sat on a substring that didn't parse. Same helper is called from candidate selection, misalignment, PR body rewrite, downgrade-issue, self-review, pre-PR fidelity, and extraction — so the bug can silently drop any of those model outputs.

## Test plan

- [x] `pytest tests/test_extract_json_object.py -q` — 14/14 pass
- [x] `pytest tests/ -q --ignore=tests/integration` — 1116 passed, 1 skipped (no regression in any existing caller)
- [x] New tests cover: plain / fenced / prose-wrapped JSON; the PR #128 stray-`{` regression shape; strings containing braces; escaped quotes inside strings; empty / no-brace / non-object responses; multi-object determinism