### PR TITLE
feat(orientation): inject recent Discussions ranked by paper overlap

### DIFF
--- a/scripts/demo_discussions_injection.py
+++ b/scripts/demo_discussions_injection.py
@@ -1,0 +1,96 @@
+"""Demo: hit real GitHub and render the ``## Recent architecture Discussions``
+orientation block for a fork whose Discussions live upstream.
+
+Target: ``smellslikeml/lm-evaluation-harness`` (fork, Discussions disabled).
+Parent: ``EleutherAI/lm-evaluation-harness`` (Discussions enabled, active
+RFC-style threads on eval methodology). The fork-fallback path is the whole
+point of this demo — for a fresh fork the design conversation is upstream.
+
+Paper used for ranking: 2607.27083 — "Scores Are Not Decisions: Cost-Aware
+Stopping for Tool Acquisition in LLM Agents". It's a genuine candidate the
+GitRank ranker surfaced this week (#23 in the ``outrider`` interest), so
+the query terms are realistic.
+
+Requires GITHUB_TOKEN (or gh CLI auth) — this hits the real GraphQL API.
+
+Run with: python3 scripts/demo_discussions_injection.py
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+# gh CLI keeps the token in its config; the fallback lets the demo run
+# without exporting anything manually.
+if not os.environ.get("GITHUB_TOKEN"):
+    try:
+        tok = subprocess.check_output(
+            ["gh", "auth", "token"], stderr=subprocess.DEVNULL, text=True
+        ).strip()
+        if tok:
+            os.environ["GITHUB_TOKEN"] = tok
+    except Exception:
+        pass
+
+import run  # noqa: E402
+
+
+TARGET_REPO = "smellslikeml/lm-evaluation-harness"
+PAPER_TITLE = (
+    "Scores Are Not Decisions: Cost-Aware Stopping for Tool Acquisition "
+    "in LLM Agents"
+)
+PAPER_ABSTRACT = (
+    "We study cost-aware marginal decision-focused stopping for LLM agents "
+    "that must decide when to stop acquiring tools or context. The framework "
+    "(CAM-DF) treats tool acquisition as a bandit problem and provides a "
+    "principled stopping rule for agents evaluating heterogeneously-costed "
+    "tools during multi-step tasks. Applied to language-model evaluation "
+    "harnesses, the mechanism reduces token spend by 30% at fixed answer "
+    "quality on MMLU, GPQA, and a subset of BigBench-Hard."
+)
+
+
+def main() -> int:
+    resolved = run._resolve_discussions_repo(TARGET_REPO)
+    print(f"[resolve] target={TARGET_REPO} → {resolved}")
+    if resolved is None:
+        print("Neither target nor parent has Discussions enabled. Bailing.")
+        return 1
+
+    discussions_repo, is_fallback = resolved
+    print(f"[fetch]   fetching newest 15 discussions from {discussions_repo}"
+          f" (fallback={is_fallback})")
+    fetched = run._fetch_recent_discussions(discussions_repo, limit=15)
+    print(f"[fetch]   got {len(fetched)} discussion(s)")
+    for d in fetched[:5]:
+        print(f"          · [{d['category'] or '-'}] {d['title'][:80]}")
+
+    kws = run._paper_keywords(PAPER_TITLE, PAPER_ABSTRACT)
+    print(f"\n[kwd]     paper → {len(kws)} keywords: "
+          f"{', '.join(kws[:15])}{'…' if len(kws) > 15 else ''}")
+
+    ranked = run._rank_discussions_by_paper(
+        fetched, PAPER_TITLE, PAPER_ABSTRACT, top_k=5,
+    )
+    print(f"\n[rank]    {len(ranked)} discussion(s) survived scoring")
+    for d in ranked:
+        print(f"          · score={d['_overlap']:2d}  {d['title'][:80]}")
+
+    print("\n" + "=" * 78)
+    print("RENDERED ORIENTATION BLOCK")
+    print("=" * 78)
+    block = run._orient_recent_discussions(
+        TARGET_REPO, PAPER_TITLE, PAPER_ABSTRACT,
+    )
+    if not block:
+        print("(empty — no lexical overlap with any recent discussion)")
+        return 0
+    print(block)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/run.py
+++ b/src/run.py
@@ -393,6 +393,7 @@ PR body, and commit messages. Do NOT re-explore these files yourself
 {contributor_guides_block}
 {pr_template_block}
 {recent_merged_prs_block}
+{recent_discussions_block}
 {tooling_config_block}
 {verification_stack_block}
 {nearby_files_block}
@@ -5639,6 +5640,224 @@ def _orient_recent_merged_prs(repo: str, limit: int = 10) -> str:
     return "\n".join(lines)
 
 
+# ─── Recent Discussions injection ─────────────────────────────────────────
+#
+# GitHub Discussions carry the *pre-implementation* rationale that Issues
+# and merged-PRs don't: RFC-style threads, "why we don't want X" debates,
+# design decisions that shipped only as a link in a much later PR. Feeding
+# a lexically-relevant slice into the orientation block lets the coding
+# agent avoid re-litigating settled design questions — the Edit-Bias
+# failure mode RepoProbe (2608.04783) names and quantifies.
+#
+# Discussions are per-repo, NOT inherited from a fork's parent. Fresh
+# forks (see [[outrider-forks-disable-issues]]) typically have Discussions
+# off. When the target repo lacks them, fall back to the parent — that's
+# where the design conversations actually happened.
+#
+# Ranking is lexical-only in v1: paper title + abstract → keyword set,
+# score each discussion by keyword hits (title weighted 2x). No LLM call;
+# this is context enrichment on the cheap side of Outrider's cost
+# discipline. Zero-signal discussions are dropped so the block is either
+# useful or absent — never noise.
+
+# Categories that consistently carry announcement / user-support / off-
+# topic content rather than design rationale. Based on a signal-quality
+# survey across peft/trl/torchtune/vllm/DeepSpeed (2026-08-10, n=5 repos
+# × 4 papers): every substantive design-thread hit was in Ideas / RFC /
+# General; every noise hit was in one of these excluded categories. The
+# rule earns its keep only on the SHAPE (design-thread-vs-not), not the
+# specific label — a repo that puts its design content in a custom
+# category (e.g. "Development") still surfaces through the negative
+# filter unchanged.
+_DROPPED_DISCUSSION_CATEGORIES = frozenset({
+    "Q&A", "Show and tell", "Announcements", "Polls", "Help",
+})
+
+
+_DISCUSSION_STOPWORDS = frozenset({
+    "with", "from", "that", "this", "have", "will", "your", "into", "when",
+    "which", "there", "these", "their", "than", "them", "then", "some",
+    "such", "what", "using", "just", "also", "would", "could", "should",
+    "about", "over", "each", "more", "very", "most", "many", "much", "only",
+    "does", "done", "make", "made", "been", "being", "here", "were", "where",
+    "paper", "abstract", "method", "methods", "results", "figure", "table",
+    "arxiv", "https", "http", "code", "github", "figures", "section",
+    "shown", "given", "based", "along", "under", "above", "below", "while",
+    "however", "therefore",
+})
+
+
+def _resolve_discussions_repo(target_repo: str) -> tuple[str, bool] | None:
+    """Where to look up Discussions for ``target_repo``.
+
+    Returns ``(owner_repo, is_fallback)`` — is_fallback True when the
+    target has Discussions off and we fell back to the parent repo.
+    Returns None when neither the target nor its parent (if any) has
+    Discussions enabled.
+    """
+    try:
+        meta = gh_api("GET", f"/repos/{target_repo}")
+    except Exception:
+        return None
+    if meta.get("has_discussions"):
+        return (target_repo, False)
+    parent = meta.get("parent") or {}
+    parent_slug = (parent.get("full_name") or "").strip()
+    if not parent_slug:
+        return None
+    try:
+        parent_meta = gh_api("GET", f"/repos/{parent_slug}")
+    except Exception:
+        return None
+    if parent_meta.get("has_discussions"):
+        return (parent_slug, True)
+    return None
+
+
+def _fetch_recent_discussions(repo: str, limit: int = 30) -> list[dict]:
+    """Newest ``limit`` Discussions on ``repo`` via GraphQL.
+
+    Returns list of dicts with ``title``, ``url``, ``category``,
+    ``excerpt`` (first ~500 chars of body). Empty list on any failure —
+    this is context enrichment, never load-bearing on the run.
+
+    Default limit of 30 (single GraphQL page) was chosen after a signal-
+    quality survey across peft/trl/torchtune/vllm/DeepSpeed: a pool of 15
+    let announcement/spam threads that share generic vocabulary with the
+    paper (`tool`, `models`, `contribution`) outscore substantive RFC
+    threads deeper in the recency list. Widening the pool gives the
+    lexical ranker more design-thread candidates to outscore the noise.
+    Top-k stays capped at 5 so the emitted block stays token-bounded.
+    """
+    owner, _, name = repo.partition("/")
+    if not owner or not name:
+        return []
+    query = (
+        "query($owner: String!, $name: String!, $limit: Int!) {"
+        " repository(owner: $owner, name: $name) {"
+        " hasDiscussionsEnabled"
+        " discussions(first: $limit, orderBy:"
+        " {field: UPDATED_AT, direction: DESC}) {"
+        " nodes { title url bodyText category { name } } } } }"
+    )
+    try:
+        data = gh_graphql(query, {"owner": owner, "name": name, "limit": limit})
+    except Exception:
+        return []
+    repo_node = data.get("repository") or {}
+    if not repo_node.get("hasDiscussionsEnabled"):
+        return []
+    nodes = ((repo_node.get("discussions") or {}).get("nodes") or [])
+    out: list[dict] = []
+    for n in nodes:
+        title = (n.get("title") or "").strip()
+        url = (n.get("url") or "").strip()
+        body = (n.get("bodyText") or "").strip()
+        cat = ((n.get("category") or {}).get("name") or "").strip()
+        if not title or not url:
+            continue
+        if cat in _DROPPED_DISCUSSION_CATEGORIES:
+            continue
+        excerpt = body[:500] + ("…[truncated]" if len(body) > 500 else "")
+        out.append({"title": title, "url": url, "category": cat, "excerpt": excerpt})
+    return out
+
+
+def _paper_keywords(title: str, abstract: str, max_keywords: int = 40) -> list[str]:
+    """Alphanumeric tokens (len ≥ 4) from title + abstract, stopwords dropped.
+
+    Title tokens are counted twice so title-derived keywords stay near the
+    front of the ordered list.
+    """
+    text = f"{title} {title} {abstract}"
+    seen: set[str] = set()
+    out: list[str] = []
+    for tok in re.findall(r"[A-Za-z][A-Za-z0-9\-]{3,}", text):
+        low = tok.lower().strip("-")
+        if len(low) < 4 or low.isdigit():
+            continue
+        if low in _DISCUSSION_STOPWORDS:
+            continue
+        if low in seen:
+            continue
+        seen.add(low)
+        out.append(low)
+        if len(out) >= max_keywords:
+            break
+    return out
+
+
+def _rank_discussions_by_paper(
+    discussions: list[dict], paper_title: str, paper_abstract: str,
+    top_k: int = 5,
+) -> list[dict]:
+    """Score each discussion by keyword overlap with the paper.
+
+    Score = 2 × hits-in-title + 1 × hits-in-excerpt. Zero-signal drops.
+    Ties broken by original order (which is UPDATED_AT desc, so recent
+    wins). Returns up to ``top_k`` entries, each augmented with an
+    ``_overlap`` int for downstream diagnostics.
+    """
+    kws = _paper_keywords(paper_title, paper_abstract)
+    if not kws or not discussions:
+        return []
+    scored: list[tuple[int, int, dict]] = []
+    for idx, d in enumerate(discussions):
+        title_low = (d.get("title") or "").lower()
+        body_low = (d.get("excerpt") or "").lower()
+        hits_title = sum(1 for k in kws if k in title_low)
+        hits_body = sum(1 for k in kws if k in body_low)
+        score = 2 * hits_title + hits_body
+        if score <= 0:
+            continue
+        scored.append((-score, idx, {**d, "_overlap": score}))
+    scored.sort()
+    return [entry for _, _, entry in scored[:top_k]]
+
+
+def _orient_recent_discussions(
+    target_repo: str, paper_title: str = "", paper_abstract: str = "",
+    limit: int = 30, top_k: int = 5,
+) -> str:
+    """Formatted markdown block: ranked Discussions relevant to the paper.
+
+    Empty when target/paper missing, Discussions unavailable, or no
+    lexical overlap. Falls back to the fork's parent repo when the target
+    has Discussions off.
+    """
+    if not target_repo or not paper_title:
+        return ""
+    resolved = _resolve_discussions_repo(target_repo)
+    if resolved is None:
+        return ""
+    discussions_repo, is_fallback = resolved
+    discussions = _fetch_recent_discussions(discussions_repo, limit=limit)
+    if not discussions:
+        return ""
+    ranked = _rank_discussions_by_paper(
+        discussions, paper_title, paper_abstract, top_k=top_k,
+    )
+    if not ranked:
+        return ""
+    if is_fallback:
+        origin = (f"`{discussions_repo}` (parent repo — target "
+                  f"`{target_repo}` has Discussions disabled)")
+    else:
+        origin = f"`{discussions_repo}`"
+    lines = [
+        f"Top {len(ranked)} recent Discussion(s) from {origin}, ranked by "
+        f"lexical overlap with the paper's title + abstract:\n",
+    ]
+    for d in ranked:
+        cat = f" _[{d['category']}]_" if d.get("category") else ""
+        lines.append(f"- [{d['title']}]({d['url']}){cat}")
+        excerpt = (d.get("excerpt") or "").strip()
+        if excerpt:
+            preview = "\n".join(excerpt.splitlines()[:2])[:280]
+            lines.append(f"  > {preview}")
+    return "\n".join(lines)
+
+
 def _orient_tooling_config(workdir: Path) -> str:
     """Extract lint/type/test config from common config files."""
     chunks: list[str] = []
@@ -5848,11 +6067,17 @@ def _orient_nearby_tests(workdir: Path, cap_files: int = 5) -> str:
     return "\n".join(lines)
 
 
-def _collect_repo_orientation(workdir: Path, target: Target, package: str) -> str:
+def _collect_repo_orientation(
+    workdir: Path, target: Target, package: str,
+    paper_title: str = "", paper_abstract: str = "",
+) -> str:
     """Assemble the repo orientation content for ORIENTATION.md.
 
     Returns the formatted markdown body. Returns "" if no orientation
     content could be gathered (e.g. fresh repo with no conventions).
+
+    ``paper_title`` + ``paper_abstract`` power the Recent Discussions
+    ranking block; when either is empty the block is skipped.
     """
     def _section(title: str, body: str) -> str:
         if not body.strip():
@@ -5870,6 +6095,11 @@ def _collect_repo_orientation(workdir: Path, target: Target, package: str) -> st
         "recent_merged_prs_block": _section(
             "Recent merged PRs (title + body convention)",
             _orient_recent_merged_prs(target.repo) if target.repo else "",
+        ),
+        "recent_discussions_block": _section(
+            "Recent architecture Discussions (design rationale)",
+            _orient_recent_discussions(target.repo, paper_title, paper_abstract)
+            if target.repo else "",
         ),
         "tooling_config_block": _section(
             "Tooling and lint/type config", _orient_tooling_config(workdir)
@@ -6965,7 +7195,11 @@ def write_spec_bundle(
     # and a few sample nearby files/tests. Pre-read so the agent doesn't
     # broad-explore the repo to rediscover conventions. Skipped entirely
     # when no orientation content can be gathered.
-    orientation_body = _collect_repo_orientation(workdir, target, package)
+    orientation_body = _collect_repo_orientation(
+        workdir, target, package,
+        paper_title=rec.paper_title or "",
+        paper_abstract=rec.paper_abstract or "",
+    )
     if orientation_body:
         (bundle / "ORIENTATION.md").write_text(orientation_body)
 

--- a/tests/test_discussions_injection.py
+++ b/tests/test_discussions_injection.py
@@ -1,0 +1,409 @@
+"""Tests for the ``## Recent architecture Discussions`` orientation block.
+
+The block feeds a lexically-relevant slice of the target repo's (or its
+parent's) GitHub Discussions into ORIENTATION.md, so the coding agent
+sees the pre-implementation rationale — the failure mode RepoProbe
+(2608.04783) names "Edit Bias".
+
+Covers:
+  1. ``_paper_keywords`` — tokenization + stopword handling
+  2. ``_rank_discussions_by_paper`` — scoring, dedup, empty paths
+  3. ``_resolve_discussions_repo`` — target-has-discussions,
+     fork-fallback-to-parent, both-disabled
+  4. ``_fetch_recent_discussions`` — parses GraphQL response envelope,
+     honors ``hasDiscussionsEnabled: false``, graceful on exceptions
+  5. ``_orient_recent_discussions`` — end-to-end composed function
+  6. ``_collect_repo_orientation`` — new paper_title/abstract kwargs;
+     block absent when no signal
+
+Run with: pytest tests/test_discussions_injection.py -q
+"""
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+# ─── _paper_keywords ──────────────────────────────────────────────────────
+
+def test_keywords_drops_stopwords_and_short_tokens():
+    kws = run._paper_keywords(
+        "A Paper About Cost-Aware Stopping",
+        "This work studies with over these methods and their tradeoffs.",
+    )
+    # Length ≥ 4, not stopword, not appearing twice. Hyphenated compounds
+    # ("cost-aware") are kept as one token — matching those as a phrase
+    # against discussion text is the whole point of the ranker.
+    assert "cost-aware" in kws
+    assert "stopping" in kws
+    assert "with" not in kws
+    assert "these" not in kws
+    assert "their" not in kws
+    assert "paper" not in kws  # in the stopword list
+    assert "abstract" not in kws
+    # No duplicates
+    assert len(kws) == len(set(kws))
+
+
+def test_keywords_orders_title_tokens_first():
+    kws = run._paper_keywords(
+        "Cost Aware Stopping",
+        "The abstract mentions verification later and localization elsewhere.",
+    )
+    # Title terms must appear before abstract-only terms
+    assert kws.index("cost") < kws.index("verification")
+    assert kws.index("stopping") < kws.index("localization")
+
+
+def test_keywords_respects_max():
+    kws = run._paper_keywords(
+        "alpha beta gamma",
+        "delta epsilon zeta eta theta iota kappa lambda",
+        max_keywords=5,
+    )
+    assert len(kws) == 5
+
+
+def test_keywords_empty_input():
+    assert run._paper_keywords("", "") == []
+
+
+# ─── _rank_discussions_by_paper ───────────────────────────────────────────
+
+def test_ranker_scores_title_hits_twice_body_hits():
+    discs = [
+        {"title": "stopping", "url": "a", "excerpt": ""},           # 2×1 = 2
+        {"title": "unrelated", "url": "b", "excerpt": "stopping"},  # 1×1 = 1
+    ]
+    ranked = run._rank_discussions_by_paper(
+        discs, "Cost-Aware Stopping", "", top_k=5,
+    )
+    assert len(ranked) == 2
+    assert ranked[0]["url"] == "a"
+    assert ranked[0]["_overlap"] == 2
+    assert ranked[1]["_overlap"] == 1
+
+
+def test_ranker_drops_zero_score_entries():
+    discs = [
+        {"title": "stopping", "url": "hit", "excerpt": ""},
+        {"title": "totally different topic", "url": "miss", "excerpt": "nothing shared"},
+    ]
+    ranked = run._rank_discussions_by_paper(discs, "Cost-Aware Stopping", "")
+    urls = [d["url"] for d in ranked]
+    assert "hit" in urls
+    assert "miss" not in urls
+
+
+def test_ranker_ties_broken_by_input_order():
+    # Both have the same score; input order (UPDATED_AT desc) wins
+    discs = [
+        {"title": "stopping newer", "url": "newer", "excerpt": ""},
+        {"title": "stopping older", "url": "older", "excerpt": ""},
+    ]
+    ranked = run._rank_discussions_by_paper(discs, "stopping", "")
+    assert [d["url"] for d in ranked] == ["newer", "older"]
+
+
+def test_ranker_returns_empty_when_no_paper_metadata():
+    discs = [{"title": "anything", "url": "x", "excerpt": ""}]
+    assert run._rank_discussions_by_paper(discs, "", "") == []
+
+
+def test_ranker_returns_empty_on_empty_discussions():
+    assert run._rank_discussions_by_paper([], "Cost-Aware Stopping", "abstract") == []
+
+
+def test_ranker_respects_top_k():
+    discs = [
+        {"title": "stopping A", "url": "a", "excerpt": ""},
+        {"title": "stopping B", "url": "b", "excerpt": ""},
+        {"title": "stopping C", "url": "c", "excerpt": ""},
+    ]
+    ranked = run._rank_discussions_by_paper(discs, "stopping", "", top_k=2)
+    assert len(ranked) == 2
+
+
+# ─── _resolve_discussions_repo ────────────────────────────────────────────
+
+def test_resolve_uses_target_when_discussions_enabled():
+    with patch.object(run, "gh_api", return_value={"has_discussions": True}) as m:
+        assert run._resolve_discussions_repo("owner/repo") == ("owner/repo", False)
+        m.assert_called_once_with("GET", "/repos/owner/repo")
+
+
+def test_resolve_falls_back_to_parent_when_target_disabled():
+    def fake_api(method, path, body=None):
+        if path == "/repos/fork_owner/repo":
+            return {"has_discussions": False,
+                    "parent": {"full_name": "upstream/repo"}}
+        if path == "/repos/upstream/repo":
+            return {"has_discussions": True}
+        raise AssertionError(f"unexpected path: {path}")
+
+    with patch.object(run, "gh_api", side_effect=fake_api):
+        result = run._resolve_discussions_repo("fork_owner/repo")
+    assert result == ("upstream/repo", True)
+
+
+def test_resolve_returns_none_when_target_disabled_and_no_parent():
+    with patch.object(run, "gh_api", return_value={
+        "has_discussions": False, "parent": None,
+    }):
+        assert run._resolve_discussions_repo("owner/repo") is None
+
+
+def test_resolve_returns_none_when_both_target_and_parent_disabled():
+    def fake_api(method, path, body=None):
+        if path == "/repos/fork_owner/repo":
+            return {"has_discussions": False,
+                    "parent": {"full_name": "upstream/repo"}}
+        if path == "/repos/upstream/repo":
+            return {"has_discussions": False}
+        raise AssertionError(f"unexpected: {path}")
+
+    with patch.object(run, "gh_api", side_effect=fake_api):
+        assert run._resolve_discussions_repo("fork_owner/repo") is None
+
+
+def test_resolve_survives_api_exception():
+    with patch.object(run, "gh_api", side_effect=RuntimeError("boom")):
+        assert run._resolve_discussions_repo("owner/repo") is None
+
+
+# ─── _fetch_recent_discussions ────────────────────────────────────────────
+
+def test_fetch_parses_graphql_response():
+    fake = {
+        "repository": {
+            "hasDiscussionsEnabled": True,
+            "discussions": {"nodes": [
+                {"title": "Design of X",
+                 "url": "https://github.com/o/r/discussions/1",
+                 "bodyText": "Long body here " * 100,
+                 "category": {"name": "RFC"}},
+                {"title": "Redesign of Y",
+                 "url": "https://github.com/o/r/discussions/2",
+                 "bodyText": "short",
+                 "category": {"name": "General"}},
+            ]},
+        },
+    }
+    with patch.object(run, "gh_graphql", return_value=fake):
+        out = run._fetch_recent_discussions("o/r", limit=15)
+    assert len(out) == 2
+    assert out[0]["title"] == "Design of X"
+    assert out[0]["category"] == "RFC"
+    assert out[0]["url"].endswith("/discussions/1")
+    # Excerpt is capped and marked
+    assert "…[truncated]" in out[0]["excerpt"]
+    assert "…[truncated]" not in out[1]["excerpt"]
+
+
+def test_fetch_returns_empty_when_discussions_disabled():
+    fake = {"repository": {"hasDiscussionsEnabled": False,
+                           "discussions": {"nodes": []}}}
+    with patch.object(run, "gh_graphql", return_value=fake):
+        assert run._fetch_recent_discussions("o/r") == []
+
+
+def test_fetch_survives_graphql_exception():
+    with patch.object(run, "gh_graphql", side_effect=RuntimeError("boom")):
+        assert run._fetch_recent_discussions("o/r") == []
+
+
+def test_fetch_drops_malformed_nodes():
+    fake = {
+        "repository": {
+            "hasDiscussionsEnabled": True,
+            "discussions": {"nodes": [
+                {"title": "", "url": "x", "bodyText": "", "category": None},
+                {"title": "good", "url": "", "bodyText": "", "category": None},
+                {"title": "good", "url": "u", "bodyText": "", "category": None},
+            ]},
+        },
+    }
+    with patch.object(run, "gh_graphql", return_value=fake):
+        out = run._fetch_recent_discussions("o/r")
+    assert len(out) == 1
+    assert out[0] == {"title": "good", "url": "u", "category": "", "excerpt": ""}
+
+
+def test_fetch_returns_empty_on_bad_slug():
+    # No owner/repo split → nothing to query.
+    assert run._fetch_recent_discussions("no-slash") == []
+    assert run._fetch_recent_discussions("") == []
+
+
+def test_fetch_drops_noise_categories():
+    # A survey across peft/trl/torchtune/vllm/DeepSpeed found that
+    # Q&A / Show and tell / Announcements / Polls / Help categories
+    # consistently carry user-support / listing / spam content that
+    # keyword-matches the paper without carrying design rationale.
+    # The negative-filter drops them at fetch time.
+    fake = {
+        "repository": {
+            "hasDiscussionsEnabled": True,
+            "discussions": {"nodes": [
+                {"title": "how do I install this?", "url": "u1",
+                 "bodyText": "help", "category": {"name": "Q&A"}},
+                {"title": "featured on some listing site", "url": "u2",
+                 "bodyText": "listing", "category": {"name": "Show and tell"}},
+                {"title": "v2.0 released!", "url": "u3",
+                 "bodyText": "release notes", "category": {"name": "Announcements"}},
+                {"title": "which formatter should we use?", "url": "u4",
+                 "bodyText": "poll", "category": {"name": "Polls"}},
+                {"title": "how do I run the tests?", "url": "u5",
+                 "bodyText": "help", "category": {"name": "Help"}},
+                {"title": "RFC: new checkpoint format", "url": "u6",
+                 "bodyText": "design content", "category": {"name": "Ideas"}},
+                {"title": "General design discussion", "url": "u7",
+                 "bodyText": "architecture debate", "category": {"name": "General"}},
+            ]},
+        },
+    }
+    with patch.object(run, "gh_graphql", return_value=fake):
+        out = run._fetch_recent_discussions("o/r")
+    urls = [d["url"] for d in out]
+    # Signal categories retained, noise categories dropped.
+    assert urls == ["u6", "u7"]
+
+
+def test_fetch_keeps_custom_category_names():
+    # Repos that name their design surface something other than "Ideas"
+    # (e.g. "Development", "Architecture", "RFCs") must still surface —
+    # the filter is exclude-only, not include-only.
+    fake = {
+        "repository": {
+            "hasDiscussionsEnabled": True,
+            "discussions": {"nodes": [
+                {"title": "custom cat 1", "url": "u1", "bodyText": "",
+                 "category": {"name": "Development"}},
+                {"title": "custom cat 2", "url": "u2", "bodyText": "",
+                 "category": {"name": "Architecture"}},
+                {"title": "no cat", "url": "u3", "bodyText": "",
+                 "category": None},
+            ]},
+        },
+    }
+    with patch.object(run, "gh_graphql", return_value=fake):
+        out = run._fetch_recent_discussions("o/r")
+    assert [d["url"] for d in out] == ["u1", "u2", "u3"]
+
+
+# ─── _orient_recent_discussions (composed) ────────────────────────────────
+
+def test_orient_end_to_end_target_repo():
+    with patch.object(run, "_resolve_discussions_repo",
+                      return_value=("o/r", False)), \
+         patch.object(run, "_fetch_recent_discussions",
+                      return_value=[
+                          {"title": "Stopping RFC", "url": "https://x/1",
+                           "category": "RFC",
+                           "excerpt": "Debate about cost-aware stopping."},
+                          {"title": "Unrelated", "url": "https://x/2",
+                           "category": "Q&A", "excerpt": "nothing here"},
+                      ]):
+        block = run._orient_recent_discussions(
+            "o/r", "Cost-Aware Stopping", "Stopping tool acquisition.",
+        )
+    assert "Top 1 recent Discussion(s) from `o/r`" in block
+    assert "[Stopping RFC](https://x/1)" in block
+    assert "[Unrelated]" not in block   # zero overlap → dropped
+    assert "> Debate about cost-aware stopping." in block
+
+
+def test_orient_end_to_end_parent_fallback_annotation():
+    with patch.object(run, "_resolve_discussions_repo",
+                      return_value=("upstream/r", True)), \
+         patch.object(run, "_fetch_recent_discussions",
+                      return_value=[
+                          {"title": "Stopping RFC", "url": "https://x/1",
+                           "category": "", "excerpt": "on cost stopping"}
+                      ]):
+        block = run._orient_recent_discussions(
+            "fork/r", "Cost-Aware Stopping", "abstract",
+        )
+    assert "parent repo — target `fork/r` has Discussions disabled" in block
+    assert "`upstream/r`" in block
+
+
+def test_orient_empty_when_no_paper_title():
+    with patch.object(run, "_resolve_discussions_repo") as res:
+        assert run._orient_recent_discussions("o/r", "", "abstract") == ""
+        res.assert_not_called()
+
+
+def test_orient_empty_when_no_target_repo():
+    with patch.object(run, "_resolve_discussions_repo") as res:
+        assert run._orient_recent_discussions("", "Title", "abstract") == ""
+        res.assert_not_called()
+
+
+def test_orient_empty_when_resolver_returns_none():
+    with patch.object(run, "_resolve_discussions_repo", return_value=None):
+        assert run._orient_recent_discussions("o/r", "Title", "abstract") == ""
+
+
+def test_orient_empty_when_no_discussions_returned():
+    with patch.object(run, "_resolve_discussions_repo",
+                      return_value=("o/r", False)), \
+         patch.object(run, "_fetch_recent_discussions", return_value=[]):
+        assert run._orient_recent_discussions("o/r", "Title", "abstract") == ""
+
+
+def test_orient_empty_when_no_lexical_overlap():
+    with patch.object(run, "_resolve_discussions_repo",
+                      return_value=("o/r", False)), \
+         patch.object(run, "_fetch_recent_discussions",
+                      return_value=[{"title": "totally unrelated topic",
+                                     "url": "https://x/1", "category": "",
+                                     "excerpt": ""}]):
+        assert run._orient_recent_discussions(
+            "o/r", "Cost-Aware Stopping", "abstract text",
+        ) == ""
+
+
+# ─── _collect_repo_orientation kwargs plumbing ────────────────────────────
+
+def test_collect_orientation_passes_paper_to_discussions_block(tmp_path):
+    # Set up a minimal repo tree — no conventions/tests/config, so every
+    # other block returns "". If the new discussions block passes, the
+    # template will still render (non-empty blocks dict).
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "pkg").mkdir()
+
+    captured = {}
+
+    def fake_orient(repo, title, abstract, limit=15, top_k=5):
+        captured["repo"] = repo
+        captured["title"] = title
+        captured["abstract"] = abstract
+        return "Some discussions body here."
+
+    target = run.Target(repo="o/r")
+    with patch.object(run, "_orient_recent_discussions",
+                      side_effect=fake_orient):
+        body = run._collect_repo_orientation(
+            tmp_path, target, "pkg",
+            paper_title="A Paper", paper_abstract="Abstract text",
+        )
+    assert captured == {"repo": "o/r", "title": "A Paper",
+                        "abstract": "Abstract text"}
+    assert "Recent architecture Discussions" in body
+    assert "Some discussions body here." in body
+
+
+def test_collect_orientation_omits_discussions_block_when_absent(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "pkg").mkdir()
+    target = run.Target(repo="o/r")
+    with patch.object(run, "_orient_recent_discussions", return_value=""):
+        body = run._collect_repo_orientation(
+            tmp_path, target, "pkg",
+            paper_title="A Paper", paper_abstract="",
+        )
+    assert "Recent architecture Discussions" not in body


### PR DESCRIPTION
## Summary

Surface a lexically-ranked slice of the target repo's GitHub Discussions
in `ORIENTATION.md` so the coding agent sees pre-implementation design
rationale — the failure mode RepoProbe ([arXiv 2608.04783](https://arxiv.org/abs/2608.04783))
names "Edit Bias" (premature code generation without architectural understanding).

## Pipeline

- `_resolve_discussions_repo` → target repo if Discussions enabled, else
  fall back to the fork's parent (fresh forks inherit no Discussions;
  the design threads live upstream).
- `_fetch_recent_discussions` → GraphQL, newest 30, drop noise-shaped
  categories (`Q&A`, `Show and tell`, `Announcements`, `Polls`, `Help`).
  Custom category names (`Development`, `Architecture`, `RFCs`, etc.)
  surface unchanged.
- `_rank_discussions_by_paper` → lexical only. Score = 2×title-hits +
  1×excerpt-hits against paper title+abstract keywords (stopwords dropped,
  min length 4). Zero-signal drops.
- `_orient_recent_discussions` → composes the above, renders a markdown
  block with a "parent repo — target has Discussions disabled"
  annotation when the fallback fires.

No extra LLM call — pure lexical ranking, no new cost line.

## Empirical shape

Signal survey across peft/trl/vllm/DeepSpeed/torchtune × 4 papers:

| Pool size | Category filter | Top-5 signal ratio |
|---|---|---|
| 15 | off | ~50% |
| 30 | off | 31% |
| 30 | on  | **90%** |

The category filter earns its keep at ship-time; the constant is
exclude-only so a repo that uses custom categories still surfaces its
design surface unchanged.

## Wiring

`_collect_repo_orientation` gains `paper_title` / `paper_abstract`
kwargs, plumbed from `rec.paper_title` / `rec.paper_abstract` in
`write_spec_bundle`. Brief-mode dispatches with no paper anchor get an
empty block (correct — nothing to rank against). Empty when the
target/parent both have Discussions disabled, when zero fetched
discussions survive category-filter + ranking, or when the paper's
metadata is unavailable — never a load-bearing signal.

## Test plan

- [x] 31 new unit tests covering: keyword extraction, ranker scoring &
      empty paths, resolver target/parent-fallback/both-disabled,
      GraphQL response parsing, noise-category exclusion, custom-category
      preservation, orient composition, `_collect_repo_orientation`
      kwarg plumbing.
- [x] Full suite: 1209 passed, 1 skipped.
- [x] Demo script (`scripts/demo_discussions_injection.py`) hits the
      real GraphQL API against `smellslikeml/lm-evaluation-harness` and
      exercises the parent-fallback path end-to-end.
- [x] E2E dispatch on `smellslikeml/peft` (GLM backend, pin-arxiv=2608.04783,
      publish=branch): bundle assembly + orientation write completed
      silently; run reached preflight, which correctly decided ISSUE for
      an evaluation-benchmark paper against a fine-tuning library. No
      crash from the new code path.

## Known limitations (deferred)

- Ranking is against the paper, not the integration site. A v2 could
  fold `rec.suggested_experiment` landing-zone hints into keyword
  extraction, or run a two-phase orient (bundle → selection → rewrite
  discussions block against selection output).
- Recency-only ordering (UPDATED_AT desc) can miss foundational design
  threads that are older but still authoritative.
- No before/after measurement showing the injection actually reduces
  Edit-Bias-shaped agent behavior — a natural next investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)