### PR TITLE
Fix brief-mode push safety + surface branch/failure in step summary

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -1623,6 +1623,13 @@ FAILURE_EXIT_STATUSES = {
     "convention_failed_patch",
     "convention_failed_push",
     "test_failed_setup",
+    # Brief mode ("lead-content is the spec") and issue-convention mode set
+    # these as their `failure_status` when the runner throws — e.g. a rejected
+    # `git push`. Without them a real failure (agent produced nothing, or the
+    # push was rejected) exits 0 and the run looks green with no PR/branch,
+    # indistinguishable from a graceful "declined to publish". Fail visibly.
+    "brief_failed",
+    "issue_convention_failed_claude",
     # Outbound credential-scrubber abort. Not a graceful skip — the
     # operator needs to investigate the body-assembly path (whatever
     # upstream content produced credential-shaped text). Surfaces red
@@ -9610,6 +9617,33 @@ def validate_changes(workdir: Path, target: Target, package: str) -> tuple[bool,
     return (not violations, violations)
 
 
+def _strip_blocked_paths(workdir: Path, blocklist: list[str]) -> list[str]:
+    """Discard changes to ``blocklist`` paths from the working tree.
+
+    The branch push is authenticated with a token that has no ``workflows``
+    permission, so a single changed file under ``.github/workflows/**`` makes
+    GitHub reject the ENTIRE push (not just that file) — losing the whole
+    diff. Files matching :data:`ALWAYS_BLOCKED` are never a wanted agent edit
+    (see the constant's rationale), so revert them (tracked) or remove them
+    (newly created) before staging, and return what was dropped so the caller
+    can surface it for human review. This makes the push structurally safe
+    regardless of whether an upstream gate happened to catch the edit.
+    """
+    dropped: list[str] = []
+    for p in changed_files(workdir):
+        if not path_matches_glob(p, blocklist):
+            continue
+        if _file_is_new(workdir, p):
+            (workdir / p).unlink(missing_ok=True)
+        else:
+            subprocess.run(
+                ["git", "checkout", "HEAD", "--", p],
+                cwd=workdir, check=False, capture_output=True,
+            )
+        dropped.append(p)
+    return dropped
+
+
 # ── Risky-surface signal (route-to-human, not block) ───────────────────────
 #
 # Indirect prompt injection (arXiv:2607.20759) most reliably abuses a small set
@@ -10272,8 +10306,13 @@ def parse_issue_fallback_file(path: Path) -> tuple[str, str]:
 
 def commit_and_push(
     workdir: Path, branch: str, title: str, repo: str, base_branch: str = "main",
-) -> None:
+) -> list[str]:
     """Stage all changes, commit (if any), and push the branch to origin.
+
+    Returns the list of ALWAYS_BLOCKED paths (e.g. ``.github/workflows/**``)
+    that were dropped from the branch before staging — empty in the common
+    case. Callers surface these for human review; the token structurally
+    cannot push them, so including them would fail the whole push.
 
     When the session made no edits — a valid outcome for warm-start
     refinements that judge the curated branch already clean — the commit
@@ -10359,6 +10398,18 @@ def commit_and_push(
     if bundle_path.exists():
         shutil.rmtree(bundle_path, ignore_errors=True)
 
+    # Discard changes to ALWAYS_BLOCKED paths before staging. The push token
+    # has no `workflows` permission, so a single .github/workflows/** change
+    # makes GitHub reject the whole push and lose the entire diff. These paths
+    # are never a wanted agent edit; drop them and keep the rest.
+    dropped_blocked = _strip_blocked_paths(workdir, ALWAYS_BLOCKED)
+    if dropped_blocked:
+        log.warning(
+            "  → dropped %d unpushable blocked path(s) before staging "
+            "(agent may not author workflow files): %s",
+            len(dropped_blocked), ", ".join(dropped_blocked),
+        )
+
     subprocess.run(["git", "add", "-A"], cwd=workdir, check=True)
     # An empty staged diff means the session reviewed the branch and
     # changed nothing — a valid (best-case) outcome for warm-start
@@ -10432,6 +10483,8 @@ def commit_and_push(
     # commit on top.
     if has_changes:
         _recommit_via_api(workdir, repo, branch, title, parent_sha=head_sha)
+
+    return dropped_blocked
 
 
 def _recommit_via_api(
@@ -11133,10 +11186,16 @@ def run_brief_mode(target: Target) -> dict:
                 f"Routing downgraded (Issue instead of PR)."
             )
 
-        commit_and_push(
+        dropped_blocked = commit_and_push(
             workdir, branch, pr_title, target.repo,
             base_branch=default_branch,
         )
+        result["branch"] = branch
+        if dropped_blocked:
+            # Un-pushable paths (e.g. .github/workflows/**) the agent touched
+            # and we stripped before pushing. Surface in the step summary so
+            # the human knows what was dropped and can apply it manually.
+            result["dropped_blocked_paths"] = dropped_blocked
 
         # publish=branch short-circuits before ``open_pr`` — the branch
         # is pushed for review, no PR object is created. Same semantics
@@ -17951,6 +18010,12 @@ def _write_step_summary(result: dict) -> None:
     emoji = {
         "pr_opened":               "🟢",
         "pr_opened_draft":         "🟢",
+        "pr_opened_brief":         "🟢",
+        "branch_pushed_no_pr":     "🟢",
+        "branch_pushed_canary_missing": "🟡",
+        "issue_opened_canary_missing":  "🟡",
+        "brief_failed":            "❌",
+        "issue_convention_failed_claude": "❌",
         "issue_opened":            "🟡",
         "issue_opened_preflight":  "🟡",
         "issue_opened_no_integration":     "🟡",
@@ -17990,6 +18055,35 @@ def _write_step_summary(result: dict) -> None:
     discussion_url = result.get("discussion_comment_url") or ""
     if discussion_url:
         lines.append(f"**Discussion comment**: {discussion_url}\n")
+
+    # Branch-mode (publish=branch, incl. brief mode): no PR object is
+    # created, so the branch link is the only pointer to the drafted work.
+    # Render it plus the "you open the PR" nudge that matches the human-in-
+    # the-loop operating model.
+    branch_url = result.get("branch_url") or ""
+    if branch_url:
+        branch_name = result.get("branch") or branch_url.split("/tree/", 1)[-1]
+        lines.append(f"**Branch**: {branch_url}\n")
+        lines.append(
+            f"_Pushed in `publish=branch` mode — no PR opened. Review the "
+            f"branch, then open the PR yourself when ready: "
+            f"`gh pr create --head {branch_name}`._\n"
+        )
+
+    # Un-pushable paths stripped before the push (e.g. .github/workflows/**
+    # the token can't author). Surfaced so the drop isn't silent — the human
+    # applies them manually if any were actually intended.
+    dropped_blocked = result.get("dropped_blocked_paths") or []
+    if dropped_blocked:
+        items = ", ".join(f"`{p}`" for p in dropped_blocked)
+        lines.append(
+            "\n### ⚠️ Un-pushable paths dropped from the branch\n\n"
+            "The agent modified workflow/CI files the push token is not "
+            "permitted to author, so they were **removed before pushing** — "
+            "otherwise GitHub rejects the entire push and the whole draft is "
+            "lost. Review whether any were actually needed and apply them "
+            f"manually if so:\n\n{items}\n"
+        )
 
     # When the dedup gate fires (open OR closed prior Issue), surface
     # the existing-Issue context inline so the maintainer sees at a

--- a/tests/test_brief_mode_step_summary.py
+++ b/tests/test_brief_mode_step_summary.py
@@ -1,0 +1,78 @@
+"""Brief / branch-mode results must render usefully in the step summary.
+
+Before this, brief-mode statuses had no emoji entry (all fell through to
+ℹ️), the branch URL was never printed at all (only ``pr_url`` / ``issue_url``
+were), and un-pushable paths stripped before the push weren't surfaced.
+
+Pins:
+  - ``branch_url`` is rendered with the "you open the PR" nudge.
+  - ``dropped_blocked_paths`` get a visible ⚠️ section.
+  - ``brief_failed`` renders as ❌ (red), not the ℹ️ fallthrough.
+
+Run with: pytest tests/test_brief_mode_step_summary.py -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+def _render(result, tmp_path, monkeypatch):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    run._write_step_summary(result)
+    return summary.read_text()
+
+
+def test_branch_url_and_pr_nudge_rendered(tmp_path, monkeypatch):
+    out = _render(
+        {
+            "status": "branch_pushed_no_pr",
+            "branch": "feature/chebyshev-cache",
+            "branch_url":
+                "https://github.com/o/r/tree/feature/chebyshev-cache",
+        },
+        tmp_path, monkeypatch,
+    )
+    assert "🟢" in out
+    assert "https://github.com/o/r/tree/feature/chebyshev-cache" in out
+    assert "gh pr create --head feature/chebyshev-cache" in out
+
+
+def test_dropped_blocked_paths_section(tmp_path, monkeypatch):
+    out = _render(
+        {
+            "status": "branch_pushed_no_pr",
+            "branch_url": "https://github.com/o/r/tree/b",
+            "dropped_blocked_paths": [".github/workflows/claude_review.yml"],
+        },
+        tmp_path, monkeypatch,
+    )
+    assert "Un-pushable paths dropped" in out
+    assert ".github/workflows/claude_review.yml" in out
+
+
+def test_brief_failed_renders_red(tmp_path, monkeypatch):
+    out = _render(
+        {
+            "status": "brief_failed",
+            "error": "git push rejected: workflows permission",
+        },
+        tmp_path, monkeypatch,
+    )
+    assert "❌" in out
+    assert "git push rejected" in out
+
+
+def test_branch_name_derived_from_url_when_absent(tmp_path, monkeypatch):
+    # No explicit "branch" key → derive it from the /tree/ URL suffix.
+    out = _render(
+        {
+            "status": "branch_pushed_no_pr",
+            "branch_url": "https://github.com/o/r/tree/feature/afu-objective",
+        },
+        tmp_path, monkeypatch,
+    )
+    assert "gh pr create --head feature/afu-objective" in out

--- a/tests/test_commit_and_push_blocked_paths.py
+++ b/tests/test_commit_and_push_blocked_paths.py
@@ -1,0 +1,130 @@
+"""``commit_and_push`` must strip un-pushable ALWAYS_BLOCKED paths.
+
+The branch push authenticates with a token that has no ``workflows``
+permission, so a single changed file under ``.github/workflows/**`` makes
+GitHub reject the ENTIRE push and lose the whole diff. commit_and_push drops
+such paths before staging, pushes the rest, and returns what it dropped so
+callers can surface it for human review.
+
+Covers:
+- a MODIFIED workflow file → reverted to baseline, legit change still lands.
+- a NEW workflow file → removed, not present on the pushed branch.
+- a clean diff → returns [] and pushes normally.
+
+Run with: pytest tests/test_commit_and_push_blocked_paths.py -q
+"""
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+@pytest.fixture
+def fork_workdir(tmp_path):
+    """A bare "remote" plus a workdir on main, identity configured.
+
+    The seed carries a pre-existing ``.github/workflows/ci.yml`` so a later
+    edit to it is a *modification* (the revert path); new workflow files
+    exercise the *removal* path.
+    """
+    seed = tmp_path / "seed"
+    subprocess.run(["git", "init", "-q", str(seed)], check=True)
+    subprocess.run(
+        ["git", "-C", str(seed), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True,
+    )
+    (seed / ".github" / "workflows").mkdir(parents=True)
+    (seed / ".github" / "workflows" / "ci.yml").write_text("name: ci\n")
+    (seed / "README.md").write_text("baseline\n")
+    subprocess.run(["git", "-C", str(seed), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(seed), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", "baseline"],
+        check=True,
+    )
+
+    bare = tmp_path / "fork.git"
+    subprocess.run(
+        ["git", "clone", "--bare", "-q", str(seed), str(bare)], check=True,
+    )
+    workdir = tmp_path / "workdir"
+    subprocess.run(["git", "clone", "-q", str(bare), str(workdir)], check=True)
+    subprocess.run(
+        ["git", "-C", str(workdir), "config", "user.email", "bot@remyx.ai"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(workdir), "config", "user.name", "remyx-ai[bot]"],
+        check=True,
+    )
+    return workdir, bare
+
+
+def _run(workdir):
+    """commit_and_push with the network/API pieces neutralized (empty token
+    pushes to the local bare; API re-author recorded as a no-op)."""
+    with patch.object(run, "_github_token", lambda: ""), \
+         patch.object(run, "_recommit_via_api", lambda *a, **kw: None):
+        return run.commit_and_push(
+            workdir, "feature/x", "add feature",
+            repo="owner/repo", base_branch="main",
+        )
+
+
+def _pushed_tree(bare):
+    return subprocess.run(
+        ["git", "-C", str(bare), "ls-tree", "-r", "--name-only",
+         "refs/heads/feature/x"],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+
+
+def test_modified_workflow_file_is_stripped(fork_workdir):
+    workdir, bare = fork_workdir
+    (workdir / ".github" / "workflows" / "ci.yml").write_text(
+        "name: ci\n# agent-injected step\n"
+    )
+    (workdir / "feature.py").write_text("print('impl')\n")
+
+    dropped = _run(workdir)
+
+    assert ".github/workflows/ci.yml" in dropped
+    assert "feature.py" in _pushed_tree(bare)
+    # the workflow file is back to baseline, not the injected content
+    show = subprocess.run(
+        ["git", "-C", str(bare), "show",
+         "refs/heads/feature/x:.github/workflows/ci.yml"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert "agent-injected" not in show
+
+
+def test_new_workflow_file_is_removed(fork_workdir):
+    workdir, bare = fork_workdir
+    (workdir / ".github" / "workflows" / "claude_review.yml").write_text(
+        "name: review\n"
+    )
+    (workdir / "feature.py").write_text("print('impl')\n")
+
+    dropped = _run(workdir)
+
+    assert ".github/workflows/claude_review.yml" in dropped
+    tree = _pushed_tree(bare)
+    assert "feature.py" in tree
+    assert ".github/workflows/claude_review.yml" not in tree
+
+
+def test_clean_diff_returns_empty_and_pushes(fork_workdir):
+    workdir, bare = fork_workdir
+    (workdir / "feature.py").write_text("print('impl')\n")
+
+    dropped = _run(workdir)
+
+    assert dropped == []
+    assert "feature.py" in _pushed_tree(bare)

--- a/tests/test_failure_exit_statuses.py
+++ b/tests/test_failure_exit_statuses.py
@@ -1,0 +1,30 @@
+"""Terminal failure statuses must exit the workflow step non-zero.
+
+Brief mode ("lead-content is the spec") and issue-convention mode set
+``brief_failed`` / ``issue_convention_failed_claude`` as their
+``failure_status`` when the runner throws — e.g. a rejected ``git push``.
+If those aren't in ``FAILURE_EXIT_STATUSES`` the run exits 0 and looks green
+with no PR/branch, masking a real failure as a graceful "declined to publish".
+
+Run with: pytest tests/test_failure_exit_statuses.py -q
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import run  # noqa: E402
+
+
+def test_brief_failed_is_a_failure_status():
+    assert "brief_failed" in run.FAILURE_EXIT_STATUSES
+
+
+def test_issue_convention_failed_is_a_failure_status():
+    assert "issue_convention_failed_claude" in run.FAILURE_EXIT_STATUSES
+
+
+def test_graceful_brief_outcomes_stay_green():
+    # Legitimate green outcomes must NOT be treated as failures.
+    for ok in ("branch_pushed_no_pr", "pr_opened_brief"):
+        assert ok not in run.FAILURE_EXIT_STATUSES


### PR DESCRIPTION
## Problem

A `publish=branch` run could finish **green with no branch** — silently losing the draft. Two independent bugs:

1. **Push rejected, reported green.** When the agent staged a `.github/workflows/*.yml` edit, the push token (no `workflows` permission) made GitHub reject the *entire* push (`! [remote rejected] … refusing to allow a GitHub App to create or update workflow … without workflows permission`). `brief_failed` wasn't in `FAILURE_EXIT_STATUSES`, so the step still exited 0 — indistinguishable from a graceful "declined to publish."
2. **Branch never surfaced.** Even on success, brief/branch-mode statuses had no step-summary emoji and `branch_url` was never rendered — only `pr_url`/`issue_url` were.

## Fix

- `commit_and_push` strips `ALWAYS_BLOCKED` paths (`.github/workflows/**`) before staging, pushes the rest, and returns what it dropped. Workflow-file edits are never a wanted agent change, so dropping them keeps a doomed file from losing the whole diff.
- `brief_failed` and `issue_convention_failed_claude` added to `FAILURE_EXIT_STATUSES` → a rejected push / thrown runner now exits red.
- Step summary renders brief/branch-mode statuses (emoji), the branch URL with an "open the PR yourself" nudge, and a section listing any dropped un-pushable paths.

## Tests

`test_commit_and_push_blocked_paths`, `test_failure_exit_statuses`, `test_brief_mode_step_summary` (10 new). Full suite green locally aside from pre-existing network-dependent failures, which are unaffected.

Drafted with Claude Code.
