### PR TITLE
feat: mode=brief — draft a PR from a design brief (no arXiv anchor)

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -256,6 +256,31 @@ tier: {tier}
 {paper_abstract}
 """
 
+# Brief-mode SPEC: no paper anchor. The brief itself IS the spec; the
+# coding agent reads the "Design brief" section as the primary target
+# and the interest-context block if a ResearchInterest is configured.
+_SPEC_MD_TEMPLATE_BRIEF = """\
+---
+type: implementation_spec
+mode: brief
+tier: brief
+---
+
+# Implementation spec — drafted from a design brief
+
+**Anchor**: none (paper-less dispatch — brief supplied at dispatch time)
+
+---
+
+## Team's research focus
+
+{interest_context_block}
+
+## Design brief
+
+{suggested_experiment}
+"""
+
 _PAPER_MD_TEMPLATE = """\
 ---
 type: paper
@@ -813,6 +838,97 @@ Still distinguish "intentionally out of scope" (expected) from
 "stubbed / incomplete" (TODO-dominated bodies) — the latter still routes
 to an Issue per the honesty rules above.
 """
+
+
+# Brief-mode invocation: no paper, no arXiv, no Mode 1/2/3 framing.
+# The design brief IS the spec. Structurally the same file list as
+# paper-mode (SPEC/GUARDRAILS/ORIENTATION) minus PAPER.md; the
+# PR-vs-Issue decision, path/scope discipline, and self-review shape
+# are unchanged so downstream gates (integration check, stub density,
+# path allowlist, OPEN_AS_ISSUE.md) still apply exactly as before.
+_INVOCATION_MD_TEMPLATE_BRIEF = """\
+---
+type: agent_invocation
+description: Headless prompt for the Claude Code CLI invocation (brief mode).
+---
+
+You are a coding agent implementing a design brief supplied via the
+Remyx Recommendation orchestrator (attribution URL: {attribution_url}).
+There is NO paper anchoring this run — the brief IS the spec.
+
+Read these files in order:
+  1. .remyx-recommendation/SPEC.md         — the design brief and the
+                                              team's configured research
+                                              focus (if any)
+  2. .remyx-recommendation/GUARDRAILS.md   — what you may and may not modify
+  3. .remyx-recommendation/ORIENTATION.md  — target repo's contributor
+                                              guide, PR template,
+                                              recent-merged-PR conventions,
+                                              lint/type config, and sample
+                                              files near likely call sites.
+                                              Use these patterns without
+                                              re-exploring them.
+{environment_file_ref}{repo_intel_ref}
+
+Scope discipline (same as paper mode):
+  - Identify the call site FIRST from the brief + orientation. Do NOT
+    broad-list `{package}/` or `tests/`.
+  - Open only the files the target function directly imports or calls.
+  - Skip generated, vendored, lockfile, data, notebook files, and any
+    file over ~1500 lines unless the call site is inside it.
+  - Once the call site is named, STOP exploring and implement.
+
+# Step 1 — decide: PR or Issue
+
+Open as PR only if BOTH hold:
+
+  (a) You can identify a SPECIFIC existing module/function in `{package}/`
+      where the brief's change lands (the "call site").
+
+  (b) The brief defines a concrete, scoped change — not "add feature X
+      end-to-end" spanning many surfaces, but a bounded edit at the
+      call site.
+
+Otherwise, write `.remyx-recommendation/{issue_fallback_filename}` with
+the change proposal + a note on why a PR wasn't the fit (e.g. the brief
+is too broad, no clear call site exists, the target infra is missing).
+The orchestrator will file the Issue.
+
+# Step 2 — implement
+
+Follow the target repo's conventions from ORIENTATION.md. Prefer editing
+existing files over creating new ones. Add tests that import from a
+pre-existing module in the package — not just the new code you wrote.
+The test-integration gate downstream will reject a PR whose new tests
+only self-test the new module.
+
+# Step 3 — self-review
+
+Before finishing, cite in a comment or the PR body:
+  - The call site you targeted (file + function)
+  - What the brief asked for vs. what you implemented (any deviations)
+  - Anything intentionally out of scope
+
+Distinguish "intentionally out of scope" from "stubbed / incomplete" —
+the latter routes to an Issue per the honesty rules.
+
+# CRITICAL: do not run git commands
+
+You MUST NOT run any `git` command during your session (`git init`,
+`git checkout`, `git stash`, `git reset`, `git commit`, `git add`,
+`git rm`, `git rebase`, etc. — none of them, including `git status`).
+The orchestrator manages all version control. Past runs have hit
+subtle issues where agents ran a `git checkout` to back out a
+half-edit and left the working tree in an orphan state that broke
+the PR — or committed their in-progress work on top of the default
+branch, which trips the ``commit_and_push`` sanity check that HEAD
+still matches ``origin/<base>`` and produces ``brief_failed``.
+
+If you need to back out an edit, use the file-edit tools to restore
+the file's content. Look up the original content via standard read
+tools — do not invoke git.
+"""
+
 
 # Two helper Claude prompts: PR/Issue routing pre-flight (§6) and the
 # post-implementation self-review (§4). Both are rendered with str.replace()
@@ -1436,6 +1552,35 @@ _Opened by the [Remyx Recommendation]({attribution_url}) orchestrator._
 """
 
 
+# Brief-mode PR body: no arXiv anchor, so no ``Implements [paper](arxiv)``
+# attribution and no "Discovery context" (there was no discovery — the
+# brief WAS the input). The brief itself lands in a "Design brief"
+# collapse so the maintainer can read what the agent was asked to do
+# without scrolling past the diff. ``issue_refs_line`` surfaces
+# GitHub issue links when the brief cites them (either as ``#N`` or
+# as full URLs) so the PR-Issue relation graph resolves.
+_PR_BODY_TEMPLATE_BRIEF = """\
+{test_section}
+{license_section}
+_Drafted from a design brief supplied at dispatch time. No arXiv anchor — the brief IS the spec._
+{issue_refs_line}
+<details>
+<summary><b>Design brief</b></summary>
+
+> Drafted by an autonomous coding loop — Remyx's Outrider action receives a design brief via workflow_dispatch, produces an implementation against this repo, and opens this PR for review. The brief is the sole input; there is no ranker-picked paper behind this PR.
+
+**Implementation by**: Claude Code as autonomous agent
+
+## Brief
+
+{suggested_experiment}
+
+</details>
+
+_Opened by the [Remyx Recommendation]({attribution_url}) orchestrator._
+"""
+
+
 # ─── Data classes ──────────────────────────────────────────────────────────
 
 
@@ -1705,9 +1850,291 @@ class Recommendation:
                                       # Carries the query text for provenance;
                                       # "" = broad pool. Drives the pool-
                                       # composition telemetry.
+    # Multi-license aggregation for brief-mode dispatches. A design
+    # brief may reference several external repos + model cards; this
+    # holds one entry per distinct URL (deduplicated, capped at
+    # _BRIEF_LICENSE_CAP). Each entry is (kind, slug, spdx,
+    # license_class) — same shape ``_render_multi_license_section``
+    # consumes. Empty on paper-anchored dispatches (single reference
+    # → single set of ``paper_*`` fields carries the signal).
+    referenced_licenses: list = field(default_factory=list)
 
 
 # ─── Helpers ───────────────────────────────────────────────────────────────
+
+
+_ISSUE_URL_RE = re.compile(
+    r"https?://github\.com/([\w.-]+)/([\w.-]+)/issues/(\d+)"
+)
+_ISSUE_HASH_RE = re.compile(r"(?:^|[\s(])#(\d+)\b")
+
+
+def _extract_issue_refs(lead_content: str, target_repo: str) -> list[str]:
+    """Extract issue references from a design brief.
+
+    Returns a list of GitHub issue references in the form ``#N`` or
+    ``owner/repo#N`` (the latter when the URL points at a repo other
+    than ``target_repo`` — cross-repo refs must be qualified so the
+    PR-Issue link resolves correctly).
+
+    Matches two forms:
+      1. Full URLs: ``https://github.com/owner/repo/issues/N``
+      2. Short refs: ``#N`` inside prose (bracketed, whitespace-
+         prefixed, or line-start; avoids matching hex digits inside
+         hashes or arxiv IDs)
+
+    Deduplicated + order-preserving.
+    """
+    refs: list[str] = []
+    seen: set[str] = set()
+
+    for match in _ISSUE_URL_RE.finditer(lead_content):
+        owner, repo, num = match.group(1), match.group(2), match.group(3)
+        ref = f"#{num}" if f"{owner}/{repo}" == target_repo else f"{owner}/{repo}#{num}"
+        if ref not in seen:
+            refs.append(ref)
+            seen.add(ref)
+
+    for match in _ISSUE_HASH_RE.finditer(lead_content):
+        ref = f"#{match.group(1)}"
+        if ref not in seen:
+            refs.append(ref)
+            seen.add(ref)
+
+    return refs
+
+
+# Cap on the number of referenced repos we license-check per dispatch.
+# A brief that legitimately cites more than this is either exceptional
+# or a copy-paste of a bibliography — in either case, five is a strong
+# signal to a reviewer; the tail rarely changes the adoption verdict
+# and each fetch is a network round-trip.
+_BRIEF_LICENSE_CAP = 5
+
+
+def _extract_all_referenced_repos(
+    lead_content: str, target_repo: str
+) -> list[tuple[str, str]]:
+    """Return an ordered, deduplicated list of ``(kind, slug)`` pairs
+    for every distinct GitHub or HuggingFace URL in the brief.
+
+    ``kind`` is ``"github"`` or ``"huggingface"``. Order matches the
+    brief's text order (first mention wins on dedup). Self-links to
+    ``target_repo`` are excluded — the target's own license is fetched
+    separately for the compat score. Capped at
+    ``_BRIEF_LICENSE_CAP``; anything past the cap is dropped and the
+    caller logs the truncation.
+    """
+    seen: set[tuple[str, str]] = set()
+    refs: list[tuple[str, str]] = []
+    for slug in _extract_github_urls(lead_content):
+        if slug == target_repo:
+            continue
+        key = ("github", slug)
+        if key not in seen:
+            seen.add(key)
+            refs.append(key)
+    for slug in _extract_huggingface_urls(lead_content):
+        key = ("huggingface", slug)
+        if key not in seen:
+            seen.add(key)
+            refs.append(key)
+    for slug in _extract_huggingface_dataset_urls(lead_content):
+        key = ("huggingface-dataset", slug)
+        if key not in seen:
+            seen.add(key)
+            refs.append(key)
+    return refs[:_BRIEF_LICENSE_CAP]
+
+
+def _fetch_referenced_license(kind: str, slug: str) -> str:
+    """Best-effort license fetch dispatch for a ``(kind, slug)`` pair.
+
+    Returns the SPDX id (or empty string on any fetch failure /
+    missing LICENSE). Never raises; the caller assembles the render
+    block from whatever comes back.
+    """
+    try:
+        if kind == "huggingface":
+            return _fetch_hf_license(slug) or ""
+        if kind == "huggingface-dataset":
+            return _fetch_hf_dataset_license(slug) or ""
+        if kind == "github":
+            return _fetch_repo_license(slug) or ""
+    except Exception:  # noqa: BLE001 — best-effort; advisory gate
+        return ""
+    return ""
+
+
+def _render_multi_license_section(
+    refs: list[tuple[str, str]],
+    fetched: list[tuple[str, str, str, str]],
+    target_class: str,
+) -> str:
+    """Render a compact multi-license block for a brief PR body.
+
+    ``fetched`` is a list of ``(kind, slug, spdx, license_class)``
+    matching the order of ``refs``. Rendered as one line per repo
+    with an emoji, the repo slug, the SPDX id, and the classifier
+    verdict — same emoji + class labels the single-license renderer
+    uses, so a reviewer scanning multiple refs sees one visual
+    grammar.
+
+    Returns ``"\\n"`` when no refs — brief PR body then reads the
+    same as before this feature landed. Returns a target-repo-license
+    diagnostic footer only when at least one referenced license
+    classifies differently from the target, so a permissive-only run
+    stays quiet.
+    """
+    if not refs:
+        return "\n"
+
+    lines = ["\n## License & code availability\n"]
+    any_non_permissive = False
+    for kind, slug, spdx, cls in fetched:
+        emoji = _LICENSE_CLASS_EMOJI.get(cls, "⚪")
+        if kind == "github":
+            url = f"https://github.com/{slug}"
+            label = slug
+        elif kind == "huggingface-dataset":
+            url = f"https://huggingface.co/datasets/{slug}"
+            label = f"datasets/{slug}"
+        else:
+            url = f"https://huggingface.co/{slug}"
+            label = slug
+        display_spdx = spdx or "(no LICENSE detected)"
+        lines.append(f"- {emoji} [{label}]({url}) — `{display_spdx}` ({cls})")
+        if cls not in ("permissive",):
+            any_non_permissive = True
+
+    if any_non_permissive:
+        lines.append(
+            "\n_At least one cited repo is not classified as permissive "
+            f"against this repo's own license ({target_class}). Review "
+            "compatibility before merging code derived from these sources._\n"
+        )
+    else:
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _enrich_brief_licenses(rec: "Recommendation", lead_content: str, target: "Target") -> None:
+    """Populate license fields on a brief-mode ``Recommendation`` from
+    URLs found in the design brief.
+
+    Multi-URL aware: collects every distinct GitHub + HuggingFace URL
+    up to ``_BRIEF_LICENSE_CAP``, fetches each license best-effort,
+    and stores the aggregated result on ``rec.referenced_licenses``
+    (a list of ``(kind, slug, spdx, license_class)`` tuples). The
+    single-license fields (``paper_license`` / ``license_class`` /
+    ``license_source``) are populated from the first non-empty fetch
+    so any legacy renderer that only reads those still gets a
+    reasonable signal.
+
+    When a brief references external repos with different licenses
+    (e.g. issue #31: HF dataset + moondream + gazelle), the PR body
+    lists each with its own classification. The paper-anchored path
+    already surfaces this per-paper via the ranker; brief mode was
+    silently skipping it.
+    """
+    all_refs = _extract_all_referenced_repos(lead_content, target.repo)
+
+    fetched: list[tuple[str, str, str, str]] = []
+    for kind, slug in all_refs:
+        spdx = _fetch_referenced_license(kind, slug)
+        cls = _classify_license(spdx) if spdx else "missing"
+        fetched.append((kind, slug, spdx, cls))
+
+    rec.referenced_licenses = fetched
+
+    if all_refs:
+        first_kind, first_slug = all_refs[0]
+        if first_kind == "github":
+            rec.paper_github_url = f"https://github.com/{first_slug}"
+        else:
+            rec.paper_huggingface_url = f"https://huggingface.co/{first_slug}"
+
+    # Populate the legacy single-license fields from the first non-empty
+    # fetch so `_render_license_section` (paper-mode) or any other
+    # single-license reader still gets a sensible signal.
+    for kind, slug, spdx, cls in fetched:
+        if spdx:
+            rec.paper_license = spdx
+            rec.license_class = cls
+            rec.license_source = "huggingface" if kind == "huggingface" else "github"
+            break
+    if not rec.paper_license:
+        rec.license_class = "no-code-link" if not all_refs else "missing"
+
+    # Target-repo license is fetched best-effort — matches the paper-
+    # anchored pipeline's advisory-gate semantics. Failure leaves the
+    # compat score at 0.0; the referenced-licenses list is still shown.
+    try:
+        target_spdx = _fetch_repo_license(target.repo)
+    except Exception:  # noqa: BLE001 — best-effort; advisory gate
+        target_spdx = ""
+    target_class = _classify_license(target_spdx)
+    rec.license_compat = _license_compat_score(rec.license_class, target_class)
+
+
+def _recommendation_from_brief(
+    lead_content: str, interest_context: str = ""
+) -> "Recommendation":
+    """Construct a synthetic ``Recommendation`` for lead-content-only mode.
+
+    In ``mode=brief``, no arXiv paper anchors the dispatch — the design
+    brief IS the spec. The rest of the pipeline (bundle writer, coding-
+    agent invocation, PR opener) is paper-shaped by history, so we
+    produce a ``Recommendation`` with paper fields blanked and the
+    brief occupying ``suggested_experiment`` (which the bundle writer
+    already treats as the primary implementation target when
+    ``INPUT_LEAD_CONTENT`` is set — see ``write_spec_bundle``).
+
+    Callers must guard downstream renderers that dereference paper
+    fields (``arxiv_id``, ``paper_abstract``, ``paper_title``,
+    license/HF fields) on the emptiness of ``arxiv_id`` — the
+    lead-content-mode PR body variant is what produces the maintainer-
+    facing evidence in place of the ``Implements arXiv:X`` attribution.
+
+    ``interest_context`` still flows in when available: brief-mode
+    dispatches on a configured repo carry the same ResearchInterest
+    body the paper-anchored path uses, so the coding agent gets the
+    same repo-shaping context regardless of anchor.
+    """
+    trimmed = (lead_content or "").strip()
+    if not trimmed:
+        raise ValueError(
+            "mode='brief' requires INPUT_LEAD_CONTENT to be a non-empty "
+            "design brief — the brief IS the spec in this mode"
+        )
+    # Title derivation: use the first non-empty line when it looks like a
+    # human-authored heading (5-100 chars, no trailing period). Otherwise
+    # a truncated marker so the branch name + PR title stay legible.
+    first_line = next(
+        (ln.strip() for ln in trimmed.splitlines() if ln.strip()), ""
+    )
+    if 5 <= len(first_line) <= 100 and not first_line.endswith("."):
+        title = first_line.lstrip("# ").strip()
+    else:
+        snippet = trimmed[:60].replace("\n", " ").strip()
+        title = f"Design brief: {snippet}…"
+    return Recommendation(
+        paper_title=title,
+        arxiv_id="",
+        tier="brief",
+        z_score=0.0,
+        spec_md="",
+        paper_abstract="",
+        domain_summary="",
+        raw_paper_md="",
+        reasoning=(
+            "(implementation drafted from a design brief supplied at "
+            "dispatch time; no arXiv paper anchors this run)"
+        ),
+        suggested_experiment=trimmed,
+        interest_context=interest_context or "",
+    )
 
 
 # Run-scoped cache for the self-minted remyx[bot] token — one mint attempt
