### PR TITLE
outrider.yml: key the concurrency group per dispatch target

### DIFF
--- a/.github/workflows/outrider.yml
+++ b/.github/workflows/outrider.yml
@@ -49,7 +49,20 @@ on:
         default: ''
 
 concurrency:
-  group: outrider
+  # Keyed by what THIS dispatch works on, not a flat "outrider". GitHub allows
+  # exactly one *pending* run per group, and when a third arrives it cancels the
+  # one already waiting — not the newcomer — with no error and no annotation. So
+  # a batch of dispatches at one repo silently lost work: four targets produced
+  # one run, one survivor, and two cancellations that read as CI flakes.
+  #
+  # Per-target keys let distinct papers/branches run in parallel (they touch
+  # different branches), while a genuine duplicate of the same target still
+  # queues behind its predecessor. Unpinned runs fall back to run_id: never
+  # cancel a dispatch we can't prove is a duplicate.
+  #
+  # Index syntax, not dot: a bad workflow-level expression invalidates the whole
+  # workflow, and hyphenated property names are only documented as safe indexed.
+  group: outrider-${{ inputs['pin-arxiv'] || inputs['start-from-ref'] || github.run_id }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Last of the three repos in the two-fork pilot field notes (remyxai/remyxai-cli#49). CLI side: remyxai/remyxai-cli#50. Engine side: remyxai/remyx#558, which makes the identical change in `render_workflow_yaml`.

## The bug

```yaml
concurrency:
  group: outrider
  cancel-in-progress: false
```

GitHub allows exactly **one pending run** per concurrency group. When a third dispatch arrives it cancels the run already *waiting* — not the newcomer — with no error and no annotation. Firing four targets at one repo produced 1 run + 1 survivor + 2 cancellations that look like CI flakes, so you don't even know to retry them.

`cancel-in-progress: false` doesn't help: it governs the *running* job, not the queue depth, and there's no way to ask GitHub for a deeper queue. The only lever is the group key.

## The change

```yaml
group: outrider-${{ inputs['pin-arxiv'] || inputs['start-from-ref'] || github.run_id }}
```

- distinct papers/branches run in parallel — they touch different branches, so there's nothing to serialize
- a genuine duplicate of the same target still queues behind its predecessor
- unpinned runs fall back to `run_id`: never cancel a dispatch we can't prove is a duplicate
- index syntax rather than dot, because a bad workflow-level expression invalidates the whole workflow and hyphenated property names are only documented as safe when indexed

`outrider-daily.yml` and `outrider-weekly-refine.yml` keep their static groups **on purpose**: every drafter run commits to the same accumulated intel branch, so two in flight would race on the push. Serializing is protective there, not accidental.

## Release note for reviewers

This file is both this repo's own runner and the template customer installs fetch — `remyxai outrider setup-local --two-tier` and the engine's refiner fetch both read from the **`v1` tag**, which currently points at `f6b77e6`. Merging to main changes nothing for customers until `v1` is re-pointed, so this needs that follow-up to actually land anywhere.

Verified: all three workflow files still parse as YAML, and the rendered group resolves to `outrider-<paper>` / `outrider-<branch>` / `outrider-<run_id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)