### PR TITLE
docs: note --github-secrets-only for provider keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ remyxai outrider init --repo owner/name --auto-interest
 
 Installs the action, writes the workflow, sets the secrets (`REMYX_API_KEY`, `ANTHROPIC_API_KEY`). Scheduled cron handles the weekly cadence from there.
 
+Add `--github-secrets-only` to keep your provider key in one place: it is encrypted on your machine, written to the repo's Actions secrets, and no copy is stored anywhere else.
+
 Trigger an ad-hoc run:
 
 ```bash

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -12,6 +12,10 @@ The [`remyxai` CLI](https://github.com/remyxai/remyxai-cli) sets Outrider up in 
    - `REMYX_API_KEY` — from step 2
    - `ANTHROPIC_API_KEY` — your key from [console.anthropic.com](https://console.anthropic.com)
 
+   Setting these by hand means the keys only ever exist in your repo.
+   `remyxai outrider init --github-secrets-only` gets you the same thing
+   without the manual steps: it seals the key locally before sending it.
+
 4. **Allow Actions to open PRs**: *Settings → Actions → General → Workflow permissions* → ☑ *Allow GitHub Actions to create and approve pull requests*. (Without this, the action returns `HTTP 403` at PR creation.)
 
 5. **Add the workflow** at `.github/workflows/outrider.yml`:

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,6 +55,15 @@ either a **draft PR** or a **human-review Issue**. The run also fails closed —
 match or a guard trip aborts rather than filing — and a maintainer can disable the
 workflow outright.
 
+## Where the model key lives
+
+The provider key is a repo Actions secret, decrypted only inside the ephemeral
+runner. Installing with `remyxai outrider init --github-secrets-only` seals it
+against that repo's own Actions public key on your machine, so it reaches
+GitHub as ciphertext and no copy is stored anywhere else. A manual install
+(see [manual-install.md](manual-install.md)) has the same property — you set
+the secret yourself.
+
 ## What we deliberately do not rely on
 
 The two model-facing layers (L1 wrapping, L4 canary) are **signals**, not guarantees — a


### PR DESCRIPTION
`remyxai outrider init --github-secrets-only` (CLI v0.4.12) encrypts the provider key on the operator's machine, against the target repo's own Actions public key, so it reaches GitHub as ciphertext and no copy is stored anywhere else.

Docs only — no code, no change to how the action behaves.

Three edits, one place each a reader would look:

- **README quickstart** — one line beside the existing "sets the secrets" note.
- **`docs/security.md`** — a short *Where the model key lives* section. The doc covers runtime defense in depth; key custody is the adjacent question it didn't answer.
- **`docs/manual-install.md`** — notes that the managed path now gets the same property the manual one always had (keys only ever exist in your repo).

+15 lines total.