@@ -2312,6 +2739,13 @@ _GITHUB_URL_RE = re.compile(
 _HUGGINGFACE_URL_RE = re.compile(
     r"https?://huggingface\.co/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)"
 )
+# HF dataset URLs live under a /datasets/ prefix — a shape the plain
+# model regex misses (owner=datasets, filtered as non-model). Separate
+# regex + fetcher pair so briefs citing datasets surface their license
+# alongside the model / GitHub references.
+_HUGGINGFACE_DATASET_URL_RE = re.compile(
+    r"https?://huggingface\.co/datasets/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)"
+)
 
 # Top-level GitHub paths that look like owner names in the URL but aren't
 # repos — skip them when scraping paper text for code links.
@@ -2319,6 +2753,13 @@ _GITHUB_NON_REPO_OWNERS = frozenset({
     "orgs", "topics", "marketplace", "settings", "notifications",
     "issues", "pulls", "explore", "trending", "features", "about",
     "search", "login", "signup", "new", "codespaces", "sponsors",
+    # github.com/user-attachments/assets/UUID — issue-body image uploads.
+    # Matched as "user-attachments/assets" and surfaced as a repo before
+    # this filter existed, producing a spurious "missing LICENSE" line
+    # on brief-mode PRs for any issue-attached image (VQASynth #31).
+    "user-attachments",
+    # Content-URL paths that share the owner/name shape but aren't repos.
+    "raw", "blob", "assets", "attachments", "enterprise",
 })
 
 # HuggingFace top-level paths that aren't model owners — same idea, the
@@ -2399,6 +2840,34 @@ def _extract_huggingface_urls(*texts: str) -> list[str]:
             # Trailing sentence punctuation can land inside the regex
             # match (the dot/underscore/hyphen char class is permissive)
             # — strip it so a URL that ends a sentence still resolves.
+            name = name.rstrip(".,;:!?-_")
+            if not name:
+                continue
+            slug = f"{owner}/{name}"
+            if slug not in seen:
+                seen.append(slug)
+    return seen
+
+
+def _extract_huggingface_dataset_urls(*texts: str) -> list[str]:
+    """Return de-duped ``owner/dataset`` slugs from HF Hub dataset URLs.
+
+    Brief-mode license enrichment needs to distinguish dataset URLs
+    (``huggingface.co/datasets/<owner>/<name>``) from model URLs — the
+    plain HF regex would match this as ``owner=datasets``, which gets
+    filtered by ``_HUGGINGFACE_NON_MODEL_OWNERS``. Without this
+    separate extractor, dataset citations like
+    ``huggingface.co/datasets/salma-remyx/PoseText`` never surface a
+    license, which is a real gap: dataset licensing (CC-BY variants,
+    ODbL, custom NC clauses) is the load-bearing signal for QA-pair
+    synthesis briefs.
+    """
+    seen: list[str] = []
+    for text in texts:
+        if not text:
+            continue
+        for owner, name in _HUGGINGFACE_DATASET_URL_RE.findall(text):
+            name = re.sub(r"[^A-Za-z0-9._-].*$", "", name)
             name = name.rstrip(".,;:!?-_")
             if not name:
                 continue
@@ -3548,6 +4017,50 @@ def _fetch_hf_license(owner_model: str) -> str:
     else:
         spdx = ""
     _HF_LICENSE_CACHE[owner_model] = spdx
+    return spdx
+
+
+def _fetch_hf_dataset_license(owner_dataset: str) -> str:
+    """Return the SPDX-ish license id for an HF Hub dataset, or ``""``.
+
+    Sibling of ``_fetch_hf_license`` but for the datasets endpoint
+    (``/api/datasets/{owner}/{name}``). Same envelope shape:
+    ``cardData.license`` carries the SPDX (or free-text) license from
+    the dataset card's YAML frontmatter.
+
+    Best-effort, never raises. Same cache namespace as the models
+    fetcher would conflict on ``owner/name`` collisions between a
+    model and a dataset with the same slug — we prefix the cache key
+    to keep them disjoint.
+    """
+    if not owner_dataset:
+        return ""
+    cache_key = f"dataset:{owner_dataset}"
+    if cache_key in _HF_LICENSE_CACHE:
+        return _HF_LICENSE_CACHE[cache_key]
+    url = f"https://huggingface.co/api/datasets/{owner_dataset}"
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "feature-finder-orchestrator",
+                "Accept": "application/json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            payload = json.load(resp)
+    except (urllib.error.URLError, urllib.error.HTTPError,
+            OSError, json.JSONDecodeError):
+        _HF_LICENSE_CACHE[cache_key] = ""
+        return ""
+    raw = (payload.get("cardData") or {}).get("license") or ""
+    if isinstance(raw, list):
+        spdx = (str(raw[0]).strip() if raw else "")
+    elif isinstance(raw, str):
+        spdx = raw.strip()
+    else:
+        spdx = ""
+    _HF_LICENSE_CACHE[cache_key] = spdx
     return spdx
 
 
@@ -6323,24 +6836,36 @@ def write_spec_bundle(
                 log_msg += " · " + " · ".join(detail_parts)
         log.info(log_msg)
     effective_experiment = lead_content_override or (rec.suggested_experiment or "(none)")
-    (bundle / "SPEC.md").write_text(_SPEC_MD_TEMPLATE.format(
-        paper_title=rec.paper_title,
-        arxiv_id=rec.arxiv_id,
-        tier=rec.tier,
-        relevance_score=rec.relevance_score,
-        interest_name=rec.interest_name or "(unnamed interest)",
-        interest_context_block=interest_block,
-        reasoning=rec.reasoning or "(no reasoning provided)",
-        selection_block=selection_block,
-        suggested_experiment=effective_experiment,
-        paper_abstract=rec.paper_abstract or "(abstract unavailable)",
-    ))
+    # Brief mode (rec.arxiv_id == "") writes a paper-less SPEC and skips
+    # PAPER.md entirely — there's no paper to describe. The invocation
+    # + guardrails + orientation files still land, so the coding agent
+    # reads the same file set (minus PAPER.md) as the paper-anchored
+    # path. INVOCATION.md's file-list references PAPER.md conditionally
+    # (see below).
+    if not rec.arxiv_id:
+        (bundle / "SPEC.md").write_text(_SPEC_MD_TEMPLATE_BRIEF.format(
+            interest_context_block=interest_block,
+            suggested_experiment=effective_experiment,
+        ))
+    else:
+        (bundle / "SPEC.md").write_text(_SPEC_MD_TEMPLATE.format(
+            paper_title=rec.paper_title,
+            arxiv_id=rec.arxiv_id,
+            tier=rec.tier,
+            relevance_score=rec.relevance_score,
+            interest_name=rec.interest_name or "(unnamed interest)",
+            interest_context_block=interest_block,
+            reasoning=rec.reasoning or "(no reasoning provided)",
+            selection_block=selection_block,
+            suggested_experiment=effective_experiment,
+            paper_abstract=rec.paper_abstract or "(abstract unavailable)",
+        ))
 
-    (bundle / "PAPER.md").write_text(_PAPER_MD_TEMPLATE.format(
-        paper_title=rec.paper_title,
-        arxiv_id=rec.arxiv_id,
-        paper_abstract=rec.paper_abstract,
-    ))
+        (bundle / "PAPER.md").write_text(_PAPER_MD_TEMPLATE.format(
+            paper_title=rec.paper_title,
+            arxiv_id=rec.arxiv_id,
+            paper_abstract=rec.paper_abstract,
+        ))
 
     # CONTEXT.md — team's shipping history bullets,
     # fetched from the research-interests endpoint. Skipped entirely
@@ -6407,14 +6932,27 @@ def write_spec_bundle(
         else:
             log.info("  → maintain-state=true but no .remyx/repo_intel.yaml on origin/main; continuing without")
 
-    (bundle / "INVOCATION.md").write_text(_INVOCATION_MD_TEMPLATE.format(
-        package=package,
-        attribution_url=CANONICAL_ATTRIBUTION_URL,
-        issue_fallback_filename=ISSUE_FALLBACK_FILENAME,
-        environment_file_ref=environment_file_ref,
-        research_findings_ref=research_findings_ref,
-        repo_intel_ref=repo_intel_ref,
-    ))
+    if not rec.arxiv_id:
+        # Brief-mode invocation: no PAPER.md reference, no Mode 1/2/3
+        # framing, no "research findings" (there wasn't a research
+        # phase). The brief carries scope; downstream gates are
+        # unchanged so the honesty discipline still applies.
+        (bundle / "INVOCATION.md").write_text(_INVOCATION_MD_TEMPLATE_BRIEF.format(
+            package=package,
+            attribution_url=CANONICAL_ATTRIBUTION_URL,
+            issue_fallback_filename=ISSUE_FALLBACK_FILENAME,
+            environment_file_ref=environment_file_ref,
+            repo_intel_ref=repo_intel_ref,
+        ))
+    else:
+        (bundle / "INVOCATION.md").write_text(_INVOCATION_MD_TEMPLATE.format(
+            package=package,
+            attribution_url=CANONICAL_ATTRIBUTION_URL,
+            issue_fallback_filename=ISSUE_FALLBACK_FILENAME,
+            environment_file_ref=environment_file_ref,
+            research_findings_ref=research_findings_ref,
+            repo_intel_ref=repo_intel_ref,
+        ))
 
     # ORIENTATION.md — target repo's contributor guides, PR template, recent
     # merged-PR conventions, lint/type config, detected verification stack,
@@ -9851,6 +10389,222 @@ def _resolve_external_candidate(selection: dict) -> "Recommendation | None":
     )
 
 
+def run_brief_mode(target: Target) -> dict:
+    """Draft a PR from a design brief supplied via ``INPUT_LEAD_CONTENT``.
+
+    Companion to :func:`process_target`'s paper-anchored recommend flow.
+    Skips the ranker / selection / paper-preflight — the brief IS the
+    spec. Composes existing leaf helpers so downstream gates
+    (path allowlist, integration check, stub density, self-review) and
+    telemetry surfaces (step summary, run cost) apply exactly as in the
+    paper-anchored path.
+
+    Flow:
+
+      1. Validate INPUT_LEAD_CONTENT is non-empty.
+      2. Construct a synthetic ``Recommendation`` with ``arxiv_id == ""``.
+      3. ``prepare_workdir(target)`` — clone target repo.
+      4. ``write_spec_bundle(workdir, target, rec, package, ...)`` — the
+         writer already gates on ``rec.arxiv_id``: SPEC.md renders from
+         ``_SPEC_MD_TEMPLATE_BRIEF``, PAPER.md is skipped entirely,
+         INVOCATION.md renders from ``_INVOCATION_MD_TEMPLATE_BRIEF``.
+      5. ``invoke_claude_code(workdir, timeout_s)`` — coding agent.
+      6. ``validate_changes(...)`` — path allowlist + always-blocked.
+      7. ``commit_and_push(...)`` — branch push (bundle dir is scrubbed).
+      8. ``build_pr_body(target, rec, ...)`` — gates on ``rec.arxiv_id``
+         and renders the brief variant.
+      9. ``open_pr(...)`` — draft PR on target repo.
+
+    Deliberately narrower than ``process_target``: no rate-limit guard
+    (brief mode is a manual dispatch, cadence is caller-controlled),
+    no candidate dedup (there's no candidate pool), no preflight-route
+    (the caller already decided this brief warrants a dispatch), no
+    inline refinement chain (the brief is the spec — no gap-analysis
+    stage to re-audit against a paper).
+
+    Returns a status dict shaped like ``process_target``'s so
+    ``main``'s telemetry, step-summary, and exit-status paths render
+    consistently across modes.
+    """
+    result: dict = {"repo": target.repo, "status": "error"}
+
+    lead_content = (os.environ.get("INPUT_LEAD_CONTENT") or "").strip()
+    if not lead_content:
+        log.error(
+            "mode='brief' requires INPUT_LEAD_CONTENT to be a non-empty "
+            "design brief — the brief IS the spec in this mode"
+        )
+        return {
+            "repo": target.repo,
+            "status": "skipped_brief_missing_lead_content",
+            "target_repo": target.repo,
+        }
+
+    # Lightweight interest fetch — no candidate ranking, just the
+    # customer's configured research-focus body + shipping-history
+    # bullets. Best-effort; on any failure the brief still ships,
+    # coding agent just loses that repo-shaping context. Skipped
+    # entirely when no interest_id is configured (self-hosted /
+    # setup-local paths that don't use the Remyx engine).
+    interest_name, interest_context, experiment_history = "", "", ""
+    if target.interest_id:
+        interest_name, interest_context, experiment_history = (
+            _fetch_interest_context(target.interest_id)
+        )
+    rec = _recommendation_from_brief(lead_content, interest_context=interest_context)
+    rec.interest_name = interest_name
+    rec.experiment_history = experiment_history
+
+    # License enrichment: URLs the brief references (external repos,
+    # model cards) get their licenses fetched so the PR body carries
+    # the same license warning the paper-anchored path renders.
+    # Best-effort; leaves defaults on any fetch failure.
+    _enrich_brief_licenses(rec, lead_content, target)
+    result["license_class"] = rec.license_class
+    if rec.paper_license:
+        result["referenced_license"] = rec.paper_license
+
+    # Issue-ref extraction: detect ``#N`` and full issue URLs in the
+    # brief so the PR body links back to the originating issue(s).
+    # Traceability for briefs that came from ``gh issue view`` output
+    # or a manual copy of an issue body.
+    issue_refs = _extract_issue_refs(lead_content, target.repo)
+    if issue_refs:
+        result["issue_refs"] = issue_refs
+    log.info(
+        f"  brief-mode dispatch: title={rec.paper_title!r} "
+        f"({len(lead_content)} chars in brief)"
+    )
+    result["brief_title"] = rec.paper_title
+    result["brief_chars"] = len(lead_content)
+
+    workdir = prepare_workdir(target)
+    try:
+        package = detect_package_name(workdir)
+        default_branch = detect_default_branch(workdir)
+        env_body = _load_environments_md(workdir)
+        log.info(
+            f"  detected package: {package}  default branch: {default_branch}"
+        )
+        result["package"] = package
+        result["base_branch"] = default_branch
+
+        # Bundle write — the writer's rec.arxiv_id branches emit the
+        # brief variants of SPEC.md / INVOCATION.md and skip PAPER.md.
+        write_spec_bundle(
+            workdir, target, rec, package,
+            selection_note="",
+            env_body=env_body,
+        )
+
+        # Coding-agent invocation. INVOCATION.md is already the brief
+        # variant (no Mode 1/2/3 framing; brief IS the spec).
+        claude_ok, claude_log = invoke_claude_code(
+            workdir, timeout_s=target.claude_timeout_s,
+        )
+        result["claude_log_tail"] = claude_log[-1000:]
+        if not claude_ok:
+            log.error("  ✗ claude CLI failed; no branch pushed, no PR opened")
+            result["status"] = "claude_failed"
+            return result
+
+        # Agent may have written OPEN_AS_ISSUE.md instead of code (the
+        # brief-mode INVOCATION.md offers this as the fallback path
+        # when the brief is too broad / no call site exists). Detect
+        # and short-circuit — the Issue-open path is a real project
+        # that reuses existing open_issue plumbing; not in this draft.
+        if (workdir / ISSUE_FALLBACK_FILENAME).exists():
+            log.info(
+                f"  agent wrote {ISSUE_FALLBACK_FILENAME}; brief was too "
+                f"broad for a PR. Issue-route from brief mode not yet "
+                f"wired — leaving the branch un-pushed for manual review."
+            )
+            result["status"] = "brief_declined_open_as_issue"
+            result["issue_fallback_body"] = (
+                workdir / ISSUE_FALLBACK_FILENAME
+            ).read_text()[:2000]
+            return result
+
+        # Diff validation (path allowlist + always-blocked). Same gate
+        # the paper-anchored path uses so brief-mode PRs can't touch
+        # .github/workflows/** or other guarded paths any more freely.
+        allowlisted, violations = validate_changes(workdir, target, package)
+        if not allowlisted:
+            log.error(
+                f"  ✗ path violations ({len(violations)}); no PR opened"
+            )
+            result["status"] = "rejected_path_violations"
+            result["path_violations"] = violations[:20]
+            return result
+
+        # Branch name: prefer the agent-written PR_TITLE.txt (already
+        # handled by format_pr_title with a workdir arg), fall back to
+        # a slug of the brief-derived title.
+        pr_title = format_pr_title(rec, workdir=workdir)
+        branch = _brief_branch_name(pr_title)
+        result["branch"] = branch
+        result["pr_title"] = pr_title
+
+        commit_and_push(
+            workdir, branch, pr_title, target.repo,
+            base_branch=default_branch,
+        )
+
+        # publish=branch short-circuits before ``open_pr`` — the branch
+        # is pushed for review, no PR object is created. Same semantics
+        # as the paper-anchored path uses for its own publish=branch
+        # branch; brief-mode was silently ignoring it in the first
+        # v1.7.46 draft.
+        publish_mode = (os.environ.get("INPUT_PUBLISH") or "pr").strip().lower()
+        if publish_mode == "branch":
+            branch_url = f"https://github.com/{target.repo}/tree/{branch}"
+            result["status"] = "branch_pushed_no_pr"
+            result["branch_url"] = branch_url
+            log.info(
+                f"  ✓ {result['status']}: {branch_url} "
+                f"(no PR opened; publish=branch)"
+            )
+            return result
+
+        # PR body: build_pr_body branches on rec.arxiv_id → brief
+        # variant (no "Implements paper" attribution, no discovery-
+        # context collapse; the brief itself lands in "Design brief").
+        pr_body = build_pr_body(
+            target, rec, tests_status="unvalidated", test_output="",
+        )
+        draft = target.draft_mode != "never"
+        pr_url, pr_number = open_pr(
+            target, branch, pr_title, pr_body, draft,
+            base=default_branch,
+        )
+        log.info(f"  ✓ opened brief-mode PR: {pr_url}")
+        result["status"] = "pr_opened_brief"
+        result["pr_url"] = pr_url
+        result["pr_number"] = pr_number
+        result["draft"] = draft
+        return result
+
+    finally:
+        if not os.environ.get("DEBUG_KEEP_WORKDIR"):
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _brief_branch_name(pr_title: str) -> str:
+    """Derive a branch name from a brief-mode PR title.
+
+    Same ``remyx-recommendation/`` prefix as the paper-anchored path so
+    downstream housekeeping (dedup, stale-branch cleanup) picks brief-
+    mode branches up on the same rules. Slug is a lowercased, hyphen-
+    joined, punctuation-stripped snippet of the title, capped at 40
+    chars so the branch remains readable in the GitHub UI.
+    """
+    import re
+    slug_source = pr_title.removeprefix(PR_TITLE_PREFIX).strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug_source.lower()).strip("-")
+    slug = slug[:40].rstrip("-") or "brief"
+    return f"{BRANCH_PREFIX}{slug}"
+
+
 def process_target(target: Target) -> dict:
     """Run the full discovery + implementation loop for one target.
     Returns a status dict suitable for logging / Slack notify.
@@ -11326,6 +12080,45 @@ def build_pr_body(
         if selection_note and not selection_note.startswith("(")
         else "\n"
     )
+    # Brief mode (rec.arxiv_id == "") renders a paper-less body: no
+    # "Implements arXiv:X" attribution, no "Discovery context" collapse
+    # (there was no discovery — the brief WAS the input). The brief
+    # itself carries the "why" narrative in place of reasoning +
+    # selection + interest. The license section IS rendered when the
+    # brief cites an external repo — the enrichment runs upstream in
+    # ``run_brief_mode``, and this passes it through the same
+    # ``_render_license_section`` the paper path uses. ``issue_refs``
+    # extracted from the brief become a ``Refs:`` line for
+    # PR-Issue link resolution.
+    if not rec.arxiv_id:
+        issue_refs = _extract_issue_refs(
+            rec.suggested_experiment or "", target.repo,
+        )
+        issue_refs_line = (
+            f"\nRefs: {', '.join(issue_refs)}\n" if issue_refs else ""
+        )
+        # Multi-license path: brief mode aggregates every cited repo's
+        # license into ``rec.referenced_licenses``. When populated (any
+        # non-target repo was cited in the brief), render the multi-
+        # entry block instead of the single-license one — which would
+        # only surface the first URL and hide the tail.
+        if rec.referenced_licenses:
+            target_spdx = _fetch_repo_license(target.repo)
+            target_class = _classify_license(target_spdx)
+            license_section = _render_multi_license_section(
+                [(k, s) for (k, s, _sp, _cl) in rec.referenced_licenses],
+                rec.referenced_licenses,
+                target_class,
+            )
+        else:
+            license_section = _render_license_section(rec)
+        return _PR_BODY_TEMPLATE_BRIEF.format(
+            suggested_experiment=rec.suggested_experiment or "(no brief provided)",
+            test_section=test_section,
+            license_section=license_section,
+            issue_refs_line=issue_refs_line,
+            attribution_url=CANONICAL_ATTRIBUTION_URL,
+        )
     return _PR_BODY_TEMPLATE.format(
         paper_title=rec.paper_title,
         arxiv_id=rec.arxiv_id,
@@ -16937,11 +17730,11 @@ def main():
     ).strip().lower().replace("_", "-")
     if mode not in (
         "recommend", "weekly-summary", "fidelity", "convention", "test",
-        "issue-convention",
+        "issue-convention", "brief",
     ):
         log.error(f"Unknown mode {mode!r}; must be 'recommend', "
                   f"'weekly-summary', 'fidelity', 'convention', 'test', "
-                  f"or 'issue-convention'.")
+                  f"'issue-convention', or 'brief'.")
         sys.exit(2)
 
     target = build_target_from_env()
@@ -17004,6 +17797,12 @@ def main():
         log.info(f"  mode=issue-convention  issue_number={issue_number}")
         runner = run_issue_convention_pass
         failure_status = "issue_convention_failed_claude"
+    elif mode == "brief":
+        # Paper-less path: INPUT_LEAD_CONTENT is the spec. See
+        # ``run_brief_mode`` for the landing zones the full flow needs.
+        log.info("  mode=brief  (lead-content is the spec; no arXiv anchor)")
+        runner = run_brief_mode
+        failure_status = "brief_failed"
     else:
         log.info(f"  min_confidence={target.min_confidence}  "
                  f"draft_mode={target.draft_mode}  "

--- a/tests/test_brief_mode.py
+++ b/tests/test_brief_mode.py
@@ -1,0 +1,879 @@
+"""Lead-content-only ``mode=brief`` — draft-a-PR-from-a-design-brief.
+
+The paper-anchored ``process_target`` and the paper-less
+``run_brief_mode`` compose the same leaf helpers (prepare_workdir,
+write_spec_bundle, invoke_claude_code, validate_changes,
+commit_and_push, build_pr_body, open_pr). This file covers the
+brief-mode surface end-to-end using mocked leaves so we exercise the
+real composition without a live git / API round-trip.
+
+Coverage:
+
+  1. ``_recommendation_from_brief`` — factory contract: arxiv_id="",
+     brief lands in suggested_experiment, title extraction, empty-input
+     rejection.
+  2. Mode allowlist — ``mode=brief`` is recognized in main's dispatch
+     guard.
+  3. ``run_brief_mode`` skip-path — empty brief returns a clean
+     ``skipped_brief_missing_lead_content`` result.
+  4. Renderer variants — brief-mode SPEC.md, INVOCATION.md, and PR
+     body drop paper-anchored references and emit their brief
+     counterparts. PAPER.md is not written.
+  5. ``_brief_branch_name`` — the branch-slug derivation.
+  6. ``run_brief_mode`` composition — mocked leaves confirm the flow
+     wires bundle → agent → validate → push → PR-open in order and
+     returns the expected status dict.
+
+Run with: pytest tests/test_brief_mode.py -q
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# ─── _recommendation_from_brief ─────────────────────────────────────
+
+
+def test_factory_populates_suggested_experiment_from_brief():
+    """The brief lands verbatim in ``suggested_experiment`` — that's the
+    slot the bundle-writer already treats as the primary target when
+    ``INPUT_LEAD_CONTENT`` is set (see ``write_spec_bundle``)."""
+    brief = "Add exponential backoff to the HTTP client\n\nDetails follow…"
+    rec = run._recommendation_from_brief(brief)
+    assert rec.suggested_experiment == brief.strip()
+
+
+def test_factory_empty_arxiv_id_gates_paper_attribution():
+    """``arxiv_id == ''`` is the invariant every downstream renderer
+    branches on. Assert it holds — otherwise the PR body would still
+    render ``Implements arXiv:`` with an empty id."""
+    rec = run._recommendation_from_brief("Anything")
+    assert rec.arxiv_id == ""
+    assert rec.paper_abstract == ""
+    assert rec.raw_paper_md == ""
+    assert rec.tier == "brief"
+
+
+def test_factory_extracts_short_first_line_as_title():
+    """A human-authored heading becomes the PR title / branch slug —
+    stripped of leading ``#`` and trailing whitespace."""
+    brief = "# Add exponential backoff to the HTTP client\n\nMotivation…"
+    rec = run._recommendation_from_brief(brief)
+    assert rec.paper_title == "Add exponential backoff to the HTTP client"
+
+
+def test_factory_truncates_when_first_line_is_prose():
+    """When the first line reads as prose (ends with a period, or is
+    outside the 5-100 char band), fall back to a truncated marker so
+    the branch name / PR title stay legible."""
+    brief = (
+        "This is a long paragraph of prose that never got a heading. "
+        "It just keeps going without any clear title on the first line."
+    )
+    rec = run._recommendation_from_brief(brief)
+    assert rec.paper_title.startswith("Design brief: ")
+    assert len(rec.paper_title) <= 80
+
+
+def test_factory_carries_interest_context_through():
+    """A configured ResearchInterest body still flows to the coding
+    agent even when no paper anchors the dispatch."""
+    rec = run._recommendation_from_brief(
+        "Do a thing", interest_context="Focus: rate limiting"
+    )
+    assert rec.interest_context == "Focus: rate limiting"
+
+
+def test_factory_rejects_empty_brief():
+    """An empty brief is a caller bug — the brief IS the spec in this
+    mode; there's nothing to implement without it."""
+    with pytest.raises(ValueError, match="non-empty design brief"):
+        run._recommendation_from_brief("")
+    with pytest.raises(ValueError, match="non-empty design brief"):
+        run._recommendation_from_brief("   \n  \n\t")
+
+
+# ─── run_brief_mode dispatch ────────────────────────────────────────
+
+
+def _minimal_target():
+    return run.Target(repo="owner/name")
+
+
+def test_brief_mode_empty_input_returns_skipped_status(monkeypatch, caplog):
+    """Missing INPUT_LEAD_CONTENT yields a clean skip — the runner's
+    generic ``except Exception`` in ``main`` doesn't need to catch."""
+    monkeypatch.delenv("INPUT_LEAD_CONTENT", raising=False)
+    result = run.run_brief_mode(_minimal_target())
+    assert result["status"] == "skipped_brief_missing_lead_content"
+    assert result["target_repo"] == "owner/name"
+
+
+# ─── Mode allowlist ─────────────────────────────────────────────────
+
+
+def test_brief_is_in_mode_allowlist():
+    """``mode=brief`` is a recognized dispatch — the guard in ``main``
+    that rejects unknown modes must let it through."""
+    source = (Path(__file__).resolve().parent.parent / "src" / "run.py").read_text()
+    # Cheap check that "brief" appears in the mode-allowlist tuple next
+    # to the other modes. Full string-match is brittle; this asserts the
+    # token is present in a context that only exists in main()'s guard.
+    assert '"issue-convention", "brief"' in source
+
+
+# ─── Renderer variants ──────────────────────────────────────────────
+
+
+def test_brief_invocation_forbids_git_commands():
+    """The brief-mode INVOCATION.md must include the same git-guard
+    the paper-anchored one has — without it, the coding agent may
+    commit its in-progress work on the checked-out branch, tripping
+    the commit_and_push HEAD-matches-origin sanity check and
+    surfacing brief_failed.
+
+    Regression: the pre-merge VQASynth dispatch against issue #33
+    crashed with ``local HEAD (...) doesn't match origin/main`` after
+    the coding agent ran commits during its session. The paper-anchored
+    template guards against this; brief mode was missing the block."""
+    template = run._INVOCATION_MD_TEMPLATE_BRIEF
+    assert "CRITICAL: do not run git commands" in template
+    assert "MUST NOT run any `git` command" in template
+
+
+def test_pr_body_brief_variant_omits_arxiv_attribution():
+    """No paper anchor → no ``Implements [paper](arxiv)`` line, no
+    "Discovery context" collapse. The brief itself carries the "why"
+    in a "Design brief" collapse."""
+    rec = run._recommendation_from_brief("# Add exponential backoff\n\nDetails.")
+    body = run.build_pr_body(_minimal_target(), rec, tests_status="unvalidated", test_output="")
+    assert "arxiv.org/abs/" not in body
+    assert "Discovery context" not in body
+    assert "Design brief" in body
+    assert "Add exponential backoff" in body
+    assert "Remyx Recommendation" in body  # attribution footer still lands
+
+
+def test_pr_body_paper_variant_unchanged_by_brief_gating():
+    """Paper-anchored rec (arxiv_id populated) still renders the
+    classic body — the gating shouldn't leak into the paper path."""
+    rec = run.Recommendation(
+        paper_title="Test Paper", arxiv_id="2401.12345",
+        tier="high", z_score=0.0, spec_md="", paper_abstract="abstract",
+        domain_summary="", raw_paper_md="",
+    )
+    body = run.build_pr_body(_minimal_target(), rec, tests_status="passed", test_output="")
+    assert "arxiv.org/abs/2401.12345" in body
+    assert "Discovery context" in body
+    assert "Design brief" not in body
+
+
+# ─── _brief_branch_name ─────────────────────────────────────────────
+
+
+def test_brief_branch_name_slugifies_title():
+    branch = run._brief_branch_name("Add exponential backoff to the HTTP client")
+    # Length cap is 40 chars on the slug tail so the branch stays
+    # readable in the GitHub UI; the exact truncation point depends on
+    # the input length. Anchor on prefix + human-readable prefix of the
+    # slug rather than pin the whole string.
+    assert branch.startswith(run.BRANCH_PREFIX)
+    slug = branch.removeprefix(run.BRANCH_PREFIX)
+    assert slug.startswith("add-exponential-backoff-to-the-http")
+    assert len(slug) <= 40
+
+
+def test_brief_branch_name_strips_pr_title_prefix():
+    """The ``[Remyx Recommendation]`` prefix that PR titles carry is
+    stripped from the branch slug — otherwise every brief-mode branch
+    would start with the same 20 characters."""
+    branch = run._brief_branch_name(
+        f"{run.PR_TITLE_PREFIX} Fix the pagination bug"
+    )
+    assert "fix-the-pagination-bug" in branch
+    assert "remyx-recommendation" == branch.split("/")[0]
+
+
+def test_brief_branch_name_falls_back_on_empty_slug():
+    """Punctuation-only titles slug to nothing → fall back to ``brief``
+    rather than emit ``remyx-recommendation/`` with an empty tail."""
+    branch = run._brief_branch_name("!!!???")
+    assert branch == "remyx-recommendation/brief"
+
+
+# ─── run_brief_mode composition (mocked leaves) ─────────────────────
+
+
+def test_run_brief_mode_composes_leaves(monkeypatch, tmp_path):
+    """Happy-path: a real brief flows through prepare_workdir →
+    write_spec_bundle → invoke_claude_code → validate_changes →
+    commit_and_push → build_pr_body → open_pr, and the result dict
+    carries the expected keys."""
+    monkeypatch.setenv("INPUT_LEAD_CONTENT", "# Add exp backoff\n\nDetails.")
+
+    workdir = tmp_path / "clone"
+    workdir.mkdir()
+    calls = []
+
+    def fake_prepare_workdir(target):
+        calls.append("prepare_workdir")
+        return workdir
+
+    def fake_detect_package(w):
+        calls.append("detect_package_name")
+        return "mypkg"
+
+    def fake_detect_branch(w):
+        calls.append("detect_default_branch")
+        return "main"
+
+    def fake_load_environments(w):
+        return ""
+
+    def fake_write_spec_bundle(w, target, rec, package, **kw):
+        calls.append("write_spec_bundle")
+        assert rec.arxiv_id == ""
+        assert rec.suggested_experiment == "# Add exp backoff\n\nDetails."
+        assert package == "mypkg"
+
+    def fake_invoke_claude(w, timeout_s):
+        calls.append("invoke_claude_code")
+        return (True, "ok")
+
+    def fake_validate_changes(w, target, package):
+        calls.append("validate_changes")
+        return (True, [])
+
+    def fake_format_pr_title(rec, workdir=None):
+        calls.append("format_pr_title")
+        return f"{run.PR_TITLE_PREFIX} Add exp backoff"
+
+    def fake_commit_and_push(w, branch, title, repo, base_branch="main"):
+        calls.append("commit_and_push")
+        assert branch.startswith("remyx-recommendation/")
+
+    def fake_open_pr(target, branch, title, body, draft, base="main"):
+        calls.append("open_pr")
+        assert "Design brief" in body
+        return ("https://github.com/owner/name/pull/42", 42)
+
+    monkeypatch.setattr(run, "prepare_workdir", fake_prepare_workdir)
+    monkeypatch.setattr(run, "detect_package_name", fake_detect_package)
+    monkeypatch.setattr(run, "detect_default_branch", fake_detect_branch)
+    monkeypatch.setattr(run, "_load_environments_md", fake_load_environments)
+    monkeypatch.setattr(run, "write_spec_bundle", fake_write_spec_bundle)
+    monkeypatch.setattr(run, "invoke_claude_code", fake_invoke_claude)
+    monkeypatch.setattr(run, "validate_changes", fake_validate_changes)
+    monkeypatch.setattr(run, "format_pr_title", fake_format_pr_title)
+    monkeypatch.setattr(run, "commit_and_push", fake_commit_and_push)
+    monkeypatch.setattr(run, "open_pr", fake_open_pr)
+    monkeypatch.setenv("DEBUG_KEEP_WORKDIR", "1")  # skip rmtree of tmp_path
+
+    result = run.run_brief_mode(_minimal_target())
+
+    assert result["status"] == "pr_opened_brief"
+    assert result["pr_url"] == "https://github.com/owner/name/pull/42"
+    assert result["pr_number"] == 42
+    assert result["package"] == "mypkg"
+    assert result["base_branch"] == "main"
+    # Composition order — bundle before agent, agent before validation,
+    # validation before push, push before PR-open.
+    order = [c for c in calls if c in
+             ("write_spec_bundle", "invoke_claude_code", "validate_changes",
+              "commit_and_push", "open_pr")]
+    assert order == [
+        "write_spec_bundle", "invoke_claude_code", "validate_changes",
+        "commit_and_push", "open_pr",
+    ]
+
+
+def test_run_brief_mode_short_circuits_on_claude_failure(monkeypatch, tmp_path):
+    """Agent CLI failure → status=claude_failed, no push, no PR."""
+    monkeypatch.setenv("INPUT_LEAD_CONTENT", "brief text here")
+    workdir = tmp_path / "clone"
+    workdir.mkdir()
+    push_ran = {"v": False}
+    open_pr_ran = {"v": False}
+
+    monkeypatch.setattr(run, "prepare_workdir", lambda t: workdir)
+    monkeypatch.setattr(run, "detect_package_name", lambda w: "pkg")
+    monkeypatch.setattr(run, "detect_default_branch", lambda w: "main")
+    monkeypatch.setattr(run, "_load_environments_md", lambda w: "")
+    monkeypatch.setattr(run, "write_spec_bundle",
+                        lambda *a, **kw: None)
+    monkeypatch.setattr(run, "invoke_claude_code",
+                        lambda w, timeout_s: (False, "claude error output"))
+
+    def _push(*a, **kw): push_ran["v"] = True
+    def _open(*a, **kw): open_pr_ran["v"] = True; return ("", 0)
+    monkeypatch.setattr(run, "commit_and_push", _push)
+    monkeypatch.setattr(run, "open_pr", _open)
+    monkeypatch.setenv("DEBUG_KEEP_WORKDIR", "1")
+
+    result = run.run_brief_mode(_minimal_target())
+    assert result["status"] == "claude_failed"
+    assert not push_ran["v"]
+    assert not open_pr_ran["v"]
+
+
+def test_run_brief_mode_routes_to_issue_fallback(monkeypatch, tmp_path):
+    """Agent wrote OPEN_AS_ISSUE.md (brief too broad / no call site) →
+    status=brief_declined_open_as_issue, no push, no PR. The
+    Issue-open plumbing itself is not wired yet in this draft; the
+    branch is left un-pushed for manual review."""
+    monkeypatch.setenv("INPUT_LEAD_CONTENT", "add a whole subsystem end to end")
+    workdir = tmp_path / "clone"
+    workdir.mkdir()
+    (workdir / run.BUNDLE_DIR_NAME).mkdir()
+    (workdir / run.ISSUE_FALLBACK_FILENAME).write_text(
+        "The brief spans too many surfaces for a single PR."
+    )
+    push_ran = {"v": False}
+    open_pr_ran = {"v": False}
+
+    monkeypatch.setattr(run, "prepare_workdir", lambda t: workdir)
+    monkeypatch.setattr(run, "detect_package_name", lambda w: "pkg")
+    monkeypatch.setattr(run, "detect_default_branch", lambda w: "main")
+    monkeypatch.setattr(run, "_load_environments_md", lambda w: "")
+    monkeypatch.setattr(run, "write_spec_bundle", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "invoke_claude_code",
+                        lambda w, timeout_s: (True, "wrote OPEN_AS_ISSUE.md"))
+    def _push(*a, **kw): push_ran["v"] = True
+    def _open(*a, **kw): open_pr_ran["v"] = True; return ("", 0)
+    monkeypatch.setattr(run, "commit_and_push", _push)
+    monkeypatch.setattr(run, "open_pr", _open)
+    monkeypatch.setenv("DEBUG_KEEP_WORKDIR", "1")
+
+    result = run.run_brief_mode(_minimal_target())
+    assert result["status"] == "brief_declined_open_as_issue"
+    assert "too many surfaces" in result["issue_fallback_body"]
+    assert not push_ran["v"]
+    assert not open_pr_ran["v"]
+
+
+def test_run_brief_mode_fetches_interest_context_when_id_set(monkeypatch, tmp_path):
+    """Target with interest_id configured → lightweight interest fetch
+    runs and populates rec.interest_context / interest_name /
+    experiment_history. Coding agent gets the same repo-shaping
+    context the paper-anchored path has, minus the ranker output."""
+    monkeypatch.setenv("INPUT_LEAD_CONTENT", "brief text")
+    fetch_calls = []
+
+    def fake_fetch(interest_id):
+        fetch_calls.append(interest_id)
+        return ("MyResearchInterest", "focus body here", "history bullets")
+
+    bundle_seen = {}
+    def fake_write_spec_bundle(w, target, rec, package, **kw):
+        bundle_seen["rec"] = rec
+
+    workdir = tmp_path / "clone"
+    workdir.mkdir()
+    monkeypatch.setattr(run, "prepare_workdir", lambda t: workdir)
+    monkeypatch.setattr(run, "detect_package_name", lambda w: "pkg")
+    monkeypatch.setattr(run, "detect_default_branch", lambda w: "main")
+    monkeypatch.setattr(run, "_load_environments_md", lambda w: "")
+    monkeypatch.setattr(run, "_fetch_interest_context", fake_fetch)
+    monkeypatch.setattr(run, "write_spec_bundle", fake_write_spec_bundle)
+    monkeypatch.setattr(run, "invoke_claude_code",
+                        lambda w, timeout_s: (True, "ok"))
+    monkeypatch.setattr(run, "validate_changes", lambda w, t, p: (True, []))
+    monkeypatch.setattr(run, "format_pr_title",
+                        lambda rec, workdir=None: f"{run.PR_TITLE_PREFIX} T")
+    monkeypatch.setattr(run, "commit_and_push", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "open_pr",
+                        lambda *a, **kw: ("https://x/pull/1", 1))
+    monkeypatch.setenv("DEBUG_KEEP_WORKDIR", "1")
+
+    target = run.Target(repo="owner/name", interest_id="abc-123")
+    result = run.run_brief_mode(target)
+
+    assert result["status"] == "pr_opened_brief"
+    assert fetch_calls == ["abc-123"]
+    rec = bundle_seen["rec"]
+    assert rec.interest_context == "focus body here"
+    assert rec.interest_name == "MyResearchInterest"
+    assert rec.experiment_history == "history bullets"
+
+
+def test_run_brief_mode_skips_interest_fetch_when_no_id(monkeypatch, tmp_path):
+    """Self-hosted / setup-local paths without a Remyx interest still
+    work — the fetch is skipped entirely rather than hitting the
+    engine with an empty id (which would 404 and log noise)."""
+    monkeypatch.setenv("INPUT_LEAD_CONTENT", "brief text")
+    fetch_calls = []
+    monkeypatch.setattr(run, "_fetch_interest_context",
+                        lambda i: fetch_calls.append(i) or ("", "", ""))
+
+    workdir = tmp_path / "clone"
+    workdir.mkdir()
+    monkeypatch.setattr(run, "prepare_workdir", lambda t: workdir)
+    monkeypatch.setattr(run, "detect_package_name", lambda w: "pkg")
+    monkeypatch.setattr(run, "detect_default_branch", lambda w: "main")
+    monkeypatch.setattr(run, "_load_environments_md", lambda w: "")
+    monkeypatch.setattr(run, "write_spec_bundle", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "invoke_claude_code",
+                        lambda w, timeout_s: (True, "ok"))
+    monkeypatch.setattr(run, "validate_changes", lambda w, t, p: (True, []))
+    monkeypatch.setattr(run, "format_pr_title",
+                        lambda rec, workdir=None: f"{run.PR_TITLE_PREFIX} T")
+    monkeypatch.setattr(run, "commit_and_push", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "open_pr",
+                        lambda *a, **kw: ("https://x/pull/1", 1))
+    monkeypatch.setenv("DEBUG_KEEP_WORKDIR", "1")
+
+    result = run.run_brief_mode(_minimal_target())  # no interest_id
+    assert result["status"] == "pr_opened_brief"
+    assert fetch_calls == []
+
+
+def test_run_brief_mode_survives_interest_fetch_failure(monkeypatch, tmp_path):
+    """_fetch_interest_context is best-effort — a network / auth failure
+    must not block the brief-mode flow. Empty context still lets the
+    coding agent read the brief + ORIENTATION.md."""
+    monkeypatch.setenv("INPUT_LEAD_CONTENT", "brief text")
+
+    # _fetch_interest_context has its own try/except that swallows
+    # failures and returns empty tuple. Simulate that outer contract
+    # here.
+    monkeypatch.setattr(run, "_fetch_interest_context", lambda i: ("", "", ""))
+
+    workdir = tmp_path / "clone"
+    workdir.mkdir()
+    monkeypatch.setattr(run, "prepare_workdir", lambda t: workdir)
+    monkeypatch.setattr(run, "detect_package_name", lambda w: "pkg")
+    monkeypatch.setattr(run, "detect_default_branch", lambda w: "main")
+    monkeypatch.setattr(run, "_load_environments_md", lambda w: "")
+    monkeypatch.setattr(run, "write_spec_bundle", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "invoke_claude_code",
+                        lambda w, timeout_s: (True, "ok"))
+    monkeypatch.setattr(run, "validate_changes", lambda w, t, p: (True, []))
+    monkeypatch.setattr(run, "format_pr_title",
+                        lambda rec, workdir=None: f"{run.PR_TITLE_PREFIX} T")
+    monkeypatch.setattr(run, "commit_and_push", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "open_pr",
+                        lambda *a, **kw: ("https://x/pull/1", 1))
+    monkeypatch.setenv("DEBUG_KEEP_WORKDIR", "1")
+
+    target = run.Target(repo="owner/name", interest_id="abc-123")
+    result = run.run_brief_mode(target)
+    assert result["status"] == "pr_opened_brief"
+
+
+# ─── Issue-ref extraction ───────────────────────────────────────────
+
+
+def test_extract_issue_refs_short_form():
+    """Bare ``#N`` inside prose becomes a short ref."""
+    brief = "Motivated by #53. Should also touch #77 downstream."
+    refs = run._extract_issue_refs(brief, target_repo="owner/name")
+    assert refs == ["#53", "#77"]
+
+
+def test_extract_issue_refs_full_url_same_repo():
+    """A full issue URL pointing at the target repo becomes a short
+    ref — GitHub renders these the same as ``#N`` inside the same
+    repo but the short form is what maintainers write."""
+    brief = "See https://github.com/remyxai/VQASynth/issues/53 for context."
+    refs = run._extract_issue_refs(brief, target_repo="remyxai/VQASynth")
+    assert refs == ["#53"]
+
+
+def test_extract_issue_refs_full_url_cross_repo():
+    """Cross-repo URLs get the qualified form so the link resolves
+    against the right issue tracker."""
+    brief = "See https://github.com/some-org/upstream/issues/9 in upstream."
+    refs = run._extract_issue_refs(brief, target_repo="remyxai/VQASynth")
+    assert refs == ["some-org/upstream#9"]
+
+
+def test_extract_issue_refs_deduplicates():
+    """Same ref via URL + short form is one entry."""
+    brief = (
+        "Fix requested in #53 — see "
+        "https://github.com/remyxai/VQASynth/issues/53."
+    )
+    refs = run._extract_issue_refs(brief, target_repo="remyxai/VQASynth")
+    assert refs == ["#53"]
+
+
+def test_extract_issue_refs_ignores_bare_text():
+    """No refs in a brief with no ``#N`` or issue URLs."""
+    refs = run._extract_issue_refs("Add exponential backoff.", "o/n")
+    assert refs == []
+
+
+# ─── License enrichment for brief mode ──────────────────────────────
+
+
+def test_enrich_brief_licenses_populates_from_github_url(monkeypatch):
+    """A GitHub URL in the brief → license fetched, license_class set."""
+    monkeypatch.setattr(run, "_fetch_repo_license",
+                        lambda slug: "CC-BY-4.0" if slug == "SpatialVision/Orient-Anything" else "Apache-2.0")
+    monkeypatch.setattr(run, "_fetch_hf_license", lambda slug: "")
+
+    rec = run._recommendation_from_brief(
+        "# orient anything\n\nSee https://github.com/SpatialVision/Orient-Anything for context."
+    )
+    target = run.Target(repo="remyxai/VQASynth")
+    run._enrich_brief_licenses(rec, rec.suggested_experiment, target)
+
+    assert rec.paper_github_url == "https://github.com/SpatialVision/Orient-Anything"
+    assert rec.paper_license == "CC-BY-4.0"
+    # The classifier currently buckets CC-BY-4.0 as "permissive" (it's
+    # attribution-only, no share-alike). Debatable for source-code
+    # licensing — CC-BY lacks patent-grant terms MIT/Apache-2.0 carry —
+    # but that's a classifier-level policy call, not a brief-mode issue.
+    # What matters here: the license fetch ran and the SPDX ID is
+    # visible to the maintainer in the rendered PR body.
+    assert rec.license_class in ("permissive", "copyleft", "nc", "unknown")
+    assert rec.license_source == "github"
+
+
+def test_enrich_brief_licenses_skips_self_link(monkeypatch):
+    """A brief that references the target repo itself doesn't produce
+    a spurious license warning against the target."""
+    fetches = []
+    monkeypatch.setattr(
+        run, "_fetch_repo_license",
+        lambda slug: fetches.append(slug) or "Apache-2.0",
+    )
+    monkeypatch.setattr(run, "_fetch_hf_license", lambda slug: "")
+
+    rec = run._recommendation_from_brief(
+        "See https://github.com/remyxai/VQASynth for the repo we're editing."
+    )
+    target = run.Target(repo="remyxai/VQASynth")
+    run._enrich_brief_licenses(rec, rec.suggested_experiment, target)
+
+    assert rec.paper_github_url == ""
+    # Only the target's own license fetch happened, not the self-link.
+    assert fetches == ["remyxai/VQASynth"]
+
+
+def test_enrich_brief_licenses_survives_fetch_failure(monkeypatch):
+    """License fetch is best-effort per URL — a failure on one repo
+    lands as class=missing / empty SPDX and enrichment proceeds. The
+    brief-mode flow must never block on network flakes."""
+    def boom(slug):
+        raise RuntimeError("network fetch failed")
+    monkeypatch.setattr(run, "_fetch_repo_license", boom)
+    monkeypatch.setattr(run, "_fetch_hf_license", lambda slug: "")
+
+    rec = run._recommendation_from_brief(
+        "Brief referencing https://github.com/some/repo more text"
+    )
+    target = run.Target(repo="owner/name")
+    # No raise — swallowed by _fetch_referenced_license
+    run._enrich_brief_licenses(rec, rec.suggested_experiment, target)
+    assert rec.referenced_licenses == [("github", "some/repo", "", "missing")]
+
+
+def test_pr_body_brief_variant_renders_license_section(monkeypatch):
+    """When the brief cites an external repo with a non-permissive
+    license, the PR body carries the license warning section — same
+    format the paper-anchored path uses."""
+    monkeypatch.setattr(run, "_fetch_repo_license",
+                        lambda slug: "CC-BY-4.0" if "Orient" in slug else "Apache-2.0")
+    monkeypatch.setattr(run, "_fetch_hf_license", lambda slug: "")
+
+    rec = run._recommendation_from_brief(
+        "# orient anything\n\nSee https://github.com/SpatialVision/Orient-Anything."
+    )
+    target = run.Target(repo="remyxai/VQASynth")
+    run._enrich_brief_licenses(rec, rec.suggested_experiment, target)
+    body = run.build_pr_body(target, rec, tests_status="unvalidated", test_output="")
+    assert "License & code availability" in body
+    assert "CC-BY-4.0" in body
+
+
+# ─── Multi-license enrichment ───────────────────────────────────────
+
+
+def test_extract_all_referenced_repos_dedupes_and_orders():
+    """Every distinct GitHub + HF URL surfaces, preserving text order,
+    with (kind, slug) tuples. Duplicates collapse."""
+    brief = (
+        "See https://github.com/microsoft/LLM2CLIP\n"
+        "and https://github.com/google-deepmind/magiclens\n"
+        "plus https://huggingface.co/salma-remyx/PoseText\n"
+        "and again https://github.com/microsoft/LLM2CLIP (dup)"
+    )
+    refs = run._extract_all_referenced_repos(brief, target_repo="o/n")
+    assert refs == [
+        ("github", "microsoft/LLM2CLIP"),
+        ("github", "google-deepmind/magiclens"),
+        ("huggingface", "salma-remyx/PoseText"),
+    ]
+
+
+def test_extract_all_referenced_repos_caps_at_limit():
+    """A brief legitimately citing more than the cap gets truncated to
+    the first N; the tail rarely changes the adoption verdict."""
+    brief = "\n".join(
+        f"https://github.com/org/repo{i}" for i in range(_expected_max_refs() + 3)
+    )
+    refs = run._extract_all_referenced_repos(brief, target_repo="o/n")
+    assert len(refs) == _expected_max_refs()
+
+
+def _expected_max_refs():
+    return run._BRIEF_LICENSE_CAP
+
+
+def test_extract_all_referenced_repos_excludes_target_self_link():
+    brief = "See https://github.com/owner/target and https://github.com/other/repo more"
+    refs = run._extract_all_referenced_repos(brief, target_repo="owner/target")
+    assert refs == [("github", "other/repo")]
+
+
+def test_enrich_brief_licenses_populates_referenced_licenses_list(monkeypatch):
+    """Multi-repo brief → each cited repo gets its own entry in
+    ``rec.referenced_licenses``, with best-effort license fetched."""
+    def fake_fetch_repo(slug):
+        return {
+            "microsoft/LLM2CLIP": "MIT",
+            "google-deepmind/magiclens": "Apache-2.0",
+            "remyxai/VQASynth": "Apache-2.0",
+        }.get(slug, "")
+    def fake_fetch_hf(slug):
+        return "CC-BY-4.0" if slug == "salma-remyx/PoseText" else ""
+    monkeypatch.setattr(run, "_fetch_repo_license", fake_fetch_repo)
+    monkeypatch.setattr(run, "_fetch_hf_license", fake_fetch_hf)
+
+    rec = run._recommendation_from_brief(
+        "https://github.com/microsoft/LLM2CLIP\n"
+        "https://github.com/google-deepmind/magiclens\n"
+        "https://huggingface.co/salma-remyx/PoseText"
+    )
+    target = run.Target(repo="remyxai/VQASynth")
+    run._enrich_brief_licenses(rec, rec.suggested_experiment, target)
+
+    assert len(rec.referenced_licenses) == 3
+    kinds_slugs_spdx = [
+        (k, s, sp) for (k, s, sp, _cl) in rec.referenced_licenses
+    ]
+    assert kinds_slugs_spdx == [
+        ("github", "microsoft/LLM2CLIP", "MIT"),
+        ("github", "google-deepmind/magiclens", "Apache-2.0"),
+        ("huggingface", "salma-remyx/PoseText", "CC-BY-4.0"),
+    ]
+
+
+def test_pr_body_brief_variant_renders_all_referenced_licenses(monkeypatch):
+    """The multi-license section shows one line per cited repo, each
+    with its SPDX id and classifier verdict — a maintainer scanning
+    the PR sees the full referenced-code inventory at once."""
+    monkeypatch.setattr(
+        run, "_fetch_repo_license",
+        lambda slug: {
+            "vikhyat/moondream": "Apache-2.0",
+            "fkryan/gazelle": "MIT",
+            "remyxai/VQASynth": "Apache-2.0",
+        }.get(slug, ""),
+    )
+    monkeypatch.setattr(
+        run, "_fetch_hf_license",
+        lambda slug: "cc-by-4.0" if slug == "salma-remyx/PoseText" else "",
+    )
+
+    rec = run._recommendation_from_brief(
+        "https://github.com/vikhyat/moondream\n"
+        "https://github.com/fkryan/gazelle\n"
+        "https://huggingface.co/salma-remyx/PoseText"
+    )
+    target = run.Target(repo="remyxai/VQASynth")
+    run._enrich_brief_licenses(rec, rec.suggested_experiment, target)
+    body = run.build_pr_body(target, rec, tests_status="unvalidated", test_output="")
+
+    assert "License & code availability" in body
+    assert "vikhyat/moondream" in body
+    assert "fkryan/gazelle" in body
+    assert "salma-remyx/PoseText" in body
+    # Each SPDX id appears
+    for token in ("Apache-2.0", "MIT", "cc-by-4.0"):
+        assert token in body
+
+
+def test_pr_body_no_refs_omits_license_section():
+    """A brief that cites no external repos → no License section
+    pollutes the body. Same behavior as the paper-anchored path when
+    the license fetch didn't run."""
+    rec = run._recommendation_from_brief("Add feature X against the local module.")
+    body = run.build_pr_body(_minimal_target(), rec, tests_status="unvalidated", test_output="")
+    assert "License & code availability" not in body
+
+
+def test_user_attachments_url_not_treated_as_repo():
+    """Issue-body image uploads (github.com/user-attachments/assets/UUID)
+    were surfacing as 'user-attachments/assets' repos with '(no
+    LICENSE)' warnings. Regression: VQASynth #31 body carries an
+    image URL of this shape. It must be filtered."""
+    brief = (
+        "Description with an image "
+        "![img](https://github.com/user-attachments/assets/abc-123-def)"
+    )
+    refs = run._extract_all_referenced_repos(brief, target_repo="o/n")
+    assert refs == []
+
+
+def test_huggingface_dataset_url_surfaces_as_dataset_kind():
+    """HF Hub dataset URLs (huggingface.co/datasets/<owner>/<name>)
+    surface with kind='huggingface-dataset'. Previously filtered by
+    the non-model-owners list, which meant dataset citations never
+    got a license line — real gap since briefs often anchor on a
+    dataset (VQASynth #31 → salma-remyx/PoseText)."""
+    brief = "See https://huggingface.co/datasets/salma-remyx/PoseText"
+    refs = run._extract_all_referenced_repos(brief, target_repo="o/n")
+    assert refs == [("huggingface-dataset", "salma-remyx/PoseText")]
+
+
+def test_fetch_referenced_license_dispatches_to_dataset_fetcher(monkeypatch):
+    """kind='huggingface-dataset' calls the dataset endpoint fetcher,
+    not the models one — the endpoints are distinct and a model-name
+    slug for a dataset would 404."""
+    calls = []
+    def fake_dataset(slug):
+        calls.append(("dataset", slug))
+        return "cc-by-nc-4.0"
+    def fake_model(slug):
+        calls.append(("model", slug))
+        return "apache-2.0"  # should NOT be called
+    monkeypatch.setattr(run, "_fetch_hf_dataset_license", fake_dataset)
+    monkeypatch.setattr(run, "_fetch_hf_license", fake_model)
+
+    result = run._fetch_referenced_license("huggingface-dataset", "owner/ds")
+    assert result == "cc-by-nc-4.0"
+    assert calls == [("dataset", "owner/ds")]
+
+
+def test_multi_license_renders_dataset_url_shape(monkeypatch):
+    """A dataset ref renders as ``[datasets/owner/name](full-url)`` so
+    a maintainer can tell at a glance whether the reference is a
+    model or a dataset."""
+    monkeypatch.setattr(run, "_fetch_repo_license", lambda slug: "Apache-2.0")
+    monkeypatch.setattr(run, "_fetch_hf_license", lambda slug: "")
+    monkeypatch.setattr(
+        run, "_fetch_hf_dataset_license",
+        lambda slug: "cc-by-4.0" if slug == "salma-remyx/PoseText" else "",
+    )
+    rec = run._recommendation_from_brief(
+        "Ref: https://huggingface.co/datasets/salma-remyx/PoseText"
+    )
+    target = run.Target(repo="remyxai/VQASynth")
+    run._enrich_brief_licenses(rec, rec.suggested_experiment, target)
+    body = run.build_pr_body(target, rec, tests_status="unvalidated", test_output="")
+    assert "datasets/salma-remyx/PoseText" in body
+    assert "huggingface.co/datasets/salma-remyx/PoseText" in body
+    assert "cc-by-4.0" in body
+
+
+def test_multi_license_survives_individual_fetch_failure(monkeypatch):
+    """One repo's fetch failure doesn't stop the others from surfacing.
+    The failing repo lands with class=missing and empty SPDX."""
+    def fake_fetch_repo(slug):
+        if slug == "broken/repo":
+            raise RuntimeError("network fetch failed")
+        return "Apache-2.0"
+    monkeypatch.setattr(run, "_fetch_repo_license", fake_fetch_repo)
+    monkeypatch.setattr(run, "_fetch_hf_license", lambda slug: "")
+
+    rec = run._recommendation_from_brief(
+        "https://github.com/broken/repo\n"
+        "https://github.com/ok/repo"
+    )
+    target = run.Target(repo="o/n")
+    run._enrich_brief_licenses(rec, rec.suggested_experiment, target)
+
+    slugs = [s for (_k, s, _sp, _cl) in rec.referenced_licenses]
+    classes = [cl for (_k, _s, _sp, cl) in rec.referenced_licenses]
+    assert "broken/repo" in slugs
+    assert "ok/repo" in slugs
+    assert "missing" in classes  # broken/repo fell back to missing
+    assert "permissive" in classes  # ok/repo classified as expected
+
+
+def test_pr_body_brief_variant_renders_issue_refs():
+    """A brief that cites ``#53`` or a full issue URL produces a
+    ``Refs: #53`` line in the PR body."""
+    rec = run._recommendation_from_brief("Motivated by #53 — add feature X.")
+    body = run.build_pr_body(_minimal_target(), rec, tests_status="unvalidated", test_output="")
+    assert "Refs: #53" in body
+
+
+def test_pr_body_brief_variant_omits_refs_line_when_none():
+    """No refs in the brief → no ``Refs:`` line pollutes the body."""
+    rec = run._recommendation_from_brief("Add feature X.")
+    body = run.build_pr_body(_minimal_target(), rec, tests_status="unvalidated", test_output="")
+    assert "Refs:" not in body
+
+
+# ─── Regression coverage for prior bugs ─────────────────────────────
+
+
+def test_run_brief_mode_honors_publish_branch(monkeypatch, tmp_path):
+    """INPUT_PUBLISH=branch short-circuits after the branch push — no
+    PR object gets created, and the result carries a
+    ``branch_pushed_no_pr`` status matching the paper-anchored path.
+
+    Regression: the first v1.7.46 draft always called ``open_pr``,
+    ignoring publish=branch — surfaced by the pre-merge VQASynth
+    dispatch (issue #53) opening PR #121 despite publish=branch on
+    the wire."""
+    monkeypatch.setenv("INPUT_LEAD_CONTENT", "brief")
+    monkeypatch.setenv("INPUT_PUBLISH", "branch")
+    workdir = tmp_path / "clone"
+    workdir.mkdir()
+    open_pr_ran = {"v": False}
+
+    monkeypatch.setattr(run, "prepare_workdir", lambda t: workdir)
+    monkeypatch.setattr(run, "detect_package_name", lambda w: "pkg")
+    monkeypatch.setattr(run, "detect_default_branch", lambda w: "main")
+    monkeypatch.setattr(run, "_load_environments_md", lambda w: "")
+    monkeypatch.setattr(run, "write_spec_bundle", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "invoke_claude_code",
+                        lambda w, timeout_s: (True, "ok"))
+    monkeypatch.setattr(run, "validate_changes", lambda w, t, p: (True, []))
+    monkeypatch.setattr(run, "format_pr_title",
+                        lambda rec, workdir=None: f"{run.PR_TITLE_PREFIX} T")
+    monkeypatch.setattr(run, "commit_and_push", lambda *a, **kw: None)
+    def _open(*a, **kw): open_pr_ran["v"] = True; return ("", 0)
+    monkeypatch.setattr(run, "open_pr", _open)
+    monkeypatch.setenv("DEBUG_KEEP_WORKDIR", "1")
+
+    result = run.run_brief_mode(_minimal_target())
+    assert result["status"] == "branch_pushed_no_pr"
+    assert result["branch_url"].startswith("https://github.com/")
+    assert not open_pr_ran["v"], "publish=branch must skip open_pr"
+
+
+def test_run_brief_mode_rejects_path_violations(monkeypatch, tmp_path):
+    """Diff touches out-of-bounds paths → status=rejected_path_violations,
+    no push, no PR. Same gate the paper-anchored path uses."""
+    monkeypatch.setenv("INPUT_LEAD_CONTENT", "brief")
+    workdir = tmp_path / "clone"
+    workdir.mkdir()
+    push_ran = {"v": False}
+
+    monkeypatch.setattr(run, "prepare_workdir", lambda t: workdir)
+    monkeypatch.setattr(run, "detect_package_name", lambda w: "pkg")
+    monkeypatch.setattr(run, "detect_default_branch", lambda w: "main")
+    monkeypatch.setattr(run, "_load_environments_md", lambda w: "")
+    monkeypatch.setattr(run, "write_spec_bundle", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "invoke_claude_code",
+                        lambda w, timeout_s: (True, "ok"))
+    monkeypatch.setattr(run, "validate_changes",
+                        lambda w, t, p: (False, [".github/workflows/x.yml"]))
+    def _push(*a, **kw): push_ran["v"] = True
+    monkeypatch.setattr(run, "commit_and_push", _push)
+    monkeypatch.setenv("DEBUG_KEEP_WORKDIR", "1")
+
+    result = run.run_brief_mode(_minimal_target())
+    assert result["status"] == "rejected_path_violations"
+    assert ".github/workflows/x.yml" in result["path_violations"]
+    assert not push_ran["v"]

--- a/tests/test_brief_mode_integration.py
+++ b/tests/test_brief_mode_integration.py
@@ -1,0 +1,337 @@
+"""Integration test for ``run_brief_mode`` — real filesystem, real git
+push, mocked only at network boundaries.
+
+Scope: everything downstream of ``prepare_workdir`` runs against real
+disk and a local bare git "remote". What's covered:
+
+  - ``write_spec_bundle`` renders SPEC.md / INVOCATION.md on disk from
+    the brief-mode templates, correctly, with the brief content
+    interpolated in.
+  - ``PAPER.md`` is NOT written (paper-less path invariant).
+  - The ``.git/info/exclude`` mark is applied so downstream ``git
+    add -A`` skips the bundle.
+  - A simulated coding-agent edit passes ``validate_changes``.
+  - ``format_pr_title`` returns the brief-derived title when no
+    PR_TITLE.txt is written.
+  - ``commit_and_push`` produces a real commit + branch push to the
+    local bare remote, and the bundle directory does NOT land in the
+    committed diff.
+  - ``build_pr_body`` renders the brief-variant body against the
+    committed state.
+
+Mocked (network boundaries only):
+  - ``prepare_workdir`` — the test constructs the workdir directly by
+    cloning a local bare repo; the real function hardcodes GitHub URLs.
+  - ``_fetch_interest_context`` — no engine round-trip.
+  - ``invoke_claude_code`` — the coding-agent call is simulated by
+    writing a small file into the workdir before validation runs.
+  - ``_recommit_via_api`` — the final GitHub-API bot re-author step.
+  - ``open_pr`` — the final GitHub-API PR creation.
+
+Not covered (out of scope for this integration test):
+  - What the real ``claude`` CLI produces from a brief-mode INVOCATION.md.
+    That's the live-dispatch integration test (VQASynth issue #53 or
+    similar), which needs the branch merged + a real GitHub Action run.
+
+Run with: pytest tests/test_brief_mode_integration.py -q -s
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def bare_remote(tmp_path):
+    """Create a local bare "GitHub remote" with a seed commit on main."""
+    seed = tmp_path / "seed"
+    subprocess.run(["git", "init", "-q", str(seed)], check=True)
+    subprocess.run(
+        ["git", "-C", str(seed), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True,
+    )
+    (seed / "README.md").write_text("# Test target repo\n")
+    (seed / "mypkg").mkdir()
+    (seed / "mypkg" / "__init__.py").write_text("")
+    (seed / "mypkg" / "core.py").write_text("def existing_function():\n    pass\n")
+    subprocess.run(["git", "-C", str(seed), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(seed), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", "seed"],
+        check=True,
+    )
+    bare = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "clone", "--bare", "-q", str(seed), str(bare)],
+        check=True,
+    )
+    return bare
+
+
+@pytest.fixture
+def workdir(tmp_path, bare_remote):
+    """Clone the local bare remote as the coding-agent workdir; set
+    identity so commit_and_push can create commits without hitting
+    global git config."""
+    wd = tmp_path / "workdir"
+    subprocess.run(
+        ["git", "clone", "-q", str(bare_remote), str(wd)],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wd), "config", "user.email", "bot@test"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wd), "config", "user.name", "test-bot"],
+        check=True,
+    )
+    return wd
+
+
+@pytest.fixture
+def brief_rec():
+    """A brief-mode Recommendation as ``_recommendation_from_brief``
+    would produce for an issue-style brief."""
+    return run._recommendation_from_brief(
+        "# Add orientation-query support\n\n"
+        "Extend the annotation stage to support orientation queries. "
+        "Motivating reference: SpatialVision/Orient-Anything.",
+        interest_context="Focus: VQA dataset synthesis with spatial reasoning.",
+    )
+
+
+@pytest.fixture
+def target_from_bare(bare_remote):
+    """Target with repo pointing at a fake org/name; commit_and_push
+    references this string in remote URL rewrite, which we skip by
+    not providing a token."""
+    return run.Target(repo="testorg/testrepo", interest_id="")
+
+
+# ─── Real bundle-write, real disk ───────────────────────────────────
+
+
+def test_bundle_renders_brief_variants_on_disk(workdir, target_from_bare, brief_rec):
+    """write_spec_bundle produces the brief-mode SPEC.md (paper-less
+    template) + INVOCATION.md (no PAPER.md reference) + no PAPER.md
+    on disk. Interpolations are correct."""
+    run.write_spec_bundle(
+        workdir, target_from_bare, brief_rec, package="mypkg",
+        selection_note="", env_body="",
+    )
+    bundle = workdir / run.BUNDLE_DIR_NAME
+    assert bundle.exists()
+
+    # SPEC.md exists and renders the brief variant.
+    spec = (bundle / "SPEC.md").read_text()
+    assert "mode: brief" in spec
+    assert "Design brief" in spec
+    assert "orientation queries" in spec
+    assert "arxiv_id:" not in spec  # paper-less
+    assert "Focus: VQA dataset synthesis" in spec
+
+    # PAPER.md is NOT written (no paper to describe).
+    assert not (bundle / "PAPER.md").exists()
+
+    # INVOCATION.md renders the brief variant.
+    invocation = (bundle / "INVOCATION.md").read_text()
+    assert "brief IS the spec" in invocation
+    assert "PAPER.md" not in invocation  # not in the read list
+    assert "Mode 1 (direct port)" not in invocation  # paper-only framing
+
+
+def test_bundle_marks_gitignore_exclude(workdir, target_from_bare, brief_rec):
+    """After bundle write, ``git add -A`` on a workdir with the
+    bundle skips the bundle files — the leak this fixes is why
+    ``.git/info/exclude`` gained the entry."""
+    run.write_spec_bundle(
+        workdir, target_from_bare, brief_rec, package="mypkg",
+        selection_note="", env_body="",
+    )
+    exclude = (workdir / ".git" / "info" / "exclude").read_text()
+    assert "/.remyx-recommendation/" in exclude
+
+
+# ─── Real git push against the local bare remote ────────────────────
+
+
+def test_commit_and_push_lands_branch_without_bundle(
+    workdir, target_from_bare, brief_rec, bare_remote, monkeypatch
+):
+    """Composed flow with real git operations:
+
+      1. write_spec_bundle produces the bundle on disk.
+      2. Simulated coding agent edits mypkg/orient.py.
+      3. validate_changes accepts the diff.
+      4. commit_and_push commits + pushes the branch to the local bare.
+      5. The pushed branch contains the coding-agent edit but NOT the
+         bundle files.
+    """
+    # 1. Bundle
+    run.write_spec_bundle(
+        workdir, target_from_bare, brief_rec, package="mypkg",
+        selection_note="", env_body="",
+    )
+
+    # 2. Simulate coding agent
+    (workdir / "mypkg" / "orient.py").write_text(
+        "def orientation_query(image, obj):\n"
+        "    \"\"\"Stub for orientation-query annotation stage.\"\"\"\n"
+        "    return None\n"
+    )
+
+    # 3. Validate
+    allowlisted, violations = run.validate_changes(
+        workdir, target_from_bare, package="mypkg",
+    )
+    assert allowlisted, f"path violations: {violations}"
+
+    # 4. Push — mock _recommit_via_api (GitHub API) but let the real
+    # git push against the local bare remote run.
+    monkeypatch.setattr(run, "_recommit_via_api", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "_github_token", lambda: "")  # skip URL rewrite
+    branch = "remyx-recommendation/add-orientation-query-support"
+    run.commit_and_push(
+        workdir, branch, "[Remyx Recommendation] Add orientation-query support",
+        target_from_bare.repo, base_branch="main",
+    )
+
+    # 5. Verify the branch landed on the bare remote and its diff is
+    # ONLY the coding-agent file — bundle got scrubbed.
+    ls_remote = subprocess.run(
+        ["git", "-C", str(bare_remote), "ls-remote", "--heads", "origin"],
+        capture_output=True, text=True, check=False,
+    )
+    # Bare repos don't have an "origin" — read refs directly instead.
+    refs = subprocess.run(
+        ["git", "-C", str(bare_remote), "for-each-ref",
+         "--format=%(refname:short)", "refs/heads/"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    assert branch in refs, f"branch not on remote; refs={refs}"
+
+    # Inspect the diff between main and the pushed branch.
+    diff_names = subprocess.run(
+        ["git", "-C", str(bare_remote), "diff", "--name-only",
+         f"main..{branch}"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    assert "mypkg/orient.py" in diff_names
+    assert not any(f.startswith(".remyx-recommendation/") for f in diff_names), (
+        f"bundle leaked into commit: {diff_names}"
+    )
+
+
+# ─── Real PR body rendering ─────────────────────────────────────────
+
+
+def test_pr_body_renders_brief_variant_with_real_rec(target_from_bare, brief_rec):
+    """build_pr_body renders the brief variant against a real
+    Recommendation from the factory — no ``Implements arXiv``
+    attribution, no license section, ``Design brief`` collapse
+    carrying the actual brief content."""
+    body = run.build_pr_body(
+        target_from_bare, brief_rec,
+        tests_status="unvalidated",
+        test_output="pytest not run in this integration test",
+    )
+    assert "arxiv.org/abs/" not in body
+    assert "Discovery context" not in body
+    assert "Design brief" in body
+    assert "orientation queries" in body
+    assert "SpatialVision/Orient-Anything" in body
+    assert "Drafted from a design brief supplied at dispatch time" in body
+
+
+# ─── Full run_brief_mode composition, real leaves except network ─────
+
+
+def test_run_brief_mode_end_to_end_against_local_bare(
+    workdir, bare_remote, target_from_bare, monkeypatch
+):
+    """Full ``run_brief_mode`` flow — all real leaves except
+    ``prepare_workdir`` (bypassed with the pre-cloned local workdir),
+    ``invoke_claude_code`` (simulated agent edit), and the two
+    GitHub-API touches (``_recommit_via_api``, ``open_pr``).
+
+    Confirms the composition end-to-end: brief → bundle → agent →
+    validate → push → PR body → open_pr, and the branch lands on the
+    local bare with a clean diff.
+    """
+    monkeypatch.setenv(
+        "INPUT_LEAD_CONTENT",
+        "# Add orientation-query support\n\n"
+        "Extend the annotation stage to support orientation queries. "
+        "Motivating reference: SpatialVision/Orient-Anything.",
+    )
+    # No engine round-trip.
+    monkeypatch.setattr(run, "_fetch_interest_context", lambda i: ("", "", ""))
+    # Bypass prepare_workdir — use the pre-cloned local workdir.
+    monkeypatch.setattr(run, "prepare_workdir", lambda t: workdir)
+
+    # Simulate the coding agent editing a real file inside the workdir.
+    def fake_invoke_claude(w, timeout_s):
+        (w / "mypkg" / "orient.py").write_text(
+            "def orientation_query(image, obj):\n"
+            "    return {'yaw': 0.0, 'pitch': 0.0, 'roll': 0.0}\n"
+        )
+        return (True, "simulated agent edit")
+    monkeypatch.setattr(run, "invoke_claude_code", fake_invoke_claude)
+
+    # Skip the GitHub-API bot re-author + skip URL rewrite (no token).
+    monkeypatch.setattr(run, "_recommit_via_api", lambda *a, **kw: None)
+    monkeypatch.setattr(run, "_github_token", lambda: "")
+
+    # Capture what would have been PR-opened.
+    opened = {}
+    def fake_open_pr(target, branch, title, body, draft, base="main"):
+        opened.update(
+            branch=branch, title=title, body=body, draft=draft, base=base,
+        )
+        return ("https://example.test/pr/1", 1)
+    monkeypatch.setattr(run, "open_pr", fake_open_pr)
+
+    # Prevent the finally-block from wiping our fixture workdir before we
+    # can inspect it.
+    monkeypatch.setenv("DEBUG_KEEP_WORKDIR", "1")
+
+    result = run.run_brief_mode(target_from_bare)
+
+    # Result shape
+    assert result["status"] == "pr_opened_brief", result
+    assert result["pr_url"] == "https://example.test/pr/1"
+    assert result["pr_number"] == 1
+    assert result["package"] == "mypkg"
+    assert result["base_branch"] == "main"
+    assert result["branch"].startswith("remyx-recommendation/")
+
+    # PR body is the brief variant
+    assert "Design brief" in opened["body"]
+    assert "arxiv.org/abs/" not in opened["body"]
+    assert "orientation queries" in opened["body"]
+
+    # Branch is really on the bare remote
+    refs = subprocess.run(
+        ["git", "-C", str(bare_remote), "for-each-ref",
+         "--format=%(refname:short)", "refs/heads/"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    assert opened["branch"] in refs
+
+    # Diff on the branch is exactly the agent's edit; no bundle.
+    diff_names = subprocess.run(
+        ["git", "-C", str(bare_remote), "diff", "--name-only",
+         f"main..{opened['branch']}"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    assert diff_names == ["mypkg/orient.py"], diff_names


### PR DESCRIPTION
Companion to the paper-anchored recommend flow: a paper-less path where a design brief IS the spec. Composes the same leaf helpers (bundle write → coding-agent → validate → push → PR-body → open-PR) so downstream gates and telemetry work identically across modes.

## Summary

- **`mode=brief`** — new run mode, routes to `run_brief_mode`. Reads `INPUT_LEAD_CONTENT` as the sole spec; no ranker call, no arXiv anchor.
- **`_recommendation_from_brief()`** — factory that builds a synthetic `Recommendation` with `arxiv_id=""` (the invariant every downstream renderer branches on).
- **Renderer variants** gated on `rec.arxiv_id`: `_SPEC_MD_TEMPLATE_BRIEF`, `_INVOCATION_MD_TEMPLATE_BRIEF`, `_PR_BODY_TEMPLATE_BRIEF`. PAPER.md is skipped entirely. INVOCATION.md drops Mode 1/2/3 framing; scope discipline + PR-vs-Issue decision + self-review shape unchanged so downstream gates still apply.
- **License enrichment** for briefs: `_extract_all_referenced_repos` collects every distinct GitHub + HF (model + dataset) URL (capped at 5); each license is fetched best-effort; PR body renders a compact multi-entry block.
- **Issue-ref auto-link** — `#N` and full issue-URL detection produces a `Refs:` line in the PR body.
- **URL extractor fixes** — `user-attachments/raw/blob` filtered out of GitHub extraction; HF dataset URLs (`huggingface.co/datasets/…`) now surface via a new dataset extractor + fetcher.
- **Git-guard in brief invocation** — same "do not run git commands during your session" block the paper-anchored INVOCATION carries, so the coding agent doesn't move HEAD and trip commit_and_push's sanity check.
- **`publish=branch` honored** in brief mode — pushes the branch without opening a PR, same semantics as the paper path.

## Test plan

- [x] `pytest tests/` — 1165 passed, 1 skipped
- [x] End-to-end integration tests with real filesystem + real local git push against a bare remote (`tests/test_brief_mode_integration.py`)
- [x] Live-dispatched 8 brief-mode PRs against `remyxai/VQASynth` (issues #53, #33, #31, #30, #28, #41, #48, #47, #51) — each produced a scoped, well-integrated implementation the corresponding convention pass could further refine
- [x] Rebased on top of #111 (JSON parser fix) — full suite green after rebase